### PR TITLE
Add utility function to save context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,18 +90,6 @@ include(Findlibcap)
 # llvm demangler
 add_subdirectory(third_party/llvm)
 
-####################
-### Unit tests   ###
-####################
-
-### Unit tests
-# Add infrastructure for enabling tests
-option(BUILD_DDPROF_TESTING "Enable tests" ON)
-if (${BUILD_DDPROF_TESTING})
-  enable_testing()
-  add_subdirectory(test)
-endif()
-
 ###################
 ### Benchmarks  ###
 ###################
@@ -123,7 +111,7 @@ include(Version)
 string(APPEND CMAKE_C_FLAGS " ${FRAME_PTR_FLAG}")
 string(APPEND CMAKE_CXX_FLAGS " ${FRAME_PTR_FLAG}")
 
-list(APPEND DDPROF_INCLUDE_LIST ${CMAKE_SOURCE_DIR}/include)
+list(APPEND DDPROF_INCLUDE_LIST ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/third_party)
 
 # Find the source files
 aux_source_directory(src COMMON_SRC)
@@ -220,7 +208,6 @@ if (${BUILD_NATIVE_LIB})
 
    ## Libs to link
    set(NATIVE_LIB_LIBRARY_LIST llvm-demangle ${ELFUTILS_LIBRARIES} Threads::Threads)
-   list(APPEND NATIVE_LIB_INCLUDE_LIST ${CMAKE_SOURCE_DIR}/include)
 
    if (${DDPROF_JEMALLOC})
       list(PREPEND NATIVE_LIB_LIBRARY_LIST jemalloc)
@@ -236,9 +223,8 @@ if (${BUILD_NATIVE_LIB})
                          
    # libcap, can be removed from version distributed to client 
    list(APPEND NATIVE_LIB_LIBRARY_LIST libcap)
-   list(APPEND NATIVE_LIB_INCLUDE_LIST ${LIBCAP_INCLUDE_DIR})
 
-   target_include_directories(ddprof-native PRIVATE ${NATIVE_LIB_INCLUDE_LIST})
+   target_include_directories(ddprof-native PRIVATE ${DDPROF_INCLUDE_LIST})
 
    target_link_libraries(ddprof-native PRIVATE ${NATIVE_LIB_LIBRARY_LIST})
    add_library(DDProf::Native ALIAS ddprof-native)
@@ -248,4 +234,16 @@ if (${BUILD_NATIVE_LIB})
    if(${ACCURACY_TEST})
       add_subdirectory(test/self_unwind)
    endif()
+endif()
+
+####################
+### Unit tests   ###
+####################
+
+### Unit tests
+# Add infrastructure for enabling tests
+option(BUILD_DDPROF_TESTING "Enable tests" ON)
+if (${BUILD_DDPROF_TESTING})
+  enable_testing()
+  add_subdirectory(test)
 endif()

--- a/CppCheckSuppressions.txt
+++ b/CppCheckSuppressions.txt
@@ -11,3 +11,6 @@ missingInclude
 // trick to retrieve instruction pointer in unit tests
 unusedLabel:*/dso-ut.cc
 unusedLabel:*/dwfl_module-ut.cc
+
+// cppcheck does not like google benchmark macros
+constParameterCallback:*/*-bench.cc

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -3,3 +3,4 @@ elfutils,"https://sourceware.org/elfutils/",LGPL-3.0-or-later,Free Software Foun
 libcap,"https://git.kernel.org/pub/scm/libs/libcap/libcap.git/",BSD-3-Clause,Free Software Foundation 
 liblzma,"https://github.com/kobolabs/liblzma",Public-Domain,NA
 llvm-demangle,"https://github.com/llvm/llvm-project",Apache-2.0,llvm-project
+tcbrindle/span,"https://github.com/tcbrindle/span",Boost Software License 1.0

--- a/cmake/asan.supp
+++ b/cmake/asan.supp
@@ -1,0 +1,1 @@
+interceptor_via_fun:save_stack

--- a/include/perf.h
+++ b/include/perf.h
@@ -16,8 +16,6 @@
 
 #define PSAMPLE_DEFAULT_WAKEUP_MS 100 // sample frequency check
 #define PERF_SAMPLE_STACK_SIZE (4096 * 8)
-#define PERF_SAMPLE_STACK_REGS 3
-#define MAX_INSN 16
 
 // TODO, probably make this part of the unwinding context or ddprof ctx
 #define DEFAULT_SAMPLE_TYPE                                                    \

--- a/include/savecontext.hpp
+++ b/include/savecontext.hpp
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "perf_archmap.h"
+#include "span.hpp"
+
+/** Save registers and stack for remote unwinding
+ * Return saved stack size */
+size_t save_context(ddprof::span<uint64_t, PERF_REGS_COUNT> regs,
+                    ddprof::span<std::byte> buffer) __attribute__((noinline));

