### PR TITLE
Promote ddprof to version 0.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.19)
 
  project(DDProf
   LANGUAGES C CXX
-  VERSION 0.6.4
+  VERSION 0.7.0
   DESCRIPTION "Datadog's native profiler"
 )
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,11 @@
+0.6.4 to 0.7.0 (19/01/2022)
+* Asynchronous HTTP exports 
+- Reduces lost events while exporting
+* Support clang builds
+* Whole host profiling 
+  - Add support to locate files through /proc
+* Support url option
+
 0.6.3 to 0.6.4 (06/10/2021)
 * Virtual Base frames : Ensure all frames are attached to a base frame
 * Explain Unwinding errors through virtual frames (ex: anonymous regions)


### PR DESCRIPTION
# What does this PR do?

- Promote the ddprof version to 0.7.0
- Update changelog

# Motivation

- Listing the updates of the latest version
- Promoting the new version to our production systems

# Additional Notes

The new version supports url as an option. Perhaps we want to make sure most systems use this.

# How to test the change?

`ddprof --version` will show 0.7.0 