### PR TITLE
Fix accounting of CPU

### DIFF
--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -259,7 +259,7 @@ DDRes ddprof_worker_cycle(DDProfContext *ctx, int64_t now,
   // Reset the current, ensuring the timestamp starts when we are about to write
   // to it
   DDRES_CHECK_FWD(
-      pprof_reset(ctx->worker_ctx->pprof[ctx->worker_ctx.i_current_pprof]));
+      pprof_reset(ctx->worker_ctx.pprof[ctx->worker_ctx.i_current_pprof]));
 
   if (!synchronous_export) {
     pthread_create(&ctx->worker_ctx.exp_tid, NULL, ddprof_worker_export_thread,

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -205,11 +205,6 @@ void *ddprof_worker_export_thread(void *arg) {
     LG_NFO("Failed to export from worker");
     worker->exp_error = true;
   }
-
-  if (IsDDResNotOK(pprof_reset(worker->pprof[i]))) {
-    worker->exp_error = true;
-  }
-
   return nullptr;
 }
 #endif
@@ -260,6 +255,12 @@ DDRes ddprof_worker_cycle(DDProfContext *ctx, int64_t now,
   // switch before we async export to avoid any possible race conditions (then
   // take into account the switch)
   ctx->worker_ctx.i_current_pprof = 1 - ctx->worker_ctx.i_current_pprof;
+
+  // Reset the current, ensuring the timestamp starts when we are about to write
+  // to it
+  DDRES_CHECK_FWD(
+      pprof_reset(ctx->worker_ctx->pprof[ctx->worker_ctx.i_current_pprof]));
+
   if (!synchronous_export) {
     pthread_create(&ctx->worker_ctx.exp_tid, NULL, ddprof_worker_export_thread,
                    &ctx->worker_ctx);


### PR DESCRIPTION
# What does this PR do?

As the start and end of the profiles are computed when we reset the pprof,
we were off by a 2x factor. The profiles were reset once the send was complete.
The fix consists in reseting the profile once we are ready to write to it.

Investigated with @nsavoire 

# Motivation

Ensure we report numbers closer to the usage of the machine

# Additional Notes

I don't see an issue in reseting at that point as we should have killed the exporter thread if it was still ongoing.

# How to test the change?

Check that CPU accounting is closer to reality.

