### PR TITLE
Avoid duplicating register indices in mask

### DIFF
--- a/include/perf_archmap.h
+++ b/include/perf_archmap.h
@@ -13,17 +13,17 @@
 #  define PERF_REGS_MASK 0xff0fff
 #  define REGNAME(x) PAM_X86_##x
 enum PERF_ARCHMAP_X86 {
-  PAM_X86_EAX,
-  PAM_X86_EBX,
-  PAM_X86_ECX,
-  PAM_X86_EDX,
-  PAM_X86_ESI,
-  PAM_X86_EDI,
-  PAM_X86_EBP,
-  PAM_X86_ESP,
-  PAM_X86_SP = PAM_X86_ESP, // For uniformity
-  PAM_X86_EIP,
-  PAM_X86_PC = PAM_X86_EIP, // For uniformity
+  PAM_X86_RAX,
+  PAM_X86_RBX,
+  PAM_X86_RCX,
+  PAM_X86_RDX,
+  PAM_X86_RSI,
+  PAM_X86_RDI,
+  PAM_X86_RBP,
+  PAM_X86_RSP,
+  PAM_X86_SP = PAM_X86_RSP, // For uniformity
+  PAM_X86_RIP,
+  PAM_X86_PC = PAM_X86_RIP, // For uniformity
   PAM_X86_FL,
   PAM_X86_CS,
   PAM_X86_SS,

--- a/src/dwfl_thread_callbacks.cc
+++ b/src/dwfl_thread_callbacks.cc
@@ -24,13 +24,13 @@ bool set_initial_registers(Dwfl_Thread *thread, void *arg) {
 
 #ifdef __x86_64__
   // Substantial difference here in 32- and 64-bit x86; only support 64-bit now
-  regs[n++] = us->initial_regs.regs[REGNAME(EAX)];
-  regs[n++] = us->initial_regs.regs[REGNAME(EDX)];
-  regs[n++] = us->initial_regs.regs[REGNAME(ECX)];
-  regs[n++] = us->initial_regs.regs[REGNAME(EBX)];
-  regs[n++] = us->initial_regs.regs[REGNAME(ESI)];
-  regs[n++] = us->initial_regs.regs[REGNAME(EDI)];
-  regs[n++] = us->initial_regs.regs[REGNAME(EBP)];
+  regs[n++] = us->initial_regs.regs[REGNAME(RAX)];
+  regs[n++] = us->initial_regs.regs[REGNAME(RDX)];
+  regs[n++] = us->initial_regs.regs[REGNAME(RCX)];
+  regs[n++] = us->initial_regs.regs[REGNAME(RBX)];
+  regs[n++] = us->initial_regs.regs[REGNAME(RSI)];
+  regs[n++] = us->initial_regs.regs[REGNAME(RDI)];
+  regs[n++] = us->initial_regs.regs[REGNAME(RBP)];
   regs[n++] = us->initial_regs.regs[REGNAME(SP)];
   regs[n++] = us->initial_regs.regs[REGNAME(R8)];
   regs[n++] = us->initial_regs.regs[REGNAME(R9)];


### PR DESCRIPTION
Use immediate mode constraint + %c modifier to use enum values in inline asm.
