### PR TITLE
Fix ringbuffer overflow

### DIFF
--- a/src/perf_ringbuffer.c
+++ b/src/perf_ringbuffer.c
@@ -25,7 +25,7 @@ bool rb_init(RingBuffer *rb, struct perf_event_mmap_page *page, size_t size) {
   // Allocate room for a watcher-held buffer.  This is for linearizing
   // ringbuffer elements and depends on the per-watcher configuration for
   // perf_event_open().  Eventually this size will be non-static.
-  uint64_t buf_sz = PERF_REGS_COUNT + PERF_SAMPLE_STACK_SIZE;
+  uint64_t buf_sz = sizeof(uint64_t)*PERF_REGS_COUNT+ PERF_SAMPLE_STACK_SIZE;
   buf_sz += sizeof(perf_event_sample);
   unsigned char *wrbuf = malloc(buf_sz);
   if (!wrbuf)


### PR DESCRIPTION
# What does this PR do?

This fix just adds the size of the registers into
the computation for the initial size of the ringbuffer copy held by each watcher.

# Motivation

The size of the ringbuffer is given in bytes.  When that size is
initialized, we were using the *number* of registers, but not
multiplying it by the number of bytes per register.  Since the sample
object in the ringbuffer omits fields when they aren't specified by the
feature flags given to `perf_event_open()`, the ringbuffer elements were
always strictly smaller than our struct definition.  That struct
definition is part of the sizing criteria, so even though we were
undercounting the the register part of the sample, we overcounted in
other places to compensate.

Now that we're pulling in many more registers, the problem has become
noticeable to ASAN.  This fix just adds the size of the registers into
the computation.

# Additional Notes

It would be preferable to link this back to the register size,
but it would be cumbersome to inject that quantity back into the header
deserializer.  Since we don't support any registers apart from 64-bit
ones, this is fine for now.

# How to test the change?

Automatically tested since this breaks in the current ASAN tests, thanks to the ARM fixes.
