### PR TITLE
Fix test for breakpoint

### DIFF
--- a/src/perf.c
+++ b/src/perf.c
@@ -69,7 +69,7 @@ int perfopen(pid_t pid, const PerfOption *opt, int cpu, bool extras) {
   attr.freq = opt->freq;
 
   // Breakpoint
-  if (opt->type & PERF_TYPE_BREAKPOINT) {
+  if (opt->type == PERF_TYPE_BREAKPOINT) {
     attr.config = 0; // as per perf_event_open() manpage
     attr.bp_type = opt->bp_type;
   }


### PR DESCRIPTION
# What does this PR do?

PerfOption::type is not a bitmap, `==` should be used instead of `&`.
This had the effect of using PERF_COUNT_SW_CPU_CLOCK instead of PERF_COUNT_SW_TASK_CLOCK.

# Motivation

What inspired you to submit this pull request?  In order to motivate your point, it may be valuable to explain why this change is useful or what problem is being solved.

# Additional Notes

This is the section to put technical guidance/constraints, call out potential regressions, cite sources, and in general offer some exposition on the _how_ of the PR.  This section doesn't need to be incredibly detailed, but it makes life easier for reviewers!

# How to test the change?

Describe here in detail how the change can be validated.  This is a great section to call out specific tests you've added or improved, or to acknowledge code sections which are particularly difficult to test.
