### PR TITLE
Fix flaky test

### DIFF
--- a/src/region_holder.cc
+++ b/src/region_holder.cc
@@ -41,7 +41,7 @@ RegionHolder::RegionHolder(const std::string &full_path, size_t sz,
         _sz = sz;
       }
     } else {
-      LG_ERR("Unable to read file : %s", full_path.c_str());
+      LG_WRN("Unable to read file : %s", full_path.c_str());
     }
   } else {
     LG_ERR("Attempt to map unknown file type: %s (%lx/%lx)", full_path.c_str(),


### PR DESCRIPTION
# What does this PR do?

Turn error into a warning, dso in /proc/%pid%/root/... disappear when process exists, therefore RegionHolder might fail to open files.

# Motivation

Fix `native_bench.sh ${RECORD_OPTION} -b ${BINDIR} -e sleep.sh` test in CI that does many short `sleep`.
