### PR TITLE
Leak detection removal - 2nd attempt

### DIFF
--- a/cmake/ExtendBuildTypes.cmake
+++ b/cmake/ExtendBuildTypes.cmake
@@ -24,14 +24,6 @@ set(SAN_FLAGS "-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitiz
 set(ASAN_FLAGS "-fsanitize=address")
 set(TSAN_FLAGS "-fsanitize=thread")
 set(STACK_FLAGS "-fstack-protector-all")
-# On arm builds LSAN is barely usable
-# https://github.com/google/sanitizers/issues/703
-option(DDPROF_SKIP_LSAN "Remove lsan." OFF)
-if(${DDPROF_SKIP_LSAN})
-    set(LSAN_FLAGS "-fsanitize=leak")
-else()
-    set(LSAN_FLAGS "")
-endif()
 
 ## Frame pointers
 set(FRAME_PTR_FLAG "-fno-omit-frame-pointer")
@@ -43,11 +35,11 @@ message(STATUS "Adding build types...")
 
 ## Add flags for sanitized debug (asan)
 SET(CMAKE_CXX_FLAGS_SANITIZEDDEBUG
-    "${GCC_DEBUG_FLAGS} ${SAN_FLAGS} ${ASAN_FLAGS} ${LSAN_FLAGS} ${STACK_FLAGS}"
+    "${GCC_DEBUG_FLAGS} ${SAN_FLAGS} ${ASAN_FLAGS} ${STACK_FLAGS}"
     CACHE STRING "Flags used by the C++ compiler during sanitized builds."
     FORCE )
 SET(CMAKE_C_FLAGS_SANITIZEDDEBUG
-    "${GCC_DEBUG_FLAGS} ${SAN_FLAGS} ${ASAN_FLAGS} ${LSAN_FLAGS} ${STACK_FLAGS}"
+    "${GCC_DEBUG_FLAGS} ${SAN_FLAGS} ${ASAN_FLAGS} ${STACK_FLAGS}"
     CACHE STRING "Flags used by the C compiler during sanitized builds."
     FORCE )
 SET(CMAKE_EXE_LINKER_FLAGS_SANITIZEDDEBUG

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,10 @@ find_package(GTest REQUIRED)
 
 enable_testing()
 
+# On arm builds Leak Detection is barely usable.
+# https://github.com/google/sanitizers/issues/703
+option(DDPROF_DETECT_LEAK "Parameter for leak detection." 1)
+
 ### Code coverage
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Coverage")
     message(STATUS "Activating code coverage in tests")
@@ -20,7 +24,7 @@ endif()
 
 #[[ Create a unit test
 Syntax:
-add_unit_test(<name> src1 [src2 ...] [LIBRARIES lib1 lib2 ...] [DEFINITIONS def1 def2] [NO_DETECT_LEAKS])
+add_unit_test(<name> src1 [src2 ...] [LIBRARIES lib1 lib2 ...] [DEFINITIONS def1 def2])
 will compile an unit test named <name> from source files src1 src2...
 with pre-processor definitions def1 def2 (-Ddef1 -Ddef2 ... will be added to compile command)
 and link against lib1 lib2 ... and libm
@@ -46,9 +50,8 @@ function(add_unit_test name)
    target_include_directories(${name} PRIVATE ../include ${GTEST_INCLUDE_DIRS})
 
    add_test(NAME ${name} COMMAND ${name})
-   set_tests_properties(${name} PROPERTIES
-                        ENVIRONMENT "UBSAN_OPTIONS=halt_on_error=1 abort_on_error=1 print_stacktrace=1;\
-                        LSAN_OPTIONS=detect_leaks=1 malloc_context_size=2 print_suppressions=0")
+   set_tests_properties(${name} PROPERTIES  
+                        ENVIRONMENT "UBSAN_OPTIONS=halt_on_error=1 abort_on_error=1 print_stacktrace=1;LSAN_OPTIONS=detect_leaks=${DDPROF_DETECT_LEAK} malloc_context_size=2 print_suppressions=0")
    disable_clangtidy(${name})
 endfunction()
 


### PR DESCRIPTION

# What does this PR do?

Ctest sets an environment variable at runtime to ensure we trigger leak detection.
Use this variable to remove usage of sanitizer's leak detection. This is related to counter performance of leak detection on arm.

# Motivation

- Use the runtime mechanism to remove leak detection.
- As ASAN was also using LSAN, the previous leak detection removal was a failure.
