### PR TITLE
Fix small typo in Build.md

### DIFF
--- a/docs/Build.md
+++ b/docs/Build.md
@@ -65,7 +65,7 @@ docker volume rm ddprof-sync
 source setup_env.sh
 mkdir -p build_Release
 cd build_Release
-RelCmake ../
+RelCMake ../
 make -j 4 .
 ```
 


### PR DESCRIPTION
Command should be `RelCMake` instead of `RelCmake` from setup_env.sh
