### PR TITLE
Free inconsistent dwfl modules

### DIFF
--- a/CppCheckSuppressions.txt
+++ b/CppCheckSuppressions.txt
@@ -8,6 +8,8 @@
 
 // config of cpp checks needs more includes
 missingInclude
+// trick to retrieve instruction pointer in unit tests
 unusedLabel:*/dso-ut.cc
+unusedLabel:*/dwfl_module-ut.cc
 // warning about weird comma : I could not explain this warning
 constStatement:*/dwfl_symbol_lookup.cc

--- a/include/ddres_list.h
+++ b/include/ddres_list.h
@@ -27,6 +27,7 @@ extern "C" {
   X(DWFL_LIB_ERROR, "error withing dwfl library")                              \
   X(UW_CACHE_ERROR, "error from unwinding cache")                              \
   X(UW_ERROR, "error from unwinding code")                                     \
+  X(UW_MAX_DEPTH, "max depth reached in unwinding")                            \
   X(CAPLIB, "error when reading capabilities")                                 \
   X(USERID, "error in user ID manipulations")                                  \
   X(PEINIT, "error allocating space for pevent")                               \

--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -147,7 +147,7 @@ public:
   // returns null if the file was not found
   const RegionHolder *find_or_insert_region(const Dso &dso);
 
-  // Unordered map of sorted
+  // Unordered map (by pid) of sorted DSOs
   DsoPidMap _map;
   DsoStats _stats;
 

--- a/include/dwfl_hdr.hpp
+++ b/include/dwfl_hdr.hpp
@@ -10,6 +10,7 @@ extern "C" {
 #include "dwfl_internals.h"
 #include <sys/types.h>
 }
+
 #include "ddres.h"
 
 #include "ddprof_file_info.hpp"
@@ -25,7 +26,8 @@ namespace ddprof {
 struct DwflWrapper {
   explicit DwflWrapper();
 
-  DwflWrapper(DwflWrapper &&other) : _dwfl(nullptr), _attached(false) {
+  DwflWrapper(DwflWrapper &&other)
+      : _dwfl(nullptr), _attached(false), _inconsistent(false) {
     swap(*this, other);
   }
 
@@ -52,6 +54,7 @@ struct DwflWrapper {
 
   Dwfl *_dwfl;
   bool _attached;
+  bool _inconsistent;
 
   // Keep track of the files we added to the dwfl object
   std::unordered_map<FileInfoId_t, bool> _mod_added;

--- a/include/dwfl_module.hpp
+++ b/include/dwfl_module.hpp
@@ -10,17 +10,21 @@ extern "C" {
 namespace ddprof {
 
 struct DDProfMod {
-  DDProfMod()
-      : _mod(nullptr), _low_addr(0), _high_addr(0), _inconsistent(false) {}
+  enum Status {
+    kUnknown,
+    kInconsistent,
+  };
 
-  explicit DDProfMod(bool inconsistent) : DDProfMod() {
-    _inconsistent = inconsistent;
+  DDProfMod() : _mod(nullptr), _low_addr(0), _high_addr(0), _status(kUnknown) {}
+
+  explicit DDProfMod(Status inconsistent) : DDProfMod() {
+    _status = inconsistent;
   }
 
   Dwfl_Module *_mod;
   ProcessAddress_t _low_addr;
   ProcessAddress_t _high_addr;
-  bool _inconsistent;
+  Status _status;
 };
 
 // From a dso object (and the matching file), attach the module to the dwfl

--- a/include/dwfl_module.hpp
+++ b/include/dwfl_module.hpp
@@ -17,9 +17,7 @@ struct DDProfMod {
 
   DDProfMod() : _mod(nullptr), _low_addr(0), _high_addr(0), _status(kUnknown) {}
 
-  explicit DDProfMod(Status inconsistent) : DDProfMod() {
-    _status = inconsistent;
-  }
+  explicit DDProfMod(Status status) : DDProfMod() { _status = status; }
 
   Dwfl_Module *_mod;
   ProcessAddress_t _low_addr;

--- a/include/dwfl_module.hpp
+++ b/include/dwfl_module.hpp
@@ -10,10 +10,17 @@ extern "C" {
 namespace ddprof {
 
 struct DDProfMod {
-  DDProfMod() : _mod(nullptr), _low_addr(0), _high_addr(0) {}
+  DDProfMod()
+      : _mod(nullptr), _low_addr(0), _high_addr(0), _inconsistent(false) {}
+
+  explicit DDProfMod(bool inconsistent) : DDProfMod() {
+    _inconsistent = inconsistent;
+  }
+
   Dwfl_Module *_mod;
   ProcessAddress_t _low_addr;
   ProcessAddress_t _high_addr;
+  bool _inconsistent;
 };
 
 // From a dso object (and the matching file), attach the module to the dwfl

--- a/include/dwfl_symbol_lookup.hpp
+++ b/include/dwfl_symbol_lookup.hpp
@@ -9,7 +9,6 @@
 #include "ddprof_file_info.hpp"
 #include "dso.hpp"
 #include "dso_symbol_lookup.hpp"
-#include "dwfl_hdr.hpp"
 #include "hash_helper.hpp"
 #include "symbol_table.hpp"
 
@@ -23,6 +22,9 @@ typedef struct Dwfl_Module Dwfl_Module;
 }
 
 namespace ddprof {
+
+// forward declare to avoid pulling in dwfl_internals in the header
+struct DwflWrapper;
 
 #define DWFL_CACHE_AS_MAP
 
@@ -77,8 +79,7 @@ public:
   DwflSymbolLookup_V2();
 
   // Get symbol from internal cache or fetch through dwarf
-  SymbolIdx_t get_or_insert(ddprof::DwflWrapper &dwfl_wrapper,
-                            SymbolTable &table,
+  SymbolIdx_t get_or_insert(DwflWrapper *dwfl_wrapper, SymbolTable &table,
                             DsoSymbolLookup &dso_symbol_lookup,
                             ProcessAddress_t process_pc, const Dso &dso,
                             const FileInfoValue &file_info);
@@ -98,7 +99,7 @@ private:
 
   SymbolLookupSetting _lookup_setting;
 
-  SymbolIdx_t insert(ddprof::DwflWrapper &dwfl_wrapper, SymbolTable &table,
+  SymbolIdx_t insert(DwflWrapper *dwfl_wrapper, SymbolTable &table,
                      DsoSymbolLookup &dso_symbol_lookup,
                      ProcessAddress_t process_pc, const Dso &dso,
                      const FileInfoValue &file_info, DwflSymbolMap &map,

--- a/include/dwfl_symbol_lookup.hpp
+++ b/include/dwfl_symbol_lookup.hpp
@@ -79,7 +79,7 @@ public:
   DwflSymbolLookup_V2();
 
   // Get symbol from internal cache or fetch through dwarf
-  SymbolIdx_t get_or_insert(DwflWrapper *dwfl_wrapper, SymbolTable &table,
+  SymbolIdx_t get_or_insert(DwflWrapper &dwfl_wrapper, SymbolTable &table,
                             DsoSymbolLookup &dso_symbol_lookup,
                             ProcessAddress_t process_pc, const Dso &dso,
                             const FileInfoValue &file_info);
@@ -99,7 +99,7 @@ private:
 
   SymbolLookupSetting _lookup_setting;
 
-  SymbolIdx_t insert(DwflWrapper *dwfl_wrapper, SymbolTable &table,
+  SymbolIdx_t insert(DwflWrapper &dwfl_wrapper, SymbolTable &table,
                      DsoSymbolLookup &dso_symbol_lookup,
                      ProcessAddress_t process_pc, const Dso &dso,
                      const FileInfoValue &file_info, DwflSymbolMap &map,

--- a/include/dwfl_symbol_lookup.hpp
+++ b/include/dwfl_symbol_lookup.hpp
@@ -9,6 +9,7 @@
 #include "ddprof_file_info.hpp"
 #include "dso.hpp"
 #include "dso_symbol_lookup.hpp"
+#include "dwfl_hdr.hpp"
 #include "hash_helper.hpp"
 #include "symbol_table.hpp"
 
@@ -76,7 +77,8 @@ public:
   DwflSymbolLookup_V2();
 
   // Get symbol from internal cache or fetch through dwarf
-  SymbolIdx_t get_or_insert(Dwfl *dwfl, SymbolTable &table,
+  SymbolIdx_t get_or_insert(ddprof::DwflWrapper &dwfl_wrapper,
+                            SymbolTable &table,
                             DsoSymbolLookup &dso_symbol_lookup,
                             ProcessAddress_t process_pc, const Dso &dso,
                             const FileInfoValue &file_info);
@@ -96,7 +98,7 @@ private:
 
   SymbolLookupSetting _lookup_setting;
 
-  SymbolIdx_t insert(Dwfl *dwfl, SymbolTable &table,
+  SymbolIdx_t insert(ddprof::DwflWrapper &dwfl_wrapper, SymbolTable &table,
                      DsoSymbolLookup &dso_symbol_lookup,
                      ProcessAddress_t process_pc, const Dso &dso,
                      const FileInfoValue &file_info, DwflSymbolMap &map,

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -510,20 +510,15 @@ Dso DsoHdr::dso_from_procline(int pid, char *line) {
 }
 
 FileInfo DsoHdr::find_file_info(const Dso &dso) {
-  // check if file exists locally
   int64_t size;
   inode_t inode;
-  bool file_found = get_file_inode(dso._filename.c_str(), &inode, &size);
-
-  if (file_found) {
-    return FileInfo(dso._filename, size, inode);
-  }
-  // whole host :
+  // to ensure we always retrieve the file in the context of our process, we go
+  // through proc maps
   // Example : /proc/<pid>/root/usr/local/bin/exe_file
   //   or      /host/proc/<pid>/root/usr/local/bin/exe_file
   std::string proc_path = _path_to_proc + "/proc/" + std::to_string(dso._pid) +
       "/root" + dso._filename;
-  file_found = get_file_inode(proc_path.c_str(), &inode, &size);
+  bool file_found = get_file_inode(proc_path.c_str(), &inode, &size);
   if (file_found) {
     return FileInfo(proc_path, size, inode);
   }

--- a/src/dwfl_hdr.cc
+++ b/src/dwfl_hdr.cc
@@ -67,13 +67,14 @@ DDRes DwflWrapper::register_mod(ProcessAddress_t pc, const Dso &dso,
                                 const FileInfoValue &fileInfoValue) {
   bool &mod_added = _mod_added[fileInfoValue.get_id()];
   if (!mod_added) {
+    // first time we see this binary for this pid
     DDProfMod ddprof_mod = update_module(_dwfl, pc, dso, fileInfoValue);
     if (!ddprof_mod._mod) {
       LG_WRN("Unable to register mod %s - %d", dso.to_string().c_str(),
-             ddprof_mod._inconsistent);
-      // first time we see this binary for this pid, unfortunately, it
-      // overlaps with a previous binary we loaded. Flag this inconsistency
-      _inconsistent = ddprof_mod._inconsistent;
+             ddprof_mod._status);
+      // If it overlaps with a previous binary we loaded, flag this
+      // inconsistency
+      _inconsistent = ddprof_mod._status == DDProfMod::kInconsistent;
       return ddres_warn(DD_WHAT_UW_ERROR);
     }
     mod_added = true;

--- a/src/dwfl_module.cc
+++ b/src/dwfl_module.cc
@@ -58,7 +58,7 @@ DDProfMod update_module(Dwfl *dwfl, ProcessAddress_t pc, const Dso &dso,
           LG_NTC("Incoherent DSO (%s) %lx != %lx dwfl_module (%s)",
                  filepath.c_str(), dso._start - dso._pgoff,
                  ddprof_mod._low_addr, main_name);
-          return DDProfMod(true);
+          return DDProfMod(DDProfMod::kInconsistent);
         }
       }
     }

--- a/src/dwfl_module.cc
+++ b/src/dwfl_module.cc
@@ -45,44 +45,49 @@ DDProfMod update_module(Dwfl *dwfl, ProcessAddress_t pc, const Dso &dso,
       // not using only addresses (as we get off by 1 page errors)
       const std::string &filepath = fileInfoValue.get_path();
       if (filepath.empty() || main_name == nullptr) {
-        ddprof_mod._mod = nullptr;
+        return DDProfMod();
       } else {
-        // Although the check is slightly fragile
-        // we are not comparing the full path as we use the proc maps
+        // This check is slightly fragile (checking file names)
+        // We are not comparing the full path as we use the proc maps
         // to access them. So the root path could change while
         // this would still be the same file.
         const char *dso_name = get_filename(filepath.c_str());
         const char *mod_name = get_filename(main_name);
         if (strcmp(mod_name, dso_name) != 0) {
-          // A dso replaced the mod - todo free this dwfl object
+          // A dso replaced the mod - flag as incoherent for future release
           LG_NTC("Incoherent DSO (%s) %lx != %lx dwfl_module (%s)",
                  filepath.c_str(), dso._start - dso._pgoff,
                  ddprof_mod._low_addr, main_name);
-          ddprof_mod._mod = nullptr;
+          return DDProfMod(true);
         }
       }
     }
+    return ddprof_mod;
   }
 
-  // Try again if either if we failed to hit the dwfl cache above
+  // Load the file at a matching DSO address
   if (!ddprof_mod._mod && dso._type == ddprof::dso::kStandard) {
-    // assumption is that this string is built only once
     const std::string &filepath = fileInfoValue.get_path();
     if (!filepath.empty()) {
       const char *dso_name = strrchr(filepath.c_str(), '/') + 1;
       dwfl_errno(); // erase previous error
       ddprof_mod._mod = dwfl_report_elf(dwfl, dso_name, filepath.c_str(), -1,
                                         dso._start - dso._pgoff, false);
-      LG_DBG("Loaded mod from file (%s), PID %d (%s)[offset:%lx], mod[%lx;%lx]",
-             filepath.c_str(), dso._pid, dwfl_errmsg(-1), dso._pgoff,
-             ddprof_mod._low_addr, ddprof_mod._high_addr);
     }
   }
+
   if (!ddprof_mod._mod) {
+    // Ideally we would differentiate pid errors from file errors.
+    // For perf reasons we will just flag the file as errored
     fileInfoValue._errored = true;
-    LG_WRN("couldn't addrmodule (%s)[0x%lx], DSO:%s (%s)", dwfl_errmsg(-1), pc,
+    LG_WRN("Couldn't addrmodule (%s)[0x%lx], DSO:%s (%s)", dwfl_errmsg(-1), pc,
            dso.to_string().c_str(), fileInfoValue.get_path().c_str());
-    return ddprof_mod;
+  } else {
+    dwfl_module_info(ddprof_mod._mod, 0, &ddprof_mod._low_addr,
+                     &ddprof_mod._high_addr, 0, 0, 0, 0);
+    LG_DBG("Loaded mod from file (%s), PID %d (%s)[offset:%lx], mod[%lx;%lx]",
+           fileInfoValue.get_path().c_str(), dso._pid, dwfl_errmsg(-1),
+           dso._pgoff, ddprof_mod._low_addr, ddprof_mod._high_addr);
   }
 
   return ddprof_mod;

--- a/src/dwfl_symbol_lookup.cc
+++ b/src/dwfl_symbol_lookup.cc
@@ -48,7 +48,7 @@ unsigned DwflSymbolLookup_V2::size() const {
 
 // Retrieve existing symbol or attempt to read from dwarf
 SymbolIdx_t DwflSymbolLookup_V2::get_or_insert(
-    DwflWrapper *dwfl_wrapper, SymbolTable &table,
+    DwflWrapper &dwfl_wrapper, SymbolTable &table,
     DsoSymbolLookup &dso_symbol_lookup, ProcessAddress_t process_pc,
     const Dso &dso, const FileInfoValue &file_info) {
   ++_stats._calls;
@@ -71,7 +71,7 @@ SymbolIdx_t DwflSymbolLookup_V2::get_or_insert(
     // symbols
     if (_lookup_setting == K_CACHE_VALIDATE) {
       DDProfMod ddprof_mod =
-          update_module(dwfl_wrapper->_dwfl, process_pc, dso, file_info);
+          update_module(dwfl_wrapper._dwfl, process_pc, dso, file_info);
       if (symbol_lookup_check(ddprof_mod._mod, process_pc,
                               table[find_res.first->second.get_symbol_idx()])) {
         ++_stats._errors;
@@ -113,7 +113,7 @@ DwflSymbolMapFindRes DwflSymbolLookup_V2::find_closest(DwflSymbolMap &map,
 }
 
 SymbolIdx_t
-DwflSymbolLookup_V2::insert(DwflWrapper *dwfl_wrapper, SymbolTable &table,
+DwflSymbolLookup_V2::insert(DwflWrapper &dwfl_wrapper, SymbolTable &table,
                             DsoSymbolLookup &dso_symbol_lookup,
                             ProcessAddress_t process_pc, const Dso &dso,
                             const FileInfoValue &file_info, DwflSymbolMap &map,
@@ -124,10 +124,9 @@ DwflSymbolLookup_V2::insert(DwflWrapper *dwfl_wrapper, SymbolTable &table,
   Offset_t lbias;
   // Looking up Mod here is a waist (pending refactoring)
   DDProfMod ddprof_mod =
-      update_module(dwfl_wrapper->_dwfl, process_pc, dso, file_info);
+      update_module(dwfl_wrapper._dwfl, process_pc, dso, file_info);
   if (!ddprof_mod._mod) {
-    dwfl_wrapper->_inconsistent =
-        ddprof_mod._status == DDProfMod::kInconsistent;
+    dwfl_wrapper._inconsistent = ddprof_mod._status == DDProfMod::kInconsistent;
   }
 
   RegionAddress_t region_pc = process_pc - dso._start;

--- a/src/dwfl_symbol_lookup.cc
+++ b/src/dwfl_symbol_lookup.cc
@@ -124,8 +124,7 @@ SymbolIdx_t DwflSymbolLookup_V2::insert(
   DDProfMod ddprof_mod =
       update_module(dwfl_wrapper._dwfl, process_pc, dso, file_info);
   if (!ddprof_mod._mod) {
-    dwfl_wrapper._inconsistent = ddprof_mod._inconsistent;
-    LG_WRN("Unable to retrieve mod. %d ", ddprof_mod._inconsistent);
+    dwfl_wrapper._inconsistent = ddprof_mod._status == DDProfMod::kInconsistent;
   }
 
   RegionAddress_t region_pc = process_pc - dso._start;

--- a/src/dwfl_symbol_lookup.cc
+++ b/src/dwfl_symbol_lookup.cc
@@ -14,6 +14,7 @@ extern "C" {
 #include <cassert>
 #include <string>
 
+#include "dwfl_hdr.hpp"
 #include "dwfl_module.hpp"
 #include "dwfl_symbol.hpp"
 #include "string_format.hpp"
@@ -47,7 +48,7 @@ unsigned DwflSymbolLookup_V2::size() const {
 
 // Retrieve existing symbol or attempt to read from dwarf
 SymbolIdx_t DwflSymbolLookup_V2::get_or_insert(
-    ddprof::DwflWrapper &dwfl_wrapper, SymbolTable &table,
+    DwflWrapper *dwfl_wrapper, SymbolTable &table,
     DsoSymbolLookup &dso_symbol_lookup, ProcessAddress_t process_pc,
     const Dso &dso, const FileInfoValue &file_info) {
   ++_stats._calls;
@@ -70,7 +71,7 @@ SymbolIdx_t DwflSymbolLookup_V2::get_or_insert(
     // symbols
     if (_lookup_setting == K_CACHE_VALIDATE) {
       DDProfMod ddprof_mod =
-          update_module(dwfl_wrapper._dwfl, process_pc, dso, file_info);
+          update_module(dwfl_wrapper->_dwfl, process_pc, dso, file_info);
       if (symbol_lookup_check(ddprof_mod._mod, process_pc,
                               table[find_res.first->second.get_symbol_idx()])) {
         ++_stats._errors;
@@ -111,20 +112,22 @@ DwflSymbolMapFindRes DwflSymbolLookup_V2::find_closest(DwflSymbolMap &map,
                                                std::move(is_within));
 }
 
-SymbolIdx_t DwflSymbolLookup_V2::insert(
-    ddprof::DwflWrapper &dwfl_wrapper, SymbolTable &table,
-    DsoSymbolLookup &dso_symbol_lookup, ProcessAddress_t process_pc,
-    const Dso &dso, const FileInfoValue &file_info, DwflSymbolMap &map,
-    DwflSymbolMapFindRes find_res) {
+SymbolIdx_t
+DwflSymbolLookup_V2::insert(DwflWrapper *dwfl_wrapper, SymbolTable &table,
+                            DsoSymbolLookup &dso_symbol_lookup,
+                            ProcessAddress_t process_pc, const Dso &dso,
+                            const FileInfoValue &file_info, DwflSymbolMap &map,
+                            DwflSymbolMapFindRes find_res) {
 
   Symbol symbol;
   GElf_Sym elf_sym;
   Offset_t lbias;
   // Looking up Mod here is a waist (pending refactoring)
   DDProfMod ddprof_mod =
-      update_module(dwfl_wrapper._dwfl, process_pc, dso, file_info);
+      update_module(dwfl_wrapper->_dwfl, process_pc, dso, file_info);
   if (!ddprof_mod._mod) {
-    dwfl_wrapper._inconsistent = ddprof_mod._status == DDProfMod::kInconsistent;
+    dwfl_wrapper->_inconsistent =
+        ddprof_mod._status == DDProfMod::kInconsistent;
   }
 
   RegionAddress_t region_pc = process_pc - dso._start;

--- a/src/dwfl_symbol_lookup.cc
+++ b/src/dwfl_symbol_lookup.cc
@@ -46,11 +46,10 @@ unsigned DwflSymbolLookup_V2::size() const {
 /****************/
 
 // Retrieve existing symbol or attempt to read from dwarf
-SymbolIdx_t
-DwflSymbolLookup_V2::get_or_insert(Dwfl *dwfl, SymbolTable &table,
-                                   DsoSymbolLookup &dso_symbol_lookup,
-                                   ProcessAddress_t process_pc, const Dso &dso,
-                                   const FileInfoValue &file_info) {
+SymbolIdx_t DwflSymbolLookup_V2::get_or_insert(
+    ddprof::DwflWrapper &dwfl_wrapper, SymbolTable &table,
+    DsoSymbolLookup &dso_symbol_lookup, ProcessAddress_t process_pc,
+    const Dso &dso, const FileInfoValue &file_info) {
   ++_stats._calls;
   RegionAddress_t region_pc = process_pc - dso._start;
 
@@ -70,7 +69,8 @@ DwflSymbolLookup_V2::get_or_insert(Dwfl *dwfl, SymbolTable &table,
     // cache validation mechanism: force dwfl lookup to compare with matched
     // symbols
     if (_lookup_setting == K_CACHE_VALIDATE) {
-      DDProfMod ddprof_mod = update_module(dwfl, process_pc, dso, file_info);
+      DDProfMod ddprof_mod =
+          update_module(dwfl_wrapper._dwfl, process_pc, dso, file_info);
       if (symbol_lookup_check(ddprof_mod._mod, process_pc,
                               table[find_res.first->second.get_symbol_idx()])) {
         ++_stats._errors;
@@ -80,8 +80,8 @@ DwflSymbolLookup_V2::get_or_insert(Dwfl *dwfl, SymbolTable &table,
     return find_res.first->second.get_symbol_idx();
   }
 
-  return insert(dwfl, table, dso_symbol_lookup, process_pc, dso, file_info, map,
-                find_res);
+  return insert(dwfl_wrapper, table, dso_symbol_lookup, process_pc, dso,
+                file_info, map, find_res);
 }
 
 DwflSymbolMapFindRes DwflSymbolLookup_V2::find_closest(DwflSymbolMap &map,
@@ -112,15 +112,22 @@ DwflSymbolMapFindRes DwflSymbolLookup_V2::find_closest(DwflSymbolMap &map,
 }
 
 SymbolIdx_t DwflSymbolLookup_V2::insert(
-    Dwfl *dwfl, SymbolTable &table, DsoSymbolLookup &dso_symbol_lookup,
-    ProcessAddress_t process_pc, const Dso &dso, const FileInfoValue &file_info,
-    DwflSymbolMap &map, DwflSymbolMapFindRes find_res) {
+    ddprof::DwflWrapper &dwfl_wrapper, SymbolTable &table,
+    DsoSymbolLookup &dso_symbol_lookup, ProcessAddress_t process_pc,
+    const Dso &dso, const FileInfoValue &file_info, DwflSymbolMap &map,
+    DwflSymbolMapFindRes find_res) {
 
   Symbol symbol;
   GElf_Sym elf_sym;
   Offset_t lbias;
   // Looking up Mod here is a waist (pending refactoring)
-  DDProfMod ddprof_mod = update_module(dwfl, process_pc, dso, file_info);
+  DDProfMod ddprof_mod =
+      update_module(dwfl_wrapper._dwfl, process_pc, dso, file_info);
+  if (!ddprof_mod._mod) {
+    dwfl_wrapper._inconsistent = ddprof_mod._inconsistent;
+    LG_WRN("Unable to retrieve mod. %d ", ddprof_mod._inconsistent);
+  }
+
   RegionAddress_t region_pc = process_pc - dso._start;
 
   if (!symbol_get_from_dwfl(ddprof_mod._mod, process_pc, symbol, elf_sym,

--- a/src/unwind.cc
+++ b/src/unwind.cc
@@ -56,7 +56,7 @@ DDRes unwindstate__unwind(UnwindState *us) {
   add_virtual_base_frame(us);
   if (us->_dwfl_wrapper->_inconsistent) {
     // error detected on this pid
-    LG_WRN("Let us get rid of pid %d \n", us->pid);
+    LG_WRN("(Inconsistent DWFL/DSOs)%d - Free associated objects", us->pid);
     unwind_pid_free(us, us->pid);
   }
   return res;

--- a/src/unwind.cc
+++ b/src/unwind.cc
@@ -54,6 +54,11 @@ DDRes unwindstate__unwind(UnwindState *us) {
   }
   // Add a frame that identifies executable to which these belong
   add_virtual_base_frame(us);
+  if (us->_dwfl_wrapper->_inconsistent) {
+    // error detected on this pid
+    LG_WRN("Let us get rid of pid %d \n", us->pid);
+    unwind_pid_free(us, us->pid);
+  }
   return res;
 }
 

--- a/src/unwind_dwfl.cc
+++ b/src/unwind_dwfl.cc
@@ -190,7 +190,7 @@ static DDRes add_dwfl_frame(UnwindState *us, const Dso &dso, ElfAddress_t pc) {
   // get or create the dwfl symbol
   output->locs[current_loc_idx]._symbol_idx =
       unwind_symbol_hdr._dwfl_symbol_lookup_v2.get_or_insert(
-          *(us->_dwfl_wrapper), unwind_symbol_hdr._symbol_table,
+          us->_dwfl_wrapper, unwind_symbol_hdr._symbol_table,
           unwind_symbol_hdr._dso_symbol_lookup, pc, dso, file_info_value);
 #ifdef DEBUG
   LG_NTC("Considering frame with IP : %lx / %s ", pc,

--- a/src/unwind_dwfl.cc
+++ b/src/unwind_dwfl.cc
@@ -190,7 +190,7 @@ static DDRes add_dwfl_frame(UnwindState *us, const Dso &dso, ElfAddress_t pc) {
   // get or create the dwfl symbol
   output->locs[current_loc_idx]._symbol_idx =
       unwind_symbol_hdr._dwfl_symbol_lookup_v2.get_or_insert(
-          us->_dwfl_wrapper, unwind_symbol_hdr._symbol_table,
+          *(us->_dwfl_wrapper), unwind_symbol_hdr._symbol_table,
           unwind_symbol_hdr._dso_symbol_lookup, pc, dso, file_info_value);
 #ifdef DEBUG
   LG_NTC("Considering frame with IP : %lx / %s ", pc,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -194,7 +194,7 @@ add_unit_test(
     LIBRARIES DDProf::FFI
     DEFINITIONS MYNAME="ddprof_pprof-ut"
 )
-target_include_directories(ddprof_pprof-ut PRIVATE ${ELFUTILS_INCLUDE_LIST} ${LIBDDPROF_INCLUDE_DIR})
+target_include_directories(ddprof_pprof-ut PRIVATE ${LIBDDPROF_INCLUDE_DIR})
 
 
 add_unit_test(
@@ -209,7 +209,7 @@ add_unit_test(
     LIBRARIES DDProf::FFI
     DEFINITIONS MYNAME="ddprof_exporter-ut"
 )
-target_include_directories(ddprof_exporter-ut PRIVATE ${ELFUTILS_INCLUDE_LIST} ${LIBDDPROF_INCLUDE_DIR})
+target_include_directories(ddprof_exporter-ut PRIVATE ${LIBDDPROF_INCLUDE_DIR})
 
 add_unit_test(
     region_holder-ut

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -264,5 +264,3 @@ add_unit_test(
 )
 target_include_directories(dwfl_module-ut PRIVATE ${ELFUTILS_INCLUDE_LIST})
 add_compile_definitions("DWFL_TEST_DATA=\"${CMAKE_CURRENT_SOURCE_DIR}/data\"")
-
-# set_target_properties(dwfl_module-ut PROPERTIES COMPILE_OPTIONS "-fpie" LINK_FLAGS "-pie")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,6 +44,7 @@ function(add_unit_test name)
    add_dependencies(${name} deps)
    set_property(TARGET ${name} PROPERTY CXX_STANDARD 14)
 
+
    target_link_libraries(${name} PRIVATE gtest Threads::Threads gmock_main gmock)
    target_include_directories(${name} PRIVATE ../include ${GTEST_INCLUDE_DIRS})
 
@@ -193,7 +194,7 @@ add_unit_test(
     LIBRARIES DDProf::FFI
     DEFINITIONS MYNAME="ddprof_pprof-ut"
 )
-target_include_directories(ddprof_pprof-ut PRIVATE ${LIBDDPROF_INCLUDE_DIR})
+target_include_directories(ddprof_pprof-ut PRIVATE ${ELFUTILS_INCLUDE_LIST} ${LIBDDPROF_INCLUDE_DIR})
 
 
 add_unit_test(
@@ -208,7 +209,7 @@ add_unit_test(
     LIBRARIES DDProf::FFI
     DEFINITIONS MYNAME="ddprof_exporter-ut"
 )
-target_include_directories(ddprof_exporter-ut PRIVATE ${LIBDDPROF_INCLUDE_DIR})
+target_include_directories(ddprof_exporter-ut PRIVATE ${ELFUTILS_INCLUDE_LIST} ${LIBDDPROF_INCLUDE_DIR})
 
 add_unit_test(
     region_holder-ut
@@ -246,3 +247,22 @@ add_unit_test(
     DEFINITIONS MYNAME="dwfl_symbol-ut"
 )
 target_include_directories(dwfl_symbol-ut PRIVATE ${ELFUTILS_INCLUDE_LIST} ${LLVM_DEMANGLE_PATH}/include)
+
+add_unit_test(
+    dwfl_module-ut
+    dwfl_module-ut.cc
+    ../src/dwfl_hdr.cc
+    ../src/dwfl_module.cc
+    ../src/dso.cc 
+    ../src/dso_hdr.cc
+    ../src/ddprof_file_info.cc
+    ../src/procutils.c
+    ../src/signal_helper.c
+    ../src/region_holder.cc
+    LIBRARIES ${ELFUTILS_LIBRARIES}
+    DEFINITIONS MYNAME="dwfl_symbol-ut"
+)
+target_include_directories(dwfl_module-ut PRIVATE ${ELFUTILS_INCLUDE_LIST})
+add_compile_definitions("DWFL_TEST_DATA=\"${CMAKE_CURRENT_SOURCE_DIR}/data\"")
+
+# set_target_properties(dwfl_module-ut PROPERTIES COMPILE_OPTIONS "-fpie" LINK_FLAGS "-pie")

--- a/test/dwfl_module-ut.cc
+++ b/test/dwfl_module-ut.cc
@@ -1,0 +1,118 @@
+#include "dwfl_module.hpp"
+
+#include "dso_hdr.hpp"
+#include "dwfl_hdr.hpp"
+
+#include <gtest/gtest.h>
+#include <string>
+
+#include "dwfl_internals.h"
+#include "loghandle.hpp"
+
+namespace ddprof {
+
+// Retrieves instruction pointer
+#define _THIS_IP_                                                              \
+  ({                                                                           \
+    __label__ __here;                                                          \
+  __here:                                                                      \
+    (unsigned long)&&__here;                                                   \
+  })
+
+TEST(DwflModule, inconsistency_test) {
+  LogHandle handle;
+  // Load DSOs from our unit test
+  ElfAddress_t ip = _THIS_IP_;
+  DsoHdr dso_hdr;
+  pid_t my_pid = getpid();
+  DsoHdr::DsoFindRes find_res = dso_hdr.dso_find_or_backpopulate(my_pid, ip);
+  // Check that we found the DSO matching this IP
+  ASSERT_TRUE(find_res.second);
+
+  DwflWrapper dwfl_wrapper;
+  // retrieve the map associated to pid
+  DsoHdr::DsoMap &dso_map = dso_hdr._map[my_pid];
+
+  for (auto &tmp_dso : dso_map) {
+    const Dso &dso = tmp_dso.second;
+    if (dso._type != dso::kStandard || !dso._executable) {
+      continue; // skip non exec / non standard (anon/vdso...)
+    }
+
+    FileInfoId_t file_info_id = dso_hdr.get_or_insert_file_info(dso);
+    ASSERT_TRUE(file_info_id > k_file_info_error);
+
+    const FileInfoValue &file_info_value =
+        dso_hdr.get_file_info_value(file_info_id);
+    DDProfMod ddprof_mod =
+        update_module(dwfl_wrapper._dwfl, dso._start, dso, file_info_value);
+    // check that we loaded all mods matching the DSOs
+    EXPECT_EQ(ddprof_mod._low_addr, dso._start - dso._pgoff);
+  }
+
+  {
+    // attempt loading a bad DSO that overlap with existing
+    // Create a DSO from the unit test DSO
+    const Dso &ut_dso = find_res.first->second;
+    Dso bad_dso(ut_dso);
+    bad_dso._id = k_file_info_undef;
+    // Test file to avoid matching file names
+    bad_dso._filename = DWFL_TEST_DATA "/dso_test_data.so";
+    bad_dso._start += 1; // offset to avoid matching previous dso
+
+    FileInfoId_t file_info_id = dso_hdr.get_or_insert_file_info(bad_dso);
+
+    const FileInfoValue &file_info_value =
+        dso_hdr.get_file_info_value(file_info_id);
+
+    DDProfMod ddprof_mod = update_module(dwfl_wrapper._dwfl, bad_dso._start,
+                                         bad_dso, file_info_value);
+    EXPECT_EQ(ddprof_mod._low_addr, 0);
+    EXPECT_EQ(ddprof_mod._inconsistent, true);
+  }
+}
+
+// clang-format off
+/*
+Example of proc maps on a ubuntu 18
+00400000-0057f000 r-xp 00000000 fe:01 3935372                            /app/build_UB18_gcc_Rel/test/dwfl_module-ut
+0077f000-00780000 r--p 0017f000 fe:01 3935372                            /app/build_UB18_gcc_Rel/test/dwfl_module-ut
+00780000-00782000 rw-p 00180000 fe:01 3935372                            /app/build_UB18_gcc_Rel/test/dwfl_module-ut
+02478000-02499000 rw-p 00000000 00:00 0                                  [heap]
+7f2ba2bb0000-7f2ba2d97000 r-xp 00000000 fe:01 4981142                    /lib/x86_64-linux-gnu/libc-2.27.so
+7f2ba2d97000-7f2ba2f97000 ---p 001e7000 fe:01 4981142                    /lib/x86_64-linux-gnu/libc-2.27.so
+7f2ba2f97000-7f2ba2f9b000 r--p 001e7000 fe:01 4981142                    /lib/x86_64-linux-gnu/libc-2.27.so
+7f2ba2f9b000-7f2ba2f9d000 rw-p 001eb000 fe:01 4981142                    /lib/x86_64-linux-gnu/libc-2.27.so
+7f2ba2f9d000-7f2ba2fa1000 rw-p 00000000 00:00 0 
+7f2ba2fa1000-7f2ba2fbb000 r-xp 00000000 fe:01 4981203                    /lib/x86_64-linux-gnu/libpthread-2.27.so
+7f2ba2fbb000-7f2ba31ba000 ---p 0001a000 fe:01 4981203                    /lib/x86_64-linux-gnu/libpthread-2.27.so
+7f2ba31ba000-7f2ba31bb000 r--p 00019000 fe:01 4981203                    /lib/x86_64-linux-gnu/libpthread-2.27.so
+7f2ba31bb000-7f2ba31bc000 rw-p 0001a000 fe:01 4981203                    /lib/x86_64-linux-gnu/libpthread-2.27.so
+7f2ba31bc000-7f2ba31c0000 rw-p 00000000 00:00 0 
+7f2ba31c0000-7f2ba31d7000 r-xp 00000000 fe:01 4981160                    /lib/x86_64-linux-gnu/libgcc_s.so.1
+7f2ba31d7000-7f2ba33d6000 ---p 00017000 fe:01 4981160                    /lib/x86_64-linux-gnu/libgcc_s.so.1
+7f2ba33d6000-7f2ba33d7000 r--p 00016000 fe:01 4981160                    /lib/x86_64-linux-gnu/libgcc_s.so.1
+7f2ba33d7000-7f2ba33d8000 rw-p 00017000 fe:01 4981160                    /lib/x86_64-linux-gnu/libgcc_s.so.1
+7f2ba33d8000-7f2ba3575000 r-xp 00000000 fe:01 4981167                    /lib/x86_64-linux-gnu/libm-2.27.so
+7f2ba3575000-7f2ba3774000 ---p 0019d000 fe:01 4981167                    /lib/x86_64-linux-gnu/libm-2.27.so
+7f2ba3774000-7f2ba3775000 r--p 0019c000 fe:01 4981167                    /lib/x86_64-linux-gnu/libm-2.27.so
+7f2ba3775000-7f2ba3776000 rw-p 0019d000 fe:01 4981167                    /lib/x86_64-linux-gnu/libm-2.27.so
+7f2ba3776000-7f2ba38ef000 r-xp 00000000 fe:01 4981944                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25
+7f2ba38ef000-7f2ba3aef000 ---p 00179000 fe:01 4981944                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25
+7f2ba3aef000-7f2ba3af9000 r--p 00179000 fe:01 4981944                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25
+7f2ba3af9000-7f2ba3afb000 rw-p 00183000 fe:01 4981944                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25
+7f2ba3afb000-7f2ba3aff000 rw-p 00000000 00:00 0 
+7f2ba3aff000-7f2ba3b28000 r-xp 00000000 fe:01 4981124                    /lib/x86_64-linux-gnu/ld-2.27.so
+7f2ba3d18000-7f2ba3d20000 rw-p 00000000 00:00 0 
+7f2ba3d28000-7f2ba3d29000 r--p 00029000 fe:01 4981124                    /lib/x86_64-linux-gnu/ld-2.27.so
+7f2ba3d29000-7f2ba3d2a000 rw-p 0002a000 fe:01 4981124                    /lib/x86_64-linux-gnu/ld-2.27.so
+7f2ba3d2a000-7f2ba3d2b000 rw-p 00000000 00:00 0 
+7fffe0efa000-7fffe0f1b000 rw-p 00000000 00:00 0                          [stack]
+7fffe0f47000-7fffe0f4b000 r--p 00000000 00:00 0                          [vvar]
+7fffe0f4b000-7fffe0f4d000 r-xp 00000000 00:00 0                          [vdso]
+ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
+*/
+
+// clang-format on
+
+} // namespace ddprof

--- a/test/dwfl_module-ut.cc
+++ b/test/dwfl_module-ut.cc
@@ -72,47 +72,4 @@ TEST(DwflModule, inconsistency_test) {
   }
 }
 
-// clang-format off
-/*
-Example of proc maps on a ubuntu 18
-00400000-0057f000 r-xp 00000000 fe:01 3935372                            /app/build_UB18_gcc_Rel/test/dwfl_module-ut
-0077f000-00780000 r--p 0017f000 fe:01 3935372                            /app/build_UB18_gcc_Rel/test/dwfl_module-ut
-00780000-00782000 rw-p 00180000 fe:01 3935372                            /app/build_UB18_gcc_Rel/test/dwfl_module-ut
-02478000-02499000 rw-p 00000000 00:00 0                                  [heap]
-7f2ba2bb0000-7f2ba2d97000 r-xp 00000000 fe:01 4981142                    /lib/x86_64-linux-gnu/libc-2.27.so
-7f2ba2d97000-7f2ba2f97000 ---p 001e7000 fe:01 4981142                    /lib/x86_64-linux-gnu/libc-2.27.so
-7f2ba2f97000-7f2ba2f9b000 r--p 001e7000 fe:01 4981142                    /lib/x86_64-linux-gnu/libc-2.27.so
-7f2ba2f9b000-7f2ba2f9d000 rw-p 001eb000 fe:01 4981142                    /lib/x86_64-linux-gnu/libc-2.27.so
-7f2ba2f9d000-7f2ba2fa1000 rw-p 00000000 00:00 0 
-7f2ba2fa1000-7f2ba2fbb000 r-xp 00000000 fe:01 4981203                    /lib/x86_64-linux-gnu/libpthread-2.27.so
-7f2ba2fbb000-7f2ba31ba000 ---p 0001a000 fe:01 4981203                    /lib/x86_64-linux-gnu/libpthread-2.27.so
-7f2ba31ba000-7f2ba31bb000 r--p 00019000 fe:01 4981203                    /lib/x86_64-linux-gnu/libpthread-2.27.so
-7f2ba31bb000-7f2ba31bc000 rw-p 0001a000 fe:01 4981203                    /lib/x86_64-linux-gnu/libpthread-2.27.so
-7f2ba31bc000-7f2ba31c0000 rw-p 00000000 00:00 0 
-7f2ba31c0000-7f2ba31d7000 r-xp 00000000 fe:01 4981160                    /lib/x86_64-linux-gnu/libgcc_s.so.1
-7f2ba31d7000-7f2ba33d6000 ---p 00017000 fe:01 4981160                    /lib/x86_64-linux-gnu/libgcc_s.so.1
-7f2ba33d6000-7f2ba33d7000 r--p 00016000 fe:01 4981160                    /lib/x86_64-linux-gnu/libgcc_s.so.1
-7f2ba33d7000-7f2ba33d8000 rw-p 00017000 fe:01 4981160                    /lib/x86_64-linux-gnu/libgcc_s.so.1
-7f2ba33d8000-7f2ba3575000 r-xp 00000000 fe:01 4981167                    /lib/x86_64-linux-gnu/libm-2.27.so
-7f2ba3575000-7f2ba3774000 ---p 0019d000 fe:01 4981167                    /lib/x86_64-linux-gnu/libm-2.27.so
-7f2ba3774000-7f2ba3775000 r--p 0019c000 fe:01 4981167                    /lib/x86_64-linux-gnu/libm-2.27.so
-7f2ba3775000-7f2ba3776000 rw-p 0019d000 fe:01 4981167                    /lib/x86_64-linux-gnu/libm-2.27.so
-7f2ba3776000-7f2ba38ef000 r-xp 00000000 fe:01 4981944                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25
-7f2ba38ef000-7f2ba3aef000 ---p 00179000 fe:01 4981944                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25
-7f2ba3aef000-7f2ba3af9000 r--p 00179000 fe:01 4981944                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25
-7f2ba3af9000-7f2ba3afb000 rw-p 00183000 fe:01 4981944                    /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.25
-7f2ba3afb000-7f2ba3aff000 rw-p 00000000 00:00 0 
-7f2ba3aff000-7f2ba3b28000 r-xp 00000000 fe:01 4981124                    /lib/x86_64-linux-gnu/ld-2.27.so
-7f2ba3d18000-7f2ba3d20000 rw-p 00000000 00:00 0 
-7f2ba3d28000-7f2ba3d29000 r--p 00029000 fe:01 4981124                    /lib/x86_64-linux-gnu/ld-2.27.so
-7f2ba3d29000-7f2ba3d2a000 rw-p 0002a000 fe:01 4981124                    /lib/x86_64-linux-gnu/ld-2.27.so
-7f2ba3d2a000-7f2ba3d2b000 rw-p 00000000 00:00 0 
-7fffe0efa000-7fffe0f1b000 rw-p 00000000 00:00 0                          [stack]
-7fffe0f47000-7fffe0f4b000 r--p 00000000 00:00 0                          [vvar]
-7fffe0f4b000-7fffe0f4d000 r-xp 00000000 00:00 0                          [vdso]
-ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
-*/
-
-// clang-format on
-
 } // namespace ddprof

--- a/test/dwfl_module-ut.cc
+++ b/test/dwfl_module-ut.cc
@@ -68,7 +68,7 @@ TEST(DwflModule, inconsistency_test) {
     DDProfMod ddprof_mod = update_module(dwfl_wrapper._dwfl, bad_dso._start,
                                          bad_dso, file_info_value);
     EXPECT_EQ(ddprof_mod._low_addr, 0);
-    EXPECT_EQ(ddprof_mod._inconsistent, true);
+    EXPECT_EQ(ddprof_mod._status, DDProfMod::kInconsistent);
   }
 }
 


### PR DESCRIPTION
# What does this PR do?

- Free inconsistent Dwfl modules
We can come into situations where DSOs don't match the Dwfl objects.
In this situation we can free all of the PID objects to ensure we will reload all DSOs and all dwfl objects at the next sample.
- Add a unit test around the creation of dwfl modules
- Whole host mode bug : avoid loading the wrong file
When you have a local libc and a libc in the container, we were giving precedence to the local version of the file. This was a bad strategy that ended up loading inconsistent DSO <--> DWFL Modules

# Motivation

Looking at whole host profiling, we quickly encounter situations where we are not in sync between libdwfl objects and internal DSO objects.

# Additional Notes

There are still some limitations
- We should not compare dwfl and DSO objects using filenames. Perhaps storing file IDs would be more robust. I wanted to avoid storing pointers to the dwfl mod objects internally. Other ideas are welcome.
- When we encounter an error loading a mod, we attribute that to the file. This is not true in some cases. It should be attributed to the PID + file (and we could retry for a different PID). 

# How to test the change?

I added a unit test.
The best way to observe a change is to try out the whole host profiler in an environment profiling different languages.
