### PR TITLE
Fix for sanitized debug arm builds

### DIFF
--- a/src/dwfl_thread_callbacks.cc
+++ b/src/dwfl_thread_callbacks.cc
@@ -18,7 +18,7 @@ pid_t next_thread(Dwfl *dwfl, void *arg, void **thread_argp) {
 // Instead, we crib off of libdwfl's ARM/x86 unwind code in elfutil's
 // libdwfl/unwind-libdw.c
 bool set_initial_registers(Dwfl_Thread *thread, void *arg) {
-  Dwarf_Word regs[33] = {}; // max register count across all arcs
+  Dwarf_Word regs[PERF_REGS_COUNT] = {}; // max register count across all arcs
   uint64_t n = 0;
   struct UnwindState *us = reinterpret_cast<UnwindState *>(arg);
 

--- a/test/perf_ringbuffer-ut.cc
+++ b/test/perf_ringbuffer-ut.cc
@@ -64,7 +64,10 @@ TEST(PerfRingbufferTest, SampleSymmetryx86) {
   char default_stack[4096] = {0};
   for (uint64_t i = 0; i < sizeof(default_stack) / sizeof(*default_stack); i++)
     default_stack[i] = i & 255;
-  uint64_t default_regs[3] = {0x1111, 0x2222, 0x4444};
+  uint64_t default_regs[PERF_REGS_COUNT] = {};
+  for (int i = 0; i < PERF_REGS_COUNT; ++i) {
+    default_regs[i] = 1ull << i;
+  }
   struct perf_event_sample sample = {};
   uint64_t default_val = 0x11111111;
   sample.header.type = PERF_RECORD_SAMPLE;


### PR DESCRIPTION
# What does this PR do?

Adapt unit test to consider all the registers that are copied from the stack

# Motivation

Get arm build to work in SanitizedDebug mode

# Additional Notes

NA

# How to test the change?

Check on downstream CI build
