### PR TITLE
Rename the parameter for the service version

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -2,7 +2,7 @@
 
 ```bash
  usage: ddprof [--help] [PROFILER_OPTIONS] COMMAND [COMMAND_ARGS]
- eg: ddprof -A hunter2 -H localhost -P 8192 redis-server /etc/redis/redis.conf
+ eg: ddprof -S service_name -H localhost -P 8192 redis-server /etc/redis/redis.conf
 
 Options:
   -E, --environment, (envvar: DD_ENV)
@@ -19,14 +19,14 @@ Options:
     or https://<hostname>:<port> are valid.  Overrides any other specification for
     the host or port, except if the URL is specified without a port, such as
     http://myhost.domain.com, in which case the port can be specified separately
-
+    by the user.
   -S, --service, (envvar: DD_SERVICE)
     The name of this service.  It is useful to populate this field, as it will
     make it easier to locate and filter interesting profiles.
     For global mode, note that all application-level profiles are consolidated in
     the same view.
 
-  -V, --serviceversion, (envvar: DD_VERSION)
+  -V, --vername, (envvar: DD_VERSION)
     Version of the service being profiled. Added to the tags during export.
     This is an optional field, but it is useful for locating and filtering
     regressions or interesting behavior.

--- a/include/ddprof_input.h
+++ b/include/ddprof_input.h
@@ -79,7 +79,7 @@ typedef struct DDProfInput {
   XX(DD_TRACE_AGENT_PORT,          port,                      P, 'P', 1, input, NULL, "8126",       exp_input.)  \
   XX(DD_TRACE_AGENT_URL,           url,                       U, 'U', 1, input, NULL, "", )                      \
   XX(DD_SERVICE,                   service,                   S, 'S', 1, input, NULL, "myservice",  exp_input.)  \
-  XX(DD_VERSION,                   serviceversion,            V, 'V', 1, input, NULL, "",           exp_input.)  \
+  XX(DD_VERSION,                   vername,                   V, 'V', 1, input, NULL, "",           exp_input.)  \
   XX(DD_PROFILING_EXPORT,          do_export,                 X, 'X', 1, input, NULL, "yes",        exp_input.)  \
   XX(DD_PROFILING_AGENTLESS,       agentless,                 L, 'L', 1, input, NULL, "",                     )  \
   XX(DD_TAGS,                      tags,                      T, 'T', 1, input, NULL, "", )                      \

--- a/include/exporter_input.h
+++ b/include/exporter_input.h
@@ -22,7 +22,7 @@ typedef struct ExporterInput {
   const char *port; // port appended to the host IP (ignored in agentless)
   const char
       *service; // service to identify the profiles (ex:prof-probe-native)
-  const char *serviceversion; // appended to tags (example: 1.2.1)
+  const char *vername; // appended to tags (example: 1.2.1)
   const char *do_export;      // prevent exports if needed (debug flag)
   string_view user_agent;     // ignored for now (override in shared lib)
   string_view language;       // appended to the tags (set to native)
@@ -62,7 +62,7 @@ static inline DDRes exporter_input_copy(const ExporterInput *src,
   DUP_PARAM(site);
   DUP_PARAM(port);
   DUP_PARAM(service);
-  DUP_PARAM(serviceversion);
+  DUP_PARAM(vername);
   DUP_PARAM(do_export);
   dest->user_agent = src->user_agent;
   dest->language = src->language;
@@ -79,6 +79,6 @@ static inline void exporter_input_free(ExporterInput *exporter_input) {
   free((char *)exporter_input->site);
   free((char *)exporter_input->port);
   free((char *)exporter_input->service);
-  free((char *)exporter_input->serviceversion);
+  free((char *)exporter_input->vername);
   free((char *)exporter_input->do_export);
 }

--- a/src/exporter/ddprof_exporter.cc
+++ b/src/exporter/ddprof_exporter.cc
@@ -155,10 +155,10 @@ static void fill_tags(const UserTags *user_tags, const DDProfExporter *exporter,
         .value = char_star_to_byteslice(exporter->_input.environment)});
   }
 
-  if (exporter->_input.serviceversion) {
+  if (exporter->_input.vername) {
     tags_exporter.push_back(ddprof_ffi_Tag{
         .name = char_star_to_byteslice("version"),
-        .value = char_star_to_byteslice(exporter->_input.serviceversion)});
+        .value = char_star_to_byteslice(exporter->_input.vername)});
   }
 
   if (exporter->_input.service) {

--- a/test/ddprof_exporter-ut.cc
+++ b/test/ddprof_exporter-ut.cc
@@ -85,7 +85,7 @@ void fill_mock_exporter_input(ExporterInput &exporter_input,
   exporter_input.site = "datadog_is_cool.com";
   exporter_input.port = url.second.c_str();
   exporter_input.service = MYNAME;
-  exporter_input.serviceversion = "42";
+  exporter_input.vername = "42";
   exporter_input.do_export = "yes";
   exporter_input.user_agent = STRING_VIEW_LITERAL("DDPROF_MOCK");
   exporter_input.language = STRING_VIEW_LITERAL("NATIVE");


### PR DESCRIPTION
# What does this PR do?

This renames the internal `--serviceversion` field to `--vername`, in order to make it easier and more straightforward for users.  It would nice to be able to use `--version`, however this field is taken by the `--version` longname (printing the ddprof version).

# Motivation

In writing the docs, I realized we had many places where the name we use for things is a little jarring.  This was the worst offender.  Although I do somewhat like `serviceversion`, the term `vername` is probably the second most common name for the field, behind `version`.

It was also time to regenerate the docs, since people will probably use those soon.

# Additional Notes

This was an easy change, so I don't have a strong opinion.  Right now the docs preemptively reflect the use of `vername`, but that's easy to change.

# How to test the change?

The end-to-end result of this change can be inferred by running the tests and the doc generation script.  Everything looks fine.