### PR TITLE
Avoid flaky unit test

### DIFF
--- a/test/ddprof_pprof-ut.cc
+++ b/test/ddprof_pprof-ut.cc
@@ -45,7 +45,7 @@ void test_pprof(const DDProfPProf *pprofs) {
 
   // Check that encoded time is close to now
   time_t local_time = time(NULL);
-  EXPECT_TRUE(local_time - start.seconds < 1);
+  EXPECT_TRUE(local_time - start.seconds < 2);
 
   ddprof_ffi_Buffer profile_buffer = {
       .ptr = encoded_profile->buffer.ptr,


### PR DESCRIPTION
# What does this PR do?

Testing that the pprof was created and encoded in the same second, generates random failures.
The proposal here is to consider a 2 second difference (instead of within the same second).

# Motivation

Fixing random failures in a unit test
