### PR TITLE
Activate C++20 and add clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+Checks: 'bugprone-*,-bugprone-easily-swappable-parameters,-bugprone-narrowing-conversions,cert-*,clang-analyzer-*,misc-*'
+FormatStyle: 'file'
+WarningsAsErrors: '*'
+# performance-*,modernize-*,cppcoreguidelines-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ endif()
 ###################
 ### Benchmarks  ###
 ###################
-option(BUILD_BENCHMARKS "Enable tests" OFF)
+option(BUILD_BENCHMARKS "Enable benchmarks" OFF)
 if (${BUILD_BENCHMARKS})
   add_subdirectory(bench/collatz)
 endif()
@@ -186,8 +186,6 @@ add_exe(ddprof
         LIBRARIES ${DDPROF_LIBRARY_LIST}
         DEFINITIONS ${DDPROF_DEFINITION_LIST})
 target_include_directories(ddprof PRIVATE ${DDPROF_INCLUDE_LIST})
-set_property(TARGET ddprof PROPERTY CXX_STANDARD 14)
-set_property(TARGET ddprof PROPERTY C_STANDARD 11)
 static_link_cxx(TARGET ddprof)
 
 # Ensure all dependencies are computed
@@ -218,15 +216,13 @@ add_library(ddprof_wrapper-static STATIC ${DDPROF_WRAPPER_SOURCES})
 set_target_properties(ddprof_wrapper-static PROPERTIES OUTPUT_NAME ddprof_wrapper)
 target_include_directories(ddprof_wrapper-static PUBLIC ${CMAKE_SOURCE_DIR}/include/wrapper ${CMAKE_SOURCE_DIR}/include)
 set_target_properties(ddprof_wrapper-static PROPERTIES
-   PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/wrapper/ddprof_wrapper.h"
-   CXX_STANDARD 14)
+   PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/wrapper/ddprof_wrapper.h")
 
 add_library(ddprof_wrapper-shared SHARED ${DDPROF_WRAPPER_SOURCES})
 set_target_properties(ddprof_wrapper-shared PROPERTIES OUTPUT_NAME ddprof_wrapper)
 target_include_directories(ddprof_wrapper-shared PUBLIC ${CMAKE_SOURCE_DIR}/include/wrapper ${CMAKE_SOURCE_DIR}/include)
 set_target_properties(ddprof_wrapper-shared PROPERTIES
-   PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/wrapper/ddprof_wrapper.h"
-   CXX_STANDARD 14)
+   PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/wrapper/ddprof_wrapper.h")
 
 install(TARGETS ddprof_wrapper-static ddprof_wrapper-shared)
 
@@ -256,9 +252,7 @@ if (${BUILD_NATIVE_LIB})
    ## Create the lib
    add_library(ddprof-native
                ${DDPROF_LIB_SRC})
-   set_property(TARGET ddprof-native PROPERTY CXX_STANDARD 14)
-   set_property(TARGET ddprof-native PROPERTY C_STANDARD 11)
-
+   
    set_target_properties(ddprof-native PROPERTIES VERSION ${PROJECT_VERSION})
    set_target_properties(ddprof-native PROPERTIES
                          COMPILE_DEFINITIONS DDPROF_NATIVE_LIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ list(APPEND ELFUTILS_LIBRARIES dw elf libz.a liblzma.a)
 #######################
 
 #Cpp Check
+include(ClangTidy)
 include(Cppcheckconfig)
 include(Format)
 

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -1,0 +1,30 @@
+option(ENABLE_CLANG_TIDY "Run clang-tidy with the compiler." OFF)
+if(ENABLE_CLANG_TIDY)
+    find_program(CLANG_TIDY_COMMAND NAMES clang-tidy)
+    if(NOT CLANG_TIDY_COMMAND)
+        message(WARNING "CMake_RUN_CLANG_TIDY is ON but clang-tidy is not found!")
+        set(CMAKE_CXX_CLANG_TIDY "" CACHE STRING "" FORCE)
+    else()
+        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND};-header-filter='${CMAKE_SOURCE_DIR}/include/*'")
+    endif()
+
+    # Create a preprocessor definition that depends on .clang-tidy content so
+    # the compile command will change when .clang-tidy changes.  This ensures
+    # that a subsequent build re-runs clang-tidy on all sources even if they
+    # do not otherwise need to be recompiled.  Nothing actually uses this
+    # definition.  We add it to targets on which we run clang-tidy just to
+    # get the build dependency on the .clang-tidy file.
+    file(SHA1 ${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy clang_tidy_sha1)
+    add_compile_definitions(CLANG_TIDY_SHA1=${clang_tidy_sha1})
+    unset(clang_tidy_sha1)
+    set_property(
+            DIRECTORY
+            APPEND
+            PROPERTY CMAKE_CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy)
+endif()
+
+function(disable_clangtidy target)
+    set_target_properties(${target} PROPERTIES 
+        CXX_CLANG_TIDY ""
+        C_CLANG_TIDY "")
+endfunction()

--- a/cmake/ExtendBuildTypes.cmake
+++ b/cmake/ExtendBuildTypes.cmake
@@ -6,6 +6,9 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "CMake build type" FORCE)
 endif()
 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_C_STANDARD 11)
