### PR TITLE
Bump version of libddprof to v0.4.0-rc.1

### DIFF
--- a/cmake/Findlibddprof.cmake
+++ b/cmake/Findlibddprof.cmake
@@ -3,10 +3,10 @@
 
 # libddprof : common profiler imported libraries
 ## Associated https://gitlab.ddbuild.io/DataDog/libddprof-build/-/jobs/90384402
-set(TAG_LIBDDPROF "v0.2.0-rc.2" CACHE STRING "libddprof github tag")
-set(VER_LIBDDPROF "0.2.0" CACHE STRING "libddprof version")
+set(TAG_LIBDDPROF "v0.4.0-rc.1" CACHE STRING "libddprof github tag")
+set(VER_LIBDDPROF "0.4.0-rc.1" CACHE STRING "libddprof version")
 
-set(SHA256_LIBDDPROF "7c055d11e1bcd12716fd7ff99597777c827da5dd2c99de0900f27672accb8de1" CACHE STRING "libddprof sha256")
+set(SHA256_LIBDDPROF "6b18703b24b5408d7071bfe1ddeb5bf73454ad6669e31b37a8401ad94ca9aed6" CACHE STRING "libddprof sha256")
 
 set(LIBDDPROF_X86_ROOT ${VENDOR_PATH}/libddprof/libddprof-x86_64-unknown-linux-gnu)
 set(LIBDDPROF_REL_FFI_LIB ${LIBDDPROF_X86_ROOT}/lib/libddprof_ffi.a)

--- a/tools/check_libddprof_version.sh
+++ b/tools/check_libddprof_version.sh
@@ -25,7 +25,7 @@ VERSION_INPUT=$2
 OUTPUT_CHECK=$3
 
 if [ ${VERSION_FROM_FILE} != ${VERSION_INPUT} ]; then
-    echo "--- Libddprof version does not match : ${VERSION_FROM_FILE} vs ${VERSION_INPUT}"
+    echo "--- Libddprof version does not match : ${VERSION_FROM_FILE} (file) vs ${VERSION_INPUT} (expected)"
     exit 1
 fi
 


### PR DESCRIPTION
# What does this PR do?

Bump version of libddprof to v0.4.0-rc.1

# Motivation

- Enabling arm builds
- Possible reduction in size of binary thanks to the work of @nsavoire 

# How to test the change?

If anything goes wrong, things should crash loudly in CI.