--- a/include/span.hpp
+++ b/include/span.hpp
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#pragma once
+
+#if __cpp_lib_span
+
+#  include <span>
+
+namespace ddprof {
+using std::as_bytes;
+using std::as_writable_bytes;
+using std::span;
+} // namespace ddprof
+
+#else
+
+#  define TCB_SPAN_NAMESPACE_NAME ddprof
+#  include "tcb/span.hpp"
+
+#endif

--- a/src/savecontext.cc
+++ b/src/savecontext.cc
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include "savecontext.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <pthread.h>
+
+#define XSTR(s) STR(s)
+#define STR(s) #s
+
+#ifdef __x86_64__
+// hardcode register index in mask
+// Did not find a way to reuse enum values from perf-archmap.h
+#  define RBX_IDX 1
+#  define RBP_IDX 6
+#  define RSP_IDX 7
+#  define RIP_IDX 8
+#  define R12_IDX 16
+#  define R13_IDX 17
+#  define R14_IDX 18
+#  define R15_IDX 19
+
+#  define DEST_MEM(reg) XSTR(reg##_IDX) "*8(%rdi)\n"
+#  define SAVE_REG(reg) "movq %" #  reg ", " DEST_MEM(reg)
+
+static __attribute__((noinline, naked)) void
+save_registers(ddprof::span<uint64_t, PERF_REGS_COUNT>) {
+  // The goal here is to capture the state of registers after the return of this
+  // function. That is why this function must not be inlined.
+
+  // clang-format off
+    asm (
+    // Retrieve caller save registers
+    // Callee save register are not needed since they could contain anything after function return
+    SAVE_REG(RBX)
+    SAVE_REG(RBP)    
+    SAVE_REG(R12)
+    SAVE_REG(R13)
+    SAVE_REG(R14)
+    SAVE_REG(R15)
+    // Bump the stack by 8 bytes to remove the return address, 
+    // that way we will have the value of RSP after funtion return
+    "leaq 8(%rsp), %rax\n"
+    "movq %rax, " DEST_MEM(RSP) "\n"
+    // 0(%rsp) contains the return address, this is the value of RIP after funtion return
+    "movq 0(%rsp), %rax\n"
+    "movq %rax, " DEST_MEM(RIP) "\n"
+    "ret\n"
+    );
+  // clang-format on
+}
+
+#else
+
+static __attribute__((noinline, naked)) void
+save_registers(ddprof::span<uint64_t, PERF_REGS_COUNT>) {
+  asm("ret\n");
+}
+
+#endif
+
+// Return stack end address (stack end address is the start of the stack since
+// stack grows down)
+static __attribute__((noinline)) const std::byte *get_stack_end_address() {
+  void *stack_addr;
+  size_t stack_size;
+  pthread_attr_t attrs;
+  pthread_getattr_np(pthread_self(), &attrs);
+  pthread_attr_getstack(&attrs, &stack_addr, &stack_size);
+  pthread_attr_destroy(&attrs);
+  return static_cast<std::byte *>(stack_addr) + stack_size;
+}
+
+// Disable address sanitizer, otherwise it will report a stack-buffer-underflow
+// when we are grabbing the stack. But this is not enough, because ASAN
+// intercepts memcpy and reports a satck underflow there, empirically it appears
+// that both attribute and a suppression are required.
+static __attribute__((no_sanitize("address"))) size_t
+save_stack(const std::byte *stack_ptr, ddprof::span<std::byte> buffer) {
+  // Use a thread local variable to cache the stack end address per thread
+  thread_local static const std::byte *stack_end{};
+
+  if (!stack_end) {
+    // Slow path, takes ~30us
+    stack_end = get_stack_end_address();
+  }
+
+  // take the min of current stack size and requested stack sample size
+  size_t saved_stack_size =
+      std::min(static_cast<intptr_t>(buffer.size()), stack_end - stack_ptr);
+  // Use memmove to stay on the safe side on case caller put `buffer` on the
+  // stack
+  memmove(buffer.data(), stack_ptr, saved_stack_size);
+  return saved_stack_size;
+}
+
+size_t save_context(ddprof::span<uint64_t, PERF_REGS_COUNT> regs,
+                    ddprof::span<std::byte> buffer) {
+  save_registers(regs);
+  // save the stack just after saving registers, stack part above saved RSP must
+  // no be changed between call to save_registers and call to save_stack
+  return save_stack(reinterpret_cast<const std::byte *>(regs[REGNAME(SP)]),
+                    buffer);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
 find_package(GTest REQUIRED)
+find_package(benchmark REQUIRED)
 
 enable_testing()
 
@@ -41,24 +42,24 @@ function(add_unit_test name)
    message(STATUS "Creating unit test : " ${name})
 
    ## Create exe with sources. Always add logger and error management in the unit tests
-   add_exe(${name} 
+   add_exe(${name}
         ../src/ddres_list.c
         ../src/logger.c
         ${MY_UNPARSED_ARGUMENTS})
 
    target_link_libraries(${name} PRIVATE gtest Threads::Threads gmock_main gmock)
-   target_include_directories(${name} PRIVATE ../include ${GTEST_INCLUDE_DIRS})
+   target_include_directories(${name} PRIVATE ${DDPROF_INCLUDE_LIST} ${GTEST_INCLUDE_DIRS})
 
    add_test(NAME ${name} COMMAND ${name})
-   set_tests_properties(${name} PROPERTIES  
-                        ENVIRONMENT "UBSAN_OPTIONS=halt_on_error=1 abort_on_error=1 print_stacktrace=1;LSAN_OPTIONS=detect_leaks=${DDPROF_DETECT_LEAK} malloc_context_size=2 print_suppressions=0")
+   set_tests_properties(${name} PROPERTIES
+                        ENVIRONMENT "UBSAN_OPTIONS=halt_on_error=1 abort_on_error=1 print_stacktrace=1;LSAN_OPTIONS=detect_leaks=$<BOOL:${DDPROF_DETECT_LEAK}> malloc_context_size=2 print_suppressions=0;ASAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/cmake/asan.supp")
    disable_clangtidy(${name})
 endfunction()
 
 #### Definition of unit tests ####
 add_unit_test(
     ddprofcmdline-ut
-    ../src/ddprof_cmdline.c 
+    ../src/ddprof_cmdline.c
     ../src/perf_option.c
     ddprofcmdline-ut.cc
 )
@@ -70,28 +71,28 @@ add_unit_test(
 
 add_unit_test(
     signal_helper-ut
-    ../src/signal_helper.c 
+    ../src/signal_helper.c
     signal_helper-ut.cc
 )
 
 include(Version)
 add_unit_test(
     version-ut
-    ../src/version.c 
+    ../src/version.c
     version-ut.cc
     DEFINITIONS ${DDPROF_DEFINITION_LIST}
 )
 
 add_unit_test(
     statsd-ut
-    ../src/statsd.c 
+    ../src/statsd.c
     statsd-ut.cc
 )
 
 add_unit_test(
     ddprof_stats-ut
     ../src/ddprof_stats.c
-    ../src/statsd.c 
+    ../src/statsd.c
     ddprof_stats-ut.cc
 )
 
@@ -151,7 +152,7 @@ add_unit_test(
 
 add_unit_test(
     ddprof_input-ut
-    ../src/ddprof_cmdline.c 
+    ../src/ddprof_cmdline.c
     ../src/ddprof_input.cc
     ../src/perf_option.c
     ddprof_input-ut.cc
@@ -215,13 +216,13 @@ add_unit_test(
 
 add_unit_test(
     dso-ut
-    ../src/dso.cc 
+    ../src/dso.cc
     ../src/dso_hdr.cc
     ../src/ddprof_file_info.cc
     ../src/procutils.c
     ../src/signal_helper.c
     ../src/region_holder.cc
-    dso-ut.cc 
+    dso-ut.cc
     DEFINITIONS MYNAME="dso-ut")
 target_include_directories(dso-ut PRIVATE ${LIBCAP_INCLUDE_DIR})
 
@@ -248,7 +249,7 @@ add_unit_test(
     dwfl_module-ut.cc
     ../src/dwfl_hdr.cc
     ../src/dwfl_module.cc
-    ../src/dso.cc 
+    ../src/dso.cc
     ../src/dso_hdr.cc
     ../src/ddprof_file_info.cc
     ../src/procutils.c
@@ -258,3 +259,40 @@ add_unit_test(
     DEFINITIONS MYNAME="dwfl_symbol-ut"
 )
 add_compile_definitions("DWFL_TEST_DATA=\"${CMAKE_CURRENT_SOURCE_DIR}/data\"")
+
+add_unit_test(
+    savecontext-ut
+    savecontext-ut.cc
+    ../src/base_frame_symbol_lookup.cc
+    ../src/common_mapinfo_lookup.cc
+    ../src/common_symbol_lookup.cc
+    ../src/ddprof_file_info.cc
+    ../src/ddprof_stats.c
+    ../src/dso.cc
+    ../src/dso_hdr.cc
+    ../src/dso_symbol_lookup.cc
+    ../src/dwfl_hdr.cc
+    ../src/dwfl_module.cc
+    ../src/dwfl_symbol.cc
+    ../src/dwfl_symbol_lookup.cc
+    ../src/dwfl_thread_callbacks.cc
+    ../src/savecontext.cc
+    ../src/mapinfo_lookup.cc
+    ../src/procutils.c
+    ../src/region_holder.cc
+    ../src/signal_helper.c
+    ../src/statsd.c
+    ../src/unwind.cc
+    ../src/unwind_dwfl.cc
+    ../src/unwind_helpers.cc
+    ../src/unwind_metrics.c
+    ../src/unwind_output.c
+    LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle
+    DEFINITIONS MYNAME="savecontext-ut"
+)
+
+add_executable(savecontext-bench savecontext-bench.cc ../src/savecontext.cc)
+target_link_libraries(savecontext-bench benchmark::benchmark benchmark::benchmark_main)
+target_include_directories(savecontext-bench PRIVATE ${DDPROF_INCLUDE_LIST})
+# clang-tidy does like google-benchmark macros
+disable_clangtidy(savecontext-bench)

--- a/test/savecontext-bench.cc
+++ b/test/savecontext-bench.cc
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include <benchmark/benchmark.h>
+
+#include "perf.h"
+#include "perf_archmap.h"
+#include "savecontext.hpp"
+
+#include <thread>
+
+__attribute__((noinline)) static void *get_stack_start() {
+  void *stack_addr;
+  size_t stack_size;
+  pthread_attr_t attrs;
+  pthread_getattr_np(pthread_self(), &attrs);
+  pthread_attr_getstack(&attrs, &stack_addr, &stack_size);
+  return stack_addr;
+}
+
+__attribute__((noinline)) static void *get_stack_start_tls() {
+  thread_local static void *stack_addr = nullptr;
+  if (!stack_addr) {
+    size_t stack_size;
+    pthread_attr_t attrs;
+    pthread_getattr_np(pthread_self(), &attrs);
+    pthread_attr_getstack(&attrs, &stack_addr, &stack_size);
+  }
+  return stack_addr;
+}
+
+static void BM_SaveContext(benchmark::State &state) {
+  uint64_t regs[PERF_REGS_COUNT];
+  std::byte stack[PERF_SAMPLE_STACK_SIZE];
+
+  for (auto _ : state) {
+    save_context(regs, stack);
+  }
+}
+
+BENCHMARK(BM_SaveContext);
+
+static void BM_GetStackStart(benchmark::State &state) {
+
+  for (auto _ : state) {
+    get_stack_start();
+  }
+}
+
+BENCHMARK(BM_GetStackStart);
+
+static void BM_GetStackStartInThread(benchmark::State &state) {
+  std::thread t([&] {
+    for (auto _ : state) {
+      get_stack_start();
+    }
+  });
+  t.join();
+}
+
+BENCHMARK(BM_GetStackStartInThread);
+
+static void BM_GetStackStartTLS(benchmark::State &state) {
+
+  for (auto _ : state) {
+    get_stack_start_tls();
+  }
+}
+
+BENCHMARK(BM_GetStackStartTLS);
+
+static void BM_GetStackStartInThreadTLS(benchmark::State &state) {
+  std::thread t([&] {
+    for (auto _ : state) {
+      get_stack_start_tls();
+    }
+  });
+  t.join();
+}
+
+BENCHMARK(BM_GetStackStartInThreadTLS);

--- a/test/savecontext-ut.cc
+++ b/test/savecontext-ut.cc
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include <gtest/gtest.h>
+
+#include "perf.h"
+#include "savecontext.hpp"
+#include "unwind.hpp"
+#include "unwind_state.hpp"
+
+#include <algorithm>
+#include <unistd.h>
+
+void funcA() __attribute__((noinline));
+void funcB() __attribute__((noinline));
+
+std::byte stack[PERF_SAMPLE_STACK_SIZE];
+
+void funcB() {
+  UnwindState state;
+  uint64_t regs[K_NB_REGS_UNWIND];
+  size_t stack_size = save_context(regs, stack);
+
+  ddprof::unwind_init_sample(&state, regs, getpid(), stack_size,
+                             reinterpret_cast<char *>(stack));
+  ddprof::unwindstate__unwind(&state);
+
+  auto &symbol_table = state.symbol_hdr._symbol_table;
+
+  for (size_t iloc = 0; iloc < state.output.nb_locs; ++iloc) {
+    auto &symbol = symbol_table[state.output.locs[iloc]._symbol_idx];
+    printf("%zu: %s\n", iloc, symbol._demangle_name.c_str());
+  }
+
+  EXPECT_GT(state.output.nb_locs, 3);
+  auto &symbol0 = symbol_table[state.output.locs[0]._symbol_idx];
+  EXPECT_TRUE(symbol0._demangle_name.starts_with("save_context("));
+  auto &symbol1 = symbol_table[state.output.locs[1]._symbol_idx];
+  EXPECT_EQ(symbol1._demangle_name, "funcB()");
+  auto &symbol2 = symbol_table[state.output.locs[2]._symbol_idx];
+  EXPECT_EQ(symbol2._demangle_name, "funcA()");
+}
+
+void funcA() {
+  funcB();
+  // prevent tail call optimization
+  getpid();
+}
+
+#ifdef __x86_64__
+TEST(getcontext, getcontext) { funcA(); }
+#endif

--- a/third_party/tcb/span.hpp
+++ b/third_party/tcb/span.hpp
@@ -1,0 +1,617 @@
+
+/*
+This is an implementation of C++20's std::span
+http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/n4820.pdf
+*/
+
+//          Copyright Tristan Brindle 2018.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file ../../LICENSE_1_0.txt or copy at
+//          https://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef TCB_SPAN_HPP_INCLUDED
+#define TCB_SPAN_HPP_INCLUDED
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#ifndef TCB_SPAN_NO_EXCEPTIONS
+// Attempt to discover whether we're being compiled with exception support
+#if !(defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
+#define TCB_SPAN_NO_EXCEPTIONS
+#endif
+#endif
+
+#ifndef TCB_SPAN_NO_EXCEPTIONS
+#include <cstdio>
+#include <stdexcept>
+#endif
+
+// Various feature test macros
+
+#ifndef TCB_SPAN_NAMESPACE_NAME
+#define TCB_SPAN_NAMESPACE_NAME tcb
+#endif
+
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#define TCB_SPAN_HAVE_CPP17
+#endif
+
+#if __cplusplus >= 201402L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
+#define TCB_SPAN_HAVE_CPP14
+#endif
+
+namespace TCB_SPAN_NAMESPACE_NAME {
+
+// Establish default contract checking behavior
+#if !defined(TCB_SPAN_THROW_ON_CONTRACT_VIOLATION) &&                          \
+    !defined(TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION) &&                      \
+    !defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#if defined(NDEBUG) || !defined(TCB_SPAN_HAVE_CPP14)
+#define TCB_SPAN_NO_CONTRACT_CHECKING
+#else
+#define TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION
+#endif
+#endif
+
+#if defined(TCB_SPAN_THROW_ON_CONTRACT_VIOLATION)
+struct contract_violation_error : std::logic_error {
+    explicit contract_violation_error(const char* msg) : std::logic_error(msg)
+    {}
+};
+
+inline void contract_violation(const char* msg)
+{
+    throw contract_violation_error(msg);
+}
+
+#elif defined(TCB_SPAN_TERMINATE_ON_CONTRACT_VIOLATION)
+[[noreturn]] inline void contract_violation(const char* /*unused*/)
+{
+    std::terminate();
+}
+#endif
+
+#if !defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#define TCB_SPAN_STRINGIFY(cond) #cond
+#define TCB_SPAN_EXPECT(cond)                                                  \
+    cond ? (void) 0 : contract_violation("Expected " TCB_SPAN_STRINGIFY(cond))
+#else
+#define TCB_SPAN_EXPECT(cond)
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_inline_variables)
+#define TCB_SPAN_INLINE_VAR inline
+#else
+#define TCB_SPAN_INLINE_VAR
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14) ||                                            \
+    (defined(__cpp_constexpr) && __cpp_constexpr >= 201304)
+#define TCB_SPAN_HAVE_CPP14_CONSTEXPR
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14_CONSTEXPR)
+#define TCB_SPAN_CONSTEXPR14 constexpr
+#else
+#define TCB_SPAN_CONSTEXPR14
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP14_CONSTEXPR) &&                                  \
+    (!defined(_MSC_VER) || _MSC_VER > 1900)
+#define TCB_SPAN_CONSTEXPR_ASSIGN constexpr
+#else
+#define TCB_SPAN_CONSTEXPR_ASSIGN
+#endif
+
+#if defined(TCB_SPAN_NO_CONTRACT_CHECKING)
+#define TCB_SPAN_CONSTEXPR11 constexpr
+#else
+#define TCB_SPAN_CONSTEXPR11 TCB_SPAN_CONSTEXPR14
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_deduction_guides)
+#define TCB_SPAN_HAVE_DEDUCTION_GUIDES
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_byte)
+#define TCB_SPAN_HAVE_STD_BYTE
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_array_constexpr)
+#define TCB_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC
+#endif
+
+#if defined(TCB_SPAN_HAVE_CONSTEXPR_STD_ARRAY_ETC)
+#define TCB_SPAN_ARRAY_CONSTEXPR constexpr
+#else
+#define TCB_SPAN_ARRAY_CONSTEXPR
+#endif
+
+#ifdef TCB_SPAN_HAVE_STD_BYTE
+using byte = std::byte;
+#else
+using byte = unsigned char;
+#endif
+
+#if defined(TCB_SPAN_HAVE_CPP17)
+#define TCB_SPAN_NODISCARD [[nodiscard]]
+#else
+#define TCB_SPAN_NODISCARD
+#endif
+
+TCB_SPAN_INLINE_VAR constexpr std::size_t dynamic_extent = SIZE_MAX;
+
+template <typename ElementType, std::size_t Extent = dynamic_extent>
+class span;
+
+namespace detail {
+
+template <typename E, std::size_t S>
+struct span_storage {
+    constexpr span_storage() noexcept = default;
+
+    constexpr span_storage(E* p_ptr, std::size_t /*unused*/) noexcept
+       : ptr(p_ptr)
+    {}
+
+    E* ptr = nullptr;
+    static constexpr std::size_t size = S;
+};
+
+template <typename E>
+struct span_storage<E, dynamic_extent> {
+    constexpr span_storage() noexcept = default;
+
+    constexpr span_storage(E* p_ptr, std::size_t p_size) noexcept
+        : ptr(p_ptr), size(p_size)
+    {}
+
+    E* ptr = nullptr;
+    std::size_t size = 0;
+};
+
+// Reimplementation of C++17 std::size() and std::data()
+#if defined(TCB_SPAN_HAVE_CPP17) ||                                            \
+    defined(__cpp_lib_nonmember_container_access)
+using std::data;
+using std::size;
+#else
+template <class C>
+constexpr auto size(const C& c) -> decltype(c.size())
+{
+    return c.size();
+}
+
+template <class T, std::size_t N>
+constexpr std::size_t size(const T (&)[N]) noexcept
+{
+    return N;
+}
+
+template <class C>
+constexpr auto data(C& c) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template <class C>
+constexpr auto data(const C& c) -> decltype(c.data())
+{
+    return c.data();
+}
+
+template <class T, std::size_t N>
+constexpr T* data(T (&array)[N]) noexcept
+{
+    return array;
+}
+
+template <class E>
+constexpr const E* data(std::initializer_list<E> il) noexcept
+{
+    return il.begin();
+}
+#endif // TCB_SPAN_HAVE_CPP17
+
+#if defined(TCB_SPAN_HAVE_CPP17) || defined(__cpp_lib_void_t)
+using std::void_t;
+#else
+template <typename...>
+using void_t = void;
+#endif
+
+template <typename T>
+using uncvref_t =
+    typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+
+template <typename>
+struct is_span : std::false_type {};
+
+template <typename T, std::size_t S>
+struct is_span<span<T, S>> : std::true_type {};
+
+template <typename>
+struct is_std_array : std::false_type {};
+
+template <typename T, std::size_t N>
+struct is_std_array<std::array<T, N>> : std::true_type {};
+
+template <typename, typename = void>
+struct has_size_and_data : std::false_type {};
+
+template <typename T>
+struct has_size_and_data<T, void_t<decltype(detail::size(std::declval<T>())),
+                                   decltype(detail::data(std::declval<T>()))>>
+    : std::true_type {};
+
+template <typename C, typename U = uncvref_t<C>>
+struct is_container {
+    static constexpr bool value =
+        !is_span<U>::value && !is_std_array<U>::value &&
+        !std::is_array<U>::value && has_size_and_data<C>::value;
+};
+
+template <typename T>
+using remove_pointer_t = typename std::remove_pointer<T>::type;
+
+template <typename, typename, typename = void>
+struct is_container_element_type_compatible : std::false_type {};
+
+template <typename T, typename E>
+struct is_container_element_type_compatible<
+    T, E,
+    typename std::enable_if<
+        !std::is_same<
+            typename std::remove_cv<decltype(detail::data(std::declval<T>()))>::type,
+            void>::value &&
+        std::is_convertible<
+            remove_pointer_t<decltype(detail::data(std::declval<T>()))> (*)[],
+            E (*)[]>::value
+        >::type>
+    : std::true_type {};
+
+template <typename, typename = size_t>
+struct is_complete : std::false_type {};
+
+template <typename T>
+struct is_complete<T, decltype(sizeof(T))> : std::true_type {};
+
+} // namespace detail
+
+template <typename ElementType, std::size_t Extent>
+class span {
+    static_assert(std::is_object<ElementType>::value,
+                  "A span's ElementType must be an object type (not a "
+                  "reference type or void)");
+    static_assert(detail::is_complete<ElementType>::value,
+                  "A span's ElementType must be a complete type (not a forward "
+                  "declaration)");
+    static_assert(!std::is_abstract<ElementType>::value,
+                  "A span's ElementType cannot be an abstract class type");
+
+    using storage_type = detail::span_storage<ElementType, Extent>;
+
+public:
+    // constants and types
+    using element_type = ElementType;
+    using value_type = typename std::remove_cv<ElementType>::type;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = element_type*;
+    using const_pointer = const element_type*;
+    using reference = element_type&;
+    using const_reference = const element_type&;
+    using iterator = pointer;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+
+    static constexpr size_type extent = Extent;
+
+    // [span.cons], span constructors, copy, assignment, and destructor
+    template <
+        std::size_t E = Extent,
+        typename std::enable_if<(E == dynamic_extent || E <= 0), int>::type = 0>
+    constexpr span() noexcept
+    {}
+
+    TCB_SPAN_CONSTEXPR11 span(pointer ptr, size_type count)
+        : storage_(ptr, count)
+    {
+        TCB_SPAN_EXPECT(extent == dynamic_extent || count == extent);
+    }
+
+    TCB_SPAN_CONSTEXPR11 span(pointer first_elem, pointer last_elem)
+        : storage_(first_elem, last_elem - first_elem)
+    {
+        TCB_SPAN_EXPECT(extent == dynamic_extent ||
+                        last_elem - first_elem ==
+                            static_cast<std::ptrdiff_t>(extent));
+    }
+
+    template <std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          element_type (&)[N], ElementType>::value,
+                  int>::type = 0>
+    constexpr span(element_type (&arr)[N]) noexcept : storage_(arr, N)
+    {}
+
+    template <typename T, std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          std::array<T, N>&, ElementType>::value,
+                  int>::type = 0>
+    TCB_SPAN_ARRAY_CONSTEXPR span(std::array<T, N>& arr) noexcept
+        : storage_(arr.data(), N)
+    {}
+
+    template <typename T, std::size_t N, std::size_t E = Extent,
+              typename std::enable_if<
+                  (E == dynamic_extent || N == E) &&
+                      detail::is_container_element_type_compatible<
+                          const std::array<T, N>&, ElementType>::value,
+                  int>::type = 0>
+    TCB_SPAN_ARRAY_CONSTEXPR span(const std::array<T, N>& arr) noexcept
+        : storage_(arr.data(), N)
+    {}
+
+    template <
+        typename Container, std::size_t E = Extent,
+        typename std::enable_if<
+            E == dynamic_extent && detail::is_container<Container>::value &&
+                detail::is_container_element_type_compatible<
+                    Container&, ElementType>::value,
+            int>::type = 0>
+    constexpr span(Container& cont)
+        : storage_(detail::data(cont), detail::size(cont))
+    {}
+
+    template <
+        typename Container, std::size_t E = Extent,
+        typename std::enable_if<
+            E == dynamic_extent && detail::is_container<Container>::value &&
+                detail::is_container_element_type_compatible<
+                    const Container&, ElementType>::value,
+            int>::type = 0>
+    constexpr span(const Container& cont)
+        : storage_(detail::data(cont), detail::size(cont))
+    {}
+
+    constexpr span(const span& other) noexcept = default;
+
+    template <typename OtherElementType, std::size_t OtherExtent,
+              typename std::enable_if<
+                  (Extent == OtherExtent || Extent == dynamic_extent) &&
+                      std::is_convertible<OtherElementType (*)[],
+                                          ElementType (*)[]>::value,
+                  int>::type = 0>
+    constexpr span(const span<OtherElementType, OtherExtent>& other) noexcept
+        : storage_(other.data(), other.size())
+    {}
+
+    ~span() noexcept = default;
+
+    TCB_SPAN_CONSTEXPR_ASSIGN span&
+    operator=(const span& other) noexcept = default;
+
+    // [span.sub], span subviews
+    template <std::size_t Count>
+    TCB_SPAN_CONSTEXPR11 span<element_type, Count> first() const
+    {
+        TCB_SPAN_EXPECT(Count <= size());
+        return {data(), Count};
+    }
+
+    template <std::size_t Count>
+    TCB_SPAN_CONSTEXPR11 span<element_type, Count> last() const
+    {
+        TCB_SPAN_EXPECT(Count <= size());
+        return {data() + (size() - Count), Count};
+    }
+
+    template <std::size_t Offset, std::size_t Count = dynamic_extent>
+    using subspan_return_t =
+        span<ElementType, Count != dynamic_extent
+                              ? Count
+                              : (Extent != dynamic_extent ? Extent - Offset
+                                                          : dynamic_extent)>;
+
+    template <std::size_t Offset, std::size_t Count = dynamic_extent>
+    TCB_SPAN_CONSTEXPR11 subspan_return_t<Offset, Count> subspan() const
+    {
+        TCB_SPAN_EXPECT(Offset <= size() &&
+                        (Count == dynamic_extent || Offset + Count <= size()));
+        return {data() + Offset,
+                Count != dynamic_extent ? Count : size() - Offset};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    first(size_type count) const
+    {
+        TCB_SPAN_EXPECT(count <= size());
+        return {data(), count};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    last(size_type count) const
+    {
+        TCB_SPAN_EXPECT(count <= size());
+        return {data() + (size() - count), count};
+    }
+
+    TCB_SPAN_CONSTEXPR11 span<element_type, dynamic_extent>
+    subspan(size_type offset, size_type count = dynamic_extent) const
+    {
+        TCB_SPAN_EXPECT(offset <= size() &&
+                        (count == dynamic_extent || offset + count <= size()));
+        return {data() + offset,
+                count == dynamic_extent ? size() - offset : count};
+    }
+
+    // [span.obs], span observers
+    constexpr size_type size() const noexcept { return storage_.size; }
+
+    constexpr size_type size_bytes() const noexcept
+    {
+        return size() * sizeof(element_type);
+    }
+
+    TCB_SPAN_NODISCARD constexpr bool empty() const noexcept
+    {
+        return size() == 0;
+    }
+
+    // [span.elem], span element access
+    TCB_SPAN_CONSTEXPR11 reference operator[](size_type idx) const
+    {
+        TCB_SPAN_EXPECT(idx < size());
+        return *(data() + idx);
+    }
+
+    TCB_SPAN_CONSTEXPR11 reference front() const
+    {
+        TCB_SPAN_EXPECT(!empty());
+        return *data();
+    }
+
+    TCB_SPAN_CONSTEXPR11 reference back() const
+    {
+        TCB_SPAN_EXPECT(!empty());
+        return *(data() + (size() - 1));
+    }
+
+    constexpr pointer data() const noexcept { return storage_.ptr; }
+
+    // [span.iterators], span iterator support
+    constexpr iterator begin() const noexcept { return data(); }
+
+    constexpr iterator end() const noexcept { return data() + size(); }
+
+    TCB_SPAN_ARRAY_CONSTEXPR reverse_iterator rbegin() const noexcept
+    {
+        return reverse_iterator(end());
+    }
+
+    TCB_SPAN_ARRAY_CONSTEXPR reverse_iterator rend() const noexcept
+    {
+        return reverse_iterator(begin());
+    }
+
+private:
+    storage_type storage_{};
+};
+
+#ifdef TCB_SPAN_HAVE_DEDUCTION_GUIDES
+
+/* Deduction Guides */
+template <class T, size_t N>
+span(T (&)[N])->span<T, N>;
+
+template <class T, size_t N>
+span(std::array<T, N>&)->span<T, N>;
+
+template <class T, size_t N>
+span(const std::array<T, N>&)->span<const T, N>;
+
+template <class Container>
+span(Container&)->span<typename std::remove_reference<
+    decltype(*detail::data(std::declval<Container&>()))>::type>;
+
+template <class Container>
+span(const Container&)->span<const typename Container::value_type>;
+
+#endif // TCB_HAVE_DEDUCTION_GUIDES
+
+template <typename ElementType, std::size_t Extent>
+constexpr span<ElementType, Extent>
+make_span(span<ElementType, Extent> s) noexcept
+{
+    return s;
+}
+
+template <typename T, std::size_t N>
+constexpr span<T, N> make_span(T (&arr)[N]) noexcept
+{
+    return {arr};
+}
+
+template <typename T, std::size_t N>
+TCB_SPAN_ARRAY_CONSTEXPR span<T, N> make_span(std::array<T, N>& arr) noexcept
+{
+    return {arr};
+}
+
+template <typename T, std::size_t N>
+TCB_SPAN_ARRAY_CONSTEXPR span<const T, N>
+make_span(const std::array<T, N>& arr) noexcept
+{
+    return {arr};
+}
+
+template <typename Container>
+constexpr span<typename std::remove_reference<
+    decltype(*detail::data(std::declval<Container&>()))>::type>
+make_span(Container& cont)
+{
+    return {cont};
+}
+
+template <typename Container>
+constexpr span<const typename Container::value_type>
+make_span(const Container& cont)
+{
+    return {cont};
+}
+
+template <typename ElementType, std::size_t Extent>
+span<const byte, ((Extent == dynamic_extent) ? dynamic_extent
+                                             : sizeof(ElementType) * Extent)>
+as_bytes(span<ElementType, Extent> s) noexcept
+{
+    return {reinterpret_cast<const byte*>(s.data()), s.size_bytes()};
+}
+
+template <
+    class ElementType, size_t Extent,
+    typename std::enable_if<!std::is_const<ElementType>::value, int>::type = 0>
+span<byte, ((Extent == dynamic_extent) ? dynamic_extent
+                                       : sizeof(ElementType) * Extent)>
+as_writable_bytes(span<ElementType, Extent> s) noexcept
+{
+    return {reinterpret_cast<byte*>(s.data()), s.size_bytes()};
+}
+
+template <std::size_t N, typename E, std::size_t S>
+constexpr auto get(span<E, S> s) -> decltype(s[N])
+{
+    return s[N];
+}
+
+} // namespace TCB_SPAN_NAMESPACE_NAME
+
+namespace std {
+
+template <typename ElementType, size_t Extent>
+class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<ElementType, Extent>>
+    : public integral_constant<size_t, Extent> {};
+
+template <typename ElementType>
+class tuple_size<TCB_SPAN_NAMESPACE_NAME::span<
+    ElementType, TCB_SPAN_NAMESPACE_NAME::dynamic_extent>>; // not defined
+
+template <size_t I, typename ElementType, size_t Extent>
+class tuple_element<I, TCB_SPAN_NAMESPACE_NAME::span<ElementType, Extent>> {
+public:
+    static_assert(Extent != TCB_SPAN_NAMESPACE_NAME::dynamic_extent &&
+                      I < Extent,
+                  "");
+    using type = ElementType;
+};
+
+} // end namespace std
+
+#endif // TCB_SPAN_HPP_INCLUDED


### PR DESCRIPTION
# What does this PR do?

Add utility function to save context (registers + stack) (registers + stack) necessary to perform remote unwinding.
Only works for x86_64 for now, I will do the implementation for ARM later.

Getting a green build was a battle with cppcheck / address sanitizer:
https://gitlab.ddbuild.io/DataDog/ddprof/-/pipelines/7440633

I added a third-party implementation for std::span because gcc 9 does not provide it. We could switch to gcc 11 on 16.04 but this would require compiling our own gcc.

Also added support for google-benchmark.
