### PR TITLE
Update gcc/clang/cppcheck/cmake/clangtidy

### DIFF
--- a/CppCheckSuppressions.txt
+++ b/CppCheckSuppressions.txt
@@ -11,5 +11,3 @@ missingInclude
 // trick to retrieve instruction pointer in unit tests
 unusedLabel:*/dso-ut.cc
 unusedLabel:*/dwfl_module-ut.cc
-// warning about weird comma : I could not explain this warning
-constStatement:*/dwfl_symbol_lookup.cc

--- a/app/base-env/Dockerfile
+++ b/app/base-env/Dockerfile
@@ -1,24 +1,44 @@
 # Using a recent compiler version and recent OS (better tooling)
 # We'll implement libc version sanitization in the code itself
 ARG UBUNTU_VERSION=20
-FROM ubuntu:${UBUNTU_VERSION}.04 as base
+ARG COMPILER="gcc"
 
+FROM ubuntu:${UBUNTU_VERSION}.04 as base
 ARG UBUNTU_VERSION
 ENV OS_IDENTIFIER="UB${UBUNTU_VERSION}"
-ARG CXX_COMPILER="clang++"
-ARG C_COMPILER="clang"
+
+FROM base AS base-20
+ENV GCC_VERSION=11
+ENV CLANG_VERSION=13
+
+FROM base AS base-18
+ENV GCC_VERSION=11
+ENV CLANG_VERSION=13
+
+FROM base AS base-16
+ENV GCC_VERSION=9
+ENV CLANG_VERSION=12
+
+FROM base-${UBUNTU_VERSION} AS base-gcc
+ENV CC=gcc-${GCC_VERSION}
+ENV CXX=g++-${GCC_VERSION}
+
+FROM base-${UBUNTU_VERSION} AS base-clang
+ENV CC=clang-${CLANG_VERSION}
+ENV CXX=clang++-${CLANG_VERSION}
+
+FROM base-${COMPILER} AS final
 
 # Tell docker to use bash as the default
 SHELL ["/bin/bash", "-c"]
 
-RUN apt update \
-  && DEBIAN_FRONTEND=noninteractive apt install -y \
-  software-properties-common
-
-RUN apt update \
-  && DEBIAN_FRONTEND=noninteractive apt install -y \
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  software-properties-common \
+  apt-transport-https \
   awscli \
   binutils-dev \
+  ca-certificates \
   gcovr \
   git \
   curl \
@@ -37,76 +57,74 @@ RUN apt update \
   unzip \
   wget
 
-# Only necessary for ubuntu 16
-RUN DEBIAN_FRONTEND=noninteractive apt install -y apt-transport-https ca-certificates
-
 # Codeql : static analysis tooling
 RUN curl -L https://github.com/github/codeql-action/releases/download/codeql-bundle-20210622/codeql-bundle-linux64.tar.gz -o - | tar -xz -C /usr/local
 
-RUN if [[ "${CXX_COMPILER}" == "g++" ]] ; then apt install -y gcc g++ ; else echo "Skip install of g++" ; fi
-
-################
-## LLVM SETUP ##
-################
-ADD ./app/base-env/llvm.sh /
-RUN /llvm.sh 12
-
-# Clang format not installed by default
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
-RUN apt update \
-  && DEBIAN_FRONTEND=noninteractive apt install -y \
-  clang-format-12
+####################
+## LLVM/GCC SETUP ##
+####################
+ADD ./app/base-env/llvm.sh ./app/base-env/gcc.sh /
+RUN /llvm.sh ${CLANG_VERSION} && /gcc.sh ${GCC_VERSION}
 
 # Provides the llvm-symbolizer (better debug information in case of sanitizer issue)
-ENV PATH="/usr/lib/llvm-12/bin/:$PATH"
-
-ENV CC=${C_COMPILER}
-ENV CXX=${CXX_COMPILER}
+ENV PATH="/usr/lib/llvm-${CLANG_VERSION}/bin/:$PATH"
 
 # Newer CMake