+
 add_compile_options(-Wall)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/cmake/Helperfunc.cmake
+++ b/cmake/Helperfunc.cmake
@@ -55,19 +55,3 @@ function(static_link_cxx)
   target_link_options(${STATIC_LINK_CXX_TARGET} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-static-libstdc++>)
   target_link_options(${STATIC_LINK_CXX_TARGET} PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-static-libgcc>)
 endfunction()
-
-# Set a target's disposition for clang-tidy
-function(enable_clangtidy)
-  cmake_parse_arguments(ENABLE_CLANGTIDY
-    "NOTIDY"
-    "TARGET"
-    ""
-    ${ARGN})
-    if (NOT ENABLE_CLANGTIDY_NOTIDY)
-      set(CLANG_TIDY_OPTIONS "clang-tidy; -header-filter=.; -checks=*;")
-    else()
-      set(CLANG_TIDY_OPTIONS "")
-    endif()
-    set_property(TARGET ${ENABLE_CLANGTIDY_TARGET} PROPERTY CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_OPTIONS}")
-    set_property(TARGET ${ENABLE_CLANGTIDY_TARGET} PROPERTY CMAKE_C_CLANG_TIDY "${CLANG_TIDY_OPTIONS}")
-endfunction()

--- a/include/wrapper/ddprof_wrapper.h
+++ b/include/wrapper/ddprof_wrapper.h
@@ -1,4 +1,3 @@
-
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0. This product includes software
 // developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -216,7 +216,7 @@ void *ddprof_worker_export_thread(void *arg) {
 
 /// Cycle operations : export, sync metrics, update counters
 DDRes ddprof_worker_cycle(DDProfContext *ctx, int64_t now,
-                          bool synchronous_export) {
+                          [[maybe_unused]] bool synchronous_export) {
 
   // Scrape procfs for process usage statistics
   DDRES_CHECK_FWD(worker_update_stats(&ctx->worker_ctx.proc_status,

--- a/src/dso.cc
+++ b/src/dso.cc
@@ -12,22 +12,24 @@ extern "C" {
 
 #include "string_format.hpp"
 
+#include <string_view>
+
 namespace ddprof {
 
-static const std::string s_vdso_str = "[vdso]";
-static const std::string s_vsyscall_str = "[vsyscall]";
-static const std::string s_stack_str = "[stack]";
-static const std::string s_heap_str = "[heap]";
+static const std::string_view s_vdso_str = "[vdso]";
+static const std::string_view s_vsyscall_str = "[vsyscall]";
+static const std::string_view s_stack_str = "[stack]";
+static const std::string_view s_heap_str = "[heap]";
 // anon and empty are the same (one comes from perf, the other from proc maps)
-static const std::string s_anon_str = "//anon";
-static const std::string s_jsa_str = ".jsa";
+static const std::string_view s_anon_str = "//anon";
+static const std::string_view s_jsa_str = ".jsa";
 // Example of these include : anon_inode:[perf_event]
-static const std::string s_anon_inode_str = "anon_inode";
+static const std::string_view s_anon_inode_str = "anon_inode";
 // Example socket:[123456]
-static const std::string s_socket_str = "socket";
+static const std::string_view s_socket_str = "socket";
 // null elements
-static const std::string s_dev_zero_str = "/dev/zero";
-static const std::string s_dev_null_str = "/dev/null";
+static const std::string_view s_dev_zero_str = "/dev/zero";
+static const std::string_view s_dev_null_str = "/dev/null";
 // invalid element
 Dso::Dso()
     : _pid(-1), _start(), _end(), _pgoff(), _filename(), _type(dso::kUndef),

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -12,6 +12,8 @@ extern "C" {
 #include "signal_helper.h"
 }
 #include "ddres.h"
+#include "defer.hpp"
+
 #include <algorithm>
 #include <cassert>
 #include <numeric>
@@ -30,17 +32,6 @@ static FILE *procfs_map_open(int pid, const char *path_to_proc = "") {
   }
   return fopen(buf, "r");
 }
-
-struct ProcFileHolder {
-  explicit ProcFileHolder(int pid, const std::string &path_to_proc = "") {
-    _mpf = procfs_map_open(pid, path_to_proc.c_str());
-  }
-  ~ProcFileHolder() {
-    if (_mpf)
-      fclose(_mpf);
-  }
-  FILE *_mpf;
-};
 
 #ifndef NDEBUG
 static bool ip_in_procline(char *line, uint64_t ip) {
@@ -61,8 +52,7 @@ static bool ip_in_procline(char *line, uint64_t ip) {
 
 static void pid_find_ip(int pid, uint64_t ip,
                         const std::string &path_to_proc = "") {
-  ProcFileHolder file_holder(pid, path_to_proc);
-  FILE *mpf = file_holder._mpf;
+  FILE *mpf = procfs_map_open(pid, path_to_proc.c_str());
   if (!mpf) {
     if (process_is_alive(pid))
       LG_DBG("Couldn't find ip:0x%lx for %d, process is dead", ip, pid);
@@ -70,6 +60,7 @@ static void pid_find_ip(int pid, uint64_t ip,
       LG_DBG("Couldn't find ip:0x%lx for %d, mysteriously", ip, pid);
     return;
   }
+  defer { fclose(mpf); };
 
   char *buf = NULL;
   size_t sz_buf = 0;
@@ -112,7 +103,7 @@ void DsoStats::log() const {
 
 uint64_t DsoStats::sum_event_metric(DsoEventType dso_event) const {
   return std::accumulate(_metrics[dso_event].begin(), _metrics[dso_event].end(),
-                         0);
+                         0UL);
 }
 
 /**********/
@@ -441,15 +432,15 @@ bool DsoHdr::pid_backpopulate(pid_t pid, int &nb_elts_added) {
 // elements
 bool DsoHdr::pid_backpopulate(DsoMap &map, pid_t pid, int &nb_elts_added) {
   nb_elts_added = 0;
-  ProcFileHolder proc_file_holder(pid, _path_to_proc);
   LG_DBG("[DSO] Backpopulating PID %d", pid);
-  FILE *mpf = proc_file_holder._mpf;
+  FILE *mpf = procfs_map_open(pid, _path_to_proc.c_str());
   if (!mpf) {
     LG_DBG("[DSO] Failed to open procfs for %d", pid);
     if (!process_is_alive(pid))
       LG_DBG("[DSO] Process nonexistant");
     return false;
   }
+  defer { fclose(mpf); };
 
   char *buf = NULL;
   size_t sz_buf = 0;

--- a/src/dwfl_symbol.cc
+++ b/src/dwfl_symbol.cc
@@ -11,7 +11,9 @@ extern "C" {
 #include "dwfl_internals.h"
 #include "logger.h"
 }
+
 #include <cassert>
+#include <string_view>
 
 namespace ddprof {
 
@@ -35,9 +37,9 @@ bool symbol_get_from_dwfl(Dwfl_Module *mod, ProcessAddress_t process_pc,
 // #define FLAG_SYMBOL
 // A small mechanism to create a trace around the expected function
 #ifdef FLAG_SYMBOL
-  static const std::string look_for_symb = "runtime.asmcgocall.abi0";
+  static const std::string_view look_for_symb = "runtime.asmcgocall.abi0";
   if (symbol._demangle_name.find(look_for_symb) != std::string::npos) {
-    LG_NFO("DGB:: GOING THROUGH EXPECTED FUNC: %s", look_for_symb.c_str());
+    LG_NFO("DGB:: GOING THROUGH EXPECTED FUNC: %s", look_for_symb.data());
   }
 #endif
   Dwfl_Line *line = dwfl_module_getsrc(mod, process_pc);

--- a/src/perf_mainloop.cc
+++ b/src/perf_mainloop.cc
@@ -42,7 +42,7 @@ static inline int64_t now_nanos() {
   return (tv.tv_sec * 1000000 + tv.tv_usec) * 1000;
 }
 
-static void handle_signal(int signum) {
+static void handle_signal(int) {
   g_termination_requested = true;
 
   // forwarding signal to child
@@ -148,7 +148,7 @@ static inline DDRes worker_process_ring_buffers(PEvent *pes, int pe_len,
   // While there are events to process, iterate through them
   // while limiting time spent in loop to at most PSAMPLE_DEFAULT_WAKEUP_MS
   int64_t loop_start_ns = now_nanos();
-  int64_t local_now_ns = loop_start_ns;
+  int64_t local_now_ns;
 
   bool events;
   do {

--- a/src/unwind_dwfl.cc
+++ b/src/unwind_dwfl.cc
@@ -38,7 +38,7 @@ DDRes unwind_init_dwfl(UnwindState *us) {
 
     bool success = false;
     // Find an elf file we can load for this PID
-    for (auto el : map) {
+    for (const auto &el : map) {
       if (el.second._executable) {
         const Dso &dso = el.second;
         FileInfoId_t file_info_id = us->dso_hdr.get_or_insert_file_info(dso);

--- a/src/wrapper/ddprof_wrapper.cc
+++ b/src/wrapper/ddprof_wrapper.cc
@@ -26,8 +26,8 @@ extern "C" {
 
 static constexpr int k_default_timeout_ms = 1000;
 
-extern const char _binary_ddprof_start[];
-extern const char _binary_ddprof_end[];
+extern const char _binary_ddprof_start[]; // NOLINT cert-dcl51-cpp
+extern const char _binary_ddprof_end[];   // NOLINT cert-dcl51-cpp
 
 namespace {
 struct ProfilerState {
@@ -38,7 +38,7 @@ struct ProfilerState {
 ProfilerState g_state;
 
 struct ProfilerAutoStart {
-  ProfilerAutoStart() {
+  ProfilerAutoStart() noexcept {
     // Note that library needs to be linked with `--no-as-needed` when using
     // autostart Otherwise linker will completely remove library from DT_NEEDED
     // and library will not be loaded
@@ -70,7 +70,7 @@ struct ProfilerAutoStart {
 ProfilerAutoStart g_autostart;
 } // namespace
 
-int ddprof_start_profiling() {
+static int ddprof_start_profiling_internal() {  
   if (g_state.started) {
     return -1;
   }
@@ -164,6 +164,14 @@ int ddprof_start_profiling() {
   }
 
   return 0;
+}
+
+int ddprof_start_profiling() {  
+  try {
+    return ddprof_start_profiling_internal();
+  } catch(...) {   
+  }
+  return -1;
 }
 
 void ddprof_stop_profiling(int timeout_ms) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,7 +42,7 @@ function(add_unit_test name)
         ../src/logger.c
         ${MY_UNPARSED_ARGUMENTS})
    add_dependencies(${name} deps)
-   set_property(TARGET ${name} PROPERTY CXX_STANDARD 14)
+   
 
 
    target_link_libraries(${name} PRIVATE gtest Threads::Threads gmock_main gmock)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,7 +44,6 @@ function(add_unit_test name)
    add_dependencies(${name} deps)
    
 
-
    target_link_libraries(${name} PRIVATE gtest Threads::Threads gmock_main gmock)
    target_include_directories(${name} PRIVATE ../include ${GTEST_INCLUDE_DIRS})
 
@@ -52,7 +51,7 @@ function(add_unit_test name)
    set_tests_properties(${name} PROPERTIES
                         ENVIRONMENT "UBSAN_OPTIONS=halt_on_error=1 abort_on_error=1 print_stacktrace=1;\
                         LSAN_OPTIONS=detect_leaks=1 malloc_context_size=2 print_suppressions=0")
-   enable_clangtidy(TARGET ${name} NOTIDY)
+   disable_clangtidy(${name})
 endfunction()
 
 #### Definition of unit tests ####

--- a/test/self_unwind/CMakeLists.txt
+++ b/test/self_unwind/CMakeLists.txt
@@ -7,8 +7,7 @@ add_exe(selfuw
         LIBRARIES DDProf::Native nlohmann_json::nlohmann_json
         DEFINITIONS "MYNAME=\"selfuw\"" "STACK_DATA=\"${CMAKE_CURRENT_SOURCE_DIR}/data\"")
 
-set_property(TARGET selfuw PROPERTY CXX_STANDARD 14)
-set_property(TARGET selfuw PROPERTY C_STANDARD 11)
+disable_clangtidy(selfuw)
 static_link_cxx(TARGET selfuw)
 
 # slightly hacky : we should only include public headers 

--- a/third_party/llvm/CMakeLists.txt
+++ b/third_party/llvm/CMakeLists.txt
@@ -22,9 +22,8 @@ set(LLVM_DEMANGLE_SRC_FILES
 add_library(llvm-demangle STATIC
             ${LLVM_DEMANGLE_SRC_FILES})
 
-set_property(TARGET llvm-demangle PROPERTY CXX_STANDARD 14)
-enable_clangtidy(TARGET llvm-demangle NOTIDY)
+# disable warnings for third party
+target_compile_options(llvm-demangle PRIVATE "-w")
+disable_clangtidy(llvm-demangle)
 
-target_include_directories(llvm-demangle PUBLIC
-  include
-)
+target_include_directories(llvm-demangle PUBLIC include)


### PR DESCRIPTION
# What does this PR do?

* Compile in C++20 mode
* Enable clang-tidy checks during compilation when`-DENABLE_CLANG_TIDY=ON` is passed to cmake
* Fix some clang-tidy warnings

# Motivation

* Add more static analysis tools
* Benefit from latest C++ version

# Additional Notes

This is the section to put technical guidance/constraints, call out potential regressions, cite sources, and in general offer some exposition on the _how_ of the PR.  This section doesn't need to be incredibly detailed, but it makes life easier for reviewers!

# How to test the change?

Describe here in detail how the change can be validated.  This is a great section to call out specific tests you've added or improved, or to acknowledge code sections which are particularly difficult to test.