-FROM base as cmake
-RUN CMAKE_VERSION="3.20.1" \
-  && CMAKE_SHA256="b8c141bd7a6d335600ab0a8a35e75af79f95b837f736456b5532f4d717f20a09" \
-  && curl -L --remote-name-all https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz \
-  && (printf "${CMAKE_SHA256}  cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | sha256sum --check --strict --status) \
-  && tar --no-same-owner -C /usr/local --strip-components=1 -xf cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz \
-  && rm cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
+RUN VERSION="3.22.2" \
+  && SHA256="38b3befdee8fd2bac06954e2a77cb3072e6833c69d8cc013c0a3b26f1cfdfe37" \
+  && curl -LO https://github.com/Kitware/CMake/releases/download/v${VERSION}/cmake-${VERSION}-Linux-x86_64.tar.gz \
+  && (printf "${SHA256}  cmake-${VERSION}-Linux-x86_64.tar.gz" | sha256sum --check --strict --status) \
+  && tar --no-same-owner -C /usr/local --strip-components=1 -xf cmake-${VERSION}-Linux-x86_64.tar.gz \
+  && rm cmake-${VERSION}-Linux-x86_64.tar.gz
 
 # Ninja build 1.10.2
-RUN NINJA_VERSION="1.10.2" \
-  && NINJA_SHA256="763464859c7ef2ea3a0a10f4df40d2025d3bb9438fcb1228404640410c0ec22d" \
-  && wget https://github.com/ninja-build/ninja/releases/download/v${NINJA_VERSION}/ninja-linux.zip \
-  && (printf "${NINJA_SHA256}  ninja-linux.zip" | sha256sum --check --strict --status) \
+RUN VERSION="1.10.2" \
+  && SHA256="763464859c7ef2ea3a0a10f4df40d2025d3bb9438fcb1228404640410c0ec22d" \
+  && curl -LO https://github.com/ninja-build/ninja/releases/download/v${VERSION}/ninja-linux.zip \
+  && (printf "${SHA256} ninja-linux.zip" | sha256sum --check --strict --status) \
   && unzip -d /usr/local/bin ninja-linux.zip \
   && rm ninja-linux.zip
 
 # google test / google mock
-RUN git clone --depth 1 --branch release-1.11.0 https://github.com/google/googletest.git \
-  && cd googletest \
+RUN VERSION="1.11.0" \
+  && curl -LO https://github.com/google/googletest/archive/refs/tags/release-${VERSION}.tar.gz \
+  && SHA256="b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5" \
+  && (printf "${SHA256} release-${VERSION}.tar.gz" | sha256sum --check --strict --status) \
+  && tar xf release-${VERSION}.tar.gz \
+  && pushd googletest-release-${VERSION} \
   && mkdir build \
   && cd build \
-  && cmake -DCMAKE_CXX_COMPILER="${CXX_COMPILER}" -DCMAKE_CXX_FLAGS="-std=c++14" ../ \
-  && cmake --build .  \
-  && make install
+  && cmake -GNinja ../ \
+  && cmake --build . -t install \
+  && popd \
+  && rm -rf googletest-release-${VERSION} release-${VERSION}.tar.gz
 
-# Cpp check 2.5 (ubuntu's 1.8 has some bugs on double free)
-RUN wget https://github.com/danmar/cppcheck/archive/refs/tags/2.5.tar.gz \
-  && CPPCHECK_SHA256="dc27154d799935c96903dcc46653c526c6f4148a6912b77d3a50cb35dabd82e1" \
-  && (printf "${CPPCHECK_SHA256}  2.5.tar.gz" | sha256sum --check --strict --status) \
-  && tar xvfz 2.5.tar.gz \
-  && cd cppcheck-2.5 \
+# Cpp check 2.7 (ubuntu's 1.8 has some bugs on double free)
+RUN VERSION="2.7" \
+  && curl -LO https://github.com/danmar/cppcheck/archive/refs/tags/${VERSION}.tar.gz \
+  && SHA256="5fd20549bb2fabf9a8026f772779d8cc6a5782c8f17500408529f7747afbc526" \
+  && (printf "${SHA256} ${VERSION}.tar.gz" | sha256sum --check --strict --status) \
+  && tar xf ${VERSION}.tar.gz \
+  && pushd cppcheck-${VERSION} \
   && mkdir build \
   && cd build \
-  && cmake ../ \
-  && cmake --build .  \
-  && make install
+  && cmake -GNinja ../ \
+  && cmake --build . -t install  \
+  && popd \
+  && rm -rf ${VERSION}.tar.gz cppcheck-${VERSION}
 
 # C++ json library (used for test purpose)
-RUN git clone --depth 1 --branch v3.10.2 https://github.com/nlohmann/json.git \
-  && cd json \
+RUN VERSION="3.10.5" \
+  && curl -LO https://github.com/nlohmann/json/releases/download/v${VERSION}/json.tar.xz \
+  && SHA256="344be97b757a36c5b180f1c8162f6c5f6ebd760b117f6e64b77866e97b217280" \
+  && (printf "${SHA256} json.tar.xz" | sha256sum --check --strict --status) \
+  && tar xf json.tar.xz \
+  && pushd json \
   && mkdir build && cd build \
-  && cmake -DJSON_BuildTests=Off -DCMAKE_CXX_COMPILER="${CXX_COMPILER}" -DCMAKE_CXX_FLAGS="-std=c++14" ../  \
-  && make install
+  && cmake -GNinja -DJSON_BuildTests=Off ../ \
+  && cmake --build . -t install \
+  && popd \
+  && rm -rf json json.tar.xz 
 
 # A specific user is required to get access to perf event ressources. 
 # This enables unit testing using perf-event ressources

--- a/app/base-env/gcc.sh
+++ b/app/base-env/gcc.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
+# This script will install a recent gcc version on Ubuntu
+
+set -euxo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root!"
+   exit 1
+fi
+
+# read optional command line argument
+GCC_VERSION=11
+if [ "$#" -eq 1 ]; then
+    GCC_VERSION=$1
+fi
+
+ add-apt-repository -y ppa:ubuntu-toolchain-r/test
+ apt-get update
+ apt-get install -y "gcc-$GCC_VERSION" "g++-$GCC_VERSION"

--- a/app/base-env/llvm.sh
+++ b/app/base-env/llvm.sh
@@ -79,4 +79,4 @@ esac
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 add-apt-repository "${REPO_NAME}"
 apt-get update
-apt-get install -y clang-$LLVM_VERSION lldb-$LLVM_VERSION lld-$LLVM_VERSION clangd-$LLVM_VERSION
+apt-get install -y clang-$LLVM_VERSION lldb-$LLVM_VERSION lld-$LLVM_VERSION clangd-$LLVM_VERSION clang-format-$LLVM_VERSION clang-tidy-$LLVM_VERSION

--- a/cmake/Findelfutils.cmake
+++ b/cmake/Findelfutils.cmake
@@ -7,7 +7,7 @@
 # - static lib : elf
 # - static lib : dw
 
-set(MD5_ELF "6f58aa1b9af1a5681b1cbf63e0da2d67" CACHE STRING "md5 of the elf tar")
+set(SHA256_ELF "7f6fb9149b1673d38d9178a0d3e0fb8a1ec4f53a9f4c2ff89469609879641177" CACHE STRING "SHA256 of the elf tar")
 set(VER_ELF "0.186" CACHE STRING "elfutils version")
 set(ELFUTILS_PATH ${VENDOR_PATH}/elfutils CACHE FILEPATH "location of elfutils file")
 
@@ -20,7 +20,7 @@ set(ELFUTILS_LIBS
 list(APPEND ELFUTILS_INCLUDE_LIST ${ELFUTILS_PATH} ${ELFUTILS_PATH}/libdwfl ${ELFUTILS_PATH}/libdw ${ELFUTILS_PATH}/libebl ${ELFUTILS_PATH}/libelf)
 
 add_custom_command(OUTPUT ${ELFUTILS_LIBS}
-                    COMMAND "${CMAKE_SOURCE_DIR}/tools/fetch_elfutils.sh" "${VER_ELF}" "${MD5_ELF}" ${VENDOR_PATH} ${CMAKE_C_COMPILER}
+                    COMMAND "${CMAKE_SOURCE_DIR}/tools/fetch_elfutils.sh" "${VER_ELF}" "${SHA256_ELF}" ${VENDOR_PATH} ${CMAKE_C_COMPILER}
                     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                     COMMENT "Fetching elfutils")
 add_custom_target(elfutils-deps DEPENDS ${ELFUTILS_LIBS})

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -13,35 +13,41 @@ NATIVE_LIB="ON"
 COMPILER_SETTING="-DCMAKE_CXX_COMPILER=${CXX:-"g++"} -DCMAKE_C_COMPILER=${CC:-"gcc"}"
 # Avoid having the vendors compiled in the same directory
 EXTENSION_CC=${CC:-"gcc"}
+# strip version number from compiler
+EXTENSION_CC=${EXTENSION_CC%-*}
 EXTENSION_OS=${OS_IDENTIFIER:-"linux"}
 VENDOR_EXTENSION="-DVENDOR_EXTENSION=_${EXTENSION_CC,,}_${EXTENSION_OS,,}"
-COMMON_OPT="${COMPILER_SETTING} ${VENDOR_EXTENSION} -DACCURACY_TEST=ON -DCMAKE_INSTALL_PREFIX=${DDPROF_INSTALL_PREFIX} -DBUILD_BENCHMARKS=${DDPROF_BUILD_BENCH} -DBUILD_NATIVE_LIB=${NATIVE_LIB}"
+COMMON_OPT="${COMPILER_SETTING} ${VENDOR_EXTENSION} -GNinja -DACCURACY_TEST=ON -DCMAKE_INSTALL_PREFIX=${DDPROF_INSTALL_PREFIX} -DBUILD_BENCHMARKS=${DDPROF_BUILD_BENCH} -DBUILD_NATIVE_LIB=${NATIVE_LIB}"
 
 RelCMake() {
+    # shellcheck disable=SC2086
     cmake ${COMMON_OPT} -DCMAKE_BUILD_TYPE=Release  "$@"
 }
 
 DebCMake() {
+    # shellcheck disable=SC2086
     cmake ${COMMON_OPT} -DCMAKE_BUILD_TYPE=Debug "$@"
 }
 
 SanCMake() {
+    # shellcheck disable=SC2086
     cmake ${COMMON_OPT} -DCMAKE_BUILD_TYPE=SanitizedDebug "$@"
 }
 
 TSanCMake() {
+    # shellcheck disable=SC2086
     cmake ${COMMON_OPT} -DCMAKE_BUILD_TYPE=ThreadSanitizedDebug "$@"
 }
 
 CovCMake() {
+    # shellcheck disable=SC2086
     cmake ${COMMON_OPT} -DCMAKE_BUILD_TYPE=Coverage "$@"
 }
 
 ## Build a directory with a naming that reflects the OS / compiler we are using
 ## Example : mkBuildDir Rel --> build_UB18_clang_Rel
 MkBuildDir() {
-    mkdir -p build_${OS_IDENTIFIER}_${CC}_${1}
-    cd build_${OS_IDENTIFIER}_${CC}_${1}
+    mkdir -p "build_${OS_IDENTIFIER}_${CC}_${1}" && cd "$_" || exit 1
 }
 
 RunDDBuild() {

--- a/test/perf_ringbuffer-ut.cc
+++ b/test/perf_ringbuffer-ut.cc
@@ -47,13 +47,14 @@ bool sample_eq(struct perf_event_sample *s1, struct perf_event_sample *s2) {
     printf("Stack mismatch\n");
     return false;
   }
-  return true;
 
   // TODO hardcoded register number, should get from ABI
   if (s1->abi && memcmp(s1->regs, s2->regs, 3)) {
     printf("Register mismatch\n");
     return false;
   }
+
+  return true;
 }
 
 TEST(PerfRingbufferTest, SampleSymmetryx86) {

--- a/test/self_unwind/self_unwind.cc
+++ b/test/self_unwind/self_unwind.cc
@@ -1,5 +1,7 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
 
 extern "C" {
 #include "ddprof.h"
@@ -11,14 +13,13 @@ extern "C" {
 #include <unistd.h>
 }
 
+#include "arraysize.h"
 #include "ddprof_output.hpp"
 #include "ddres.h"
 #include "stackchecker.hpp"
 
 #include <iostream>
 #include <unistd.h>
-
-#define SZ_STATIC_ARRAY(array) (sizeof(array) / sizeof(array[0]))
 
 static const char *k_test_executable = "BadBoggleSolver_run";
 
@@ -58,7 +59,7 @@ void capture_symbol(DDProfContext *ctx, SymbolMap *symbol_map) {
   ddprof_attach_handler(ctx, &stack_handler);
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char *const argv[]) {
   DDProfInput input;
   int ret = 0;
   bool continue_exec;
@@ -77,7 +78,7 @@ int main(int argc, char *argv[]) {
   SymbolMap symbol_map;
 
   // size - 1 as we add a null char at the end
-  if (IsDDResNotOK(ddprof_input_parse(SZ_STATIC_ARRAY(argv_override) - 1,
+  if (IsDDResNotOK(ddprof_input_parse(ARRAY_SIZE(argv_override) - 1,
                                       const_cast<char **>(argv_override),
                                       &input, &continue_exec))) {
     std::cerr << "unable to init input " << std::endl;

--- a/tools/fetch_elfutils.sh
+++ b/tools/fetch_elfutils.sh
@@ -3,6 +3,9 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
+set -euo pipefail
+IFS=$'\n\t'
+
 usage() {
     echo "Usage :"
     echo "$0 <version> <md5> <path> <c-compiler>"
@@ -16,16 +19,8 @@ if [ "$#" -ne 4 ]; then
     exit 1
 fi
 
-### Set directory names
-CURRENTDIR=$PWD
-SCRIPTPATH=$(readlink -f "$0")
-SCRIPTDIR=$(dirname $SCRIPTPATH)
-cd $SCRIPTDIR/../
-TOP_LVL_DIR=$PWD
-cd $CURRENTDIR
-
 VER_ELF=$1
-MD5_ELF=$2
+SHA256_ELF=$2
 mkdir -p ${3}
 cd ${3}
 DOWNLOAD_PATH=$PWD
@@ -36,25 +31,18 @@ C_COMPILER=${4}
 TAR_ELF="elfutils-${VER_ELF}.tar.bz2"
 URL_ELF="https://sourceware.org/elfutils/ftp/${VER_ELF}/${TAR_ELF}"
 
-if [ -n "$(find "${TARGET_EXTRACT}" -type f)" ]; then
-    echo "Error, clean the directory : ${TARGET_EXTRACT}"
-    exit 1
-fi
-
-if [ -e ${DOWNLOAD_PATH}/${TAR_ELF} ]; then
-    echo "Error, remove the tar file : ${DOWNLOAD_PATH}/${TAR_ELF}"
-    exit 1
+if [ -e "${TARGET_EXTRACT}" ]; then
+    rm -rf ${TARGET_EXTRACT}/*
 fi
 
 mkdir -p ${DOWNLOAD_PATH}
 cd ${DOWNLOAD_PATH}
-curl -L --remote-name-all ${URL_ELF}
+if [ ! -e ${DOWNLOAD_PATH}/${TAR_ELF} ]; then
+    curl -L --remote-name-all ${URL_ELF}
+fi
 
 echo "Checking md5 of elfutils..."
-
-echo ${MD5_ELF} ${DOWNLOAD_PATH}/${TAR_ELF} > ${DOWNLOAD_PATH}/elfutils.md5
-md5sum --status -c ${DOWNLOAD_PATH}/elfutils.md5
-
+echo "${SHA256_ELF} ${TAR_ELF}" | sha256sum --check --strict --status
 
 echo "Extract elfutils..."
 mkdir -p ${TARGET_EXTRACT}
@@ -67,8 +55,8 @@ echo "Compile elfutils using ${C_COMPILER}"
 # elfutils 186; these are irrelevant for GCC.  Note that this won't propagate
 # envvars back up to the calling build system.
 # TODO is there a better way to infer compiler family?
-if [ "clang" == $(basename ${C_COMPILER}) ]; then
-  export CFLAGS="-Wno-xor-used-as-pow -Wno-gnu-variable-sized-type-not-at-end"
+if [[ "$(basename "${C_COMPILER}")" == clang* ]]; then
+  export CFLAGS="-Wno-xor-used-as-pow -Wno-gnu-variable-sized-type-not-at-end -Wno-unused-but-set-parameter"
 fi
 cd ${TARGET_EXTRACT} && ./configure CC=${C_COMPILER} --disable-debuginfod --disable-libdebuginfod --disable-symbol-versioning
 make -j4 -C ${TARGET_EXTRACT}

--- a/tools/fetch_libddprof.sh
+++ b/tools/fetch_libddprof.sh
@@ -20,14 +20,6 @@ if [ $# != 3 ] || [ $1 == "-h" ]; then
     exit 1
 fi
 
-### Set directory names
-CURRENTDIR=$PWD
-SCRIPTPATH=$(readlink -f "$0")
-SCRIPTDIR=$(dirname $SCRIPTPATH)
-cd $SCRIPTDIR/../
-TOP_LVL_DIR=$PWD
-cd $CURRENTDIR
-
 TAG_LIBDDPROF=$1
 TAR_LIBDDPROF=libddprof_${TAG_LIBDDPROF}.tar.gz
 GITHUB_URL_LIBDDPROF=https://github.com/DataDog/libddprof/releases/download/${TAG_LIBDDPROF}/libddprof-x86_64-unknown-linux-gnu.tar.gz
@@ -38,14 +30,12 @@ cd $3
 DOWNLOAD_PATH=$PWD
 TARGET_EXTRACT=${DOWNLOAD_PATH}/libddprof
 
-if [ -n "$(find "${TARGET_EXTRACT}" -type f)" ]; then
-    echo "Error, clean the directory : ${TARGET_EXTRACT}"
-    exit 1
+if [ -e "${TARGET_EXTRACT}" ]; then
+    rm -rf ${TARGET_EXTRACT}/*
 fi
 
 mkdir -p ${TARGET_EXTRACT}
 
-IS_CI=${CI:-false}
 if [ ! -e  ${TAR_LIBDDPROF} ]; then
     echo "Downloading libddprof..."
     curl -L ${GITHUB_URL_LIBDDPROF} -o ${TAR_LIBDDPROF}

--- a/tools/launch_local_build.sh
+++ b/tools/launch_local_build.sh
@@ -3,16 +3,18 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
+set -euo pipefail
+
 DEFAULT_BASE_NAME=base_ddprof
 BASE_DOCKERFILE="./app/base-env/Dockerfile"
 
 ### Set directory names
 CURRENTDIR=$PWD
 SCRIPTPATH=$(readlink -f "$0")
-SCRIPTDIR=$(dirname $SCRIPTPATH)
-cd $SCRIPTDIR/../
+SCRIPTDIR=$(dirname "$SCRIPTPATH")
+cd "$SCRIPTDIR/../"
 TOP_LVL_DIR=$PWD
-cd $CURRENTDIR
+cd "$CURRENTDIR"
 
 usage() {
     echo "$0 [-t] [clean]"
@@ -28,67 +30,61 @@ usage() {
     echo "    --clean/-c : rebuild the image before creating it."
     echo "    --ubuntu_version/-u : specify ubuntu version (expected values: 16 / 18 / 20)"
     echo "    --image_id/-i : use a specified docker ID, conflicts with -u."
-    echo "    --gcc : use gcc instead of clang."
+    echo "    --clang : use clang instead of gcc."
 }
 
-if [ $# != 0 ] && [ $1 == "-h" ]; then
+if [ $# != 0 ] && [ "$1" == "-h" ]; then
     usage
     exit 0
 fi
 
 PERFORM_CLEAN=0
 UBUNTU_VERSION=18
-USE_GCC="no"
+COMPILER="gcc"
 
 while [ $# != 0 ]; do 
-    if [ $# != 0 ] && [ $1 == "-f" -o $1 == "--dockerfile" ]; then
-        cd $(dirname $2)
-        # Hacky, use path to identify name of docker image
-        DEFAULT_BASE_NAME=$(md5sum<<<${PWD} | awk '{print $1}')
-        cd ${CURRENTDIR}
-        BASE_DOCKERFILE="$2"
-        shift
-        shift
-        continue
-    fi
-    if [ $# != 0 ] && [ $1 == "--clean" -o $1 == "-c" ]; then
-        PERFORM_CLEAN=1
-        shift
-        continue
-    fi
-    if [ $# != 0 ] && [ $1 == "--ubuntu_version" -o $1 == "-u" ]; then
-        UBUNTU_VERSION=$2
-        shift
-        shift
-        continue
-    fi
-    if [ $# != 0 ] && [ $1 == "--image_id" -o $1 == "-i" ]; then
-        DOCKER_NAME=$2
-        DOCKER_TAG=""
-        CUSTOM_ID="yes"
-        shift
-        shift
-        continue
-    fi
-    if [ $# != 0 ] && [ $1 == "--gcc" ]; then
-        USE_GCC="yes"
-        shift
-        continue
-    fi
-    echo "Error : unhandled parameter"
-    usage
-    exit 1
+    case $1 in
+        -f|--dockerfile)
+            cd "$(dirname "$2")"
+            # Hacky, use path to identify name of docker image
+            DEFAULT_BASE_NAME=$(md5sum<<<"${PWD}" | awk '{print $1}')
+            cd "${CURRENTDIR}"
+            BASE_DOCKERFILE="$2"
+            shift
+            shift
+            ;;
+        --clean|-c)
+            PERFORM_CLEAN=1
+            shift
+            ;;
+        --ubuntu_version|-u)
+            UBUNTU_VERSION=$2
+            shift
+            shift
+            ;;
+        --image_id|-i)
+            DOCKER_NAME=$2
+            DOCKER_TAG=""
+            CUSTOM_ID="yes"
+            shift
+            shift
+            ;;
+        --clang)
+            COMPILER="clang"
+            shift
+            ;;
+        *)
+            echo "Error : unhandled parameter"
+            usage
+            exit 1
+    esac
 done
 
-if [ -e ${TOP_LVL_DIR}/.env ]; then
-    source ${TOP_LVL_DIR}/.env
+if [ -e "${TOP_LVL_DIR}/.env" ]; then
+    source "${TOP_LVL_DIR}/.env"
 fi
 
-if [ -z  ${DEFAULT_DEV_WORKSPACE} ]; then
-    DEFAULT_DEV_WORKSPACE=${TOP_LVL_DIR}
-fi
-
-MOUNT_CMD="-v ${DEFAULT_DEV_WORKSPACE}:/app"
+MOUNT_CMD="-v ${DEFAULT_DEV_WORKSPACE:-${TOP_LVL_DIR}}:/app"
 
 # Support docker sync : Improves compilation speed 
 # Example of config (to be pasted in the docker-sync.yml file)
@@ -100,10 +96,10 @@ MOUNT_CMD="-v ${DEFAULT_DEV_WORKSPACE}:/app"
 #     host_disk_mount_mode: "cached"
 if [ -e "${TOP_LVL_DIR}/docker-sync.yml" ]; then
     # Grep the docker sync config (expected in root directory) to retrieve name of volume
-    VOLUME_SYNC=$(grep -A 1 "syncs:" ${TOP_LVL_DIR}/docker-sync.yml | tail -n 1 | awk -F ':' '{print $1}' | sed "s/ //g")
-    echo $VOLUME_SYNC
+    VOLUME_SYNC=$(grep -A 1 "syncs:" "${TOP_LVL_DIR}/docker-sync.yml" | tail -n 1 | awk -F ':' '{print $1}' | sed "s/ //g")
+    echo "$VOLUME_SYNC"
     MOUNT_CMD="--mount source=${VOLUME_SYNC},target=/app"
-    if [ -z "$(docker-sync list | grep $VOLUME_SYNC)" ]; then
+    if ! grep -q "$VOLUME_SYNC" "$(docker-sync list | grep )"; then
         echo "Please generate a volume: $VOLUME_SYNC"
         echo "Suggested commands:"
         echo "docker volume create $VOLUME_SYNC"
@@ -114,11 +110,8 @@ fi
 
 # If we didn't pass a custom ID, then focus on Ubuntu
 if [ ! ${CUSTOM_ID:-,,} == "yes" ]; then
-    DOCKER_NAME=${DEFAULT_BASE_NAME}_${UBUNTU_VERSION}
+    DOCKER_NAME=${DEFAULT_BASE_NAME}_${UBUNTU_VERSION}_${COMPILER}
     DOCKER_TAG=":latest"
-    if [ ${USE_GCC:-,,} == "yes" ]; then
-        DOCKER_NAME="${DOCKER_NAME}_gcc"
-    fi
 fi
 
 echo "Considering docker image    : $DOCKER_NAME"
@@ -127,18 +120,14 @@ echo "           Mount command    : ${MOUNT_CMD}"
 
 if [ $PERFORM_CLEAN -eq 1 ]; then
     echo "Clean image : ${DOCKER_NAME}"
-    docker image rm ${DOCKER_NAME}
+    docker image rm "${DOCKER_NAME}"
 fi
 
 # Check if base image exists
-if [ ! ${CUSTOM_ID:-,,} == "yes" ] && [ -z "$(docker images | awk '{print $1}'| grep -E "^${DOCKER_NAME}$")" ]; then
+if [ ! ${CUSTOM_ID:-,,} == "yes" ] && ! docker images | awk '{print $1}'| grep -qE "^${DOCKER_NAME}$"; then
     echo "Building image"
-    COMPILE_BUILD_ARG=""
-    if [ ${USE_GCC:-,,} == "yes" ]; then
-        COMPILE_BUILD_ARG="--build-arg CXX_COMPILER=g++ --build-arg C_COMPILER=gcc"
-    fi  
-    BUILD_CMD="docker build -t ${DOCKER_NAME} -f $BASE_DOCKERFILE --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} ${COMPILE_BUILD_ARG} ."
-    eval ${BUILD_CMD}
+    BUILD_CMD="docker build -t ${DOCKER_NAME} --build-arg COMPILER=$COMPILER --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} -f $BASE_DOCKERFILE ."
+    eval "${BUILD_CMD}"
 else 
     echo "Base image found, not rebuilding. Remove it to force rebuild."
 fi
@@ -149,12 +138,11 @@ if [ -z "$(ssh-add -L)" ]; then
     exit 1
 fi
 
-if [ -z `echo $OSTYPE|grep darwin` ]; then
+if [[ "$OSTYPE" != "darwin*" ]]; then
     echo "Script only tested on MacOS."
     echo "Attempting to continue : please update script for your OS if ssh socket is failing."
 fi 
 
 echo "Launch docker image, DO NOT STORE ANYTHING outside of mounted directory (container is erased on exit)."
-docker run -it --rm -v /run/host-services/ssh-auth.sock:/ssh-agent -w /app --cap-add CAP_SYS_PTRACE --cap-add SYS_ADMIN ${MOUNT_CMD} -e SSH_AUTH_SOCK=/ssh-agent ${DOCKER_NAME}${DOCKER_TAG} /bin/bash
-
-exit 0
+ # shellcheck disable=SC2086
+docker run -it --rm -v /run/host-services/ssh-auth.sock:/ssh-agent -w /app --cap-add CAP_SYS_PTRACE --cap-add SYS_ADMIN ${MOUNT_CMD} -e SSH_AUTH_SOCK=/ssh-agent "${DOCKER_NAME}${DOCKER_TAG}" /bin/bash


### PR DESCRIPTION
# What does this PR do?

* Update to gcc 9 for ubuntu 16 and 11 for ubuntu 18/20
* Update cppcheck (allow to remove some weird suppression)
* Update cmake
* Update clang (13 for ubuntu 18/20)
* Add clang-tidy to build image

# Motivation

* Prepare for use of C++20 standard
* Prepare for activation of clang-tidy

# Additional Notes

https://github.com/DataDog/ddprof-build/pull/18 is needed to make the build succeed

# How to test the change?

Describe here in detail how the change can be validated.  This is a great section to call out specific tests you've added or improved, or to acknowledge code sections which are particularly difficult to test.
