### PR TITLE
Make cmake fail if execute_process fails

### DIFF
--- a/cmake/Findelfutils.cmake
+++ b/cmake/Findelfutils.cmake
@@ -26,7 +26,7 @@ set(LIBELF_PATH ${ELFUTILS_PATH}/lib/libelf.a)
 set(ELFUTILS_INCLUDE_DIRS ${ELFUTILS_PATH}/include)
 
 execute_process(COMMAND "${CMAKE_SOURCE_DIR}/tools/fetch_elfutils.sh" "${VER_ELF}" "${SHA256_ELF}" "${ELFUTILS_PATH}" "${CMAKE_C_COMPILER}"
-                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY)
 
 add_library(dw STATIC IMPORTED)
 set_target_properties(dw PROPERTIES

--- a/cmake/Findlibddprof.cmake
+++ b/cmake/Findlibddprof.cmake
@@ -24,7 +24,7 @@ list(APPEND
     ${LIBDDPROF_ROOT}/include)
 
 execute_process(COMMAND "${CMAKE_SOURCE_DIR}/tools/fetch_libddprof.sh" ${TAG_LIBDDPROF} ${SHA256_LIBDDPROF} ${LIBDDPROF_ROOT}
-                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} COMMAND_ERROR_IS_FATAL ANY)
 
 # This is duplicated from the cmake configuration provided by libddprof
 # How to fix this : using find_package


### PR DESCRIPTION
# What does this PR do?

Ensure that cmake fails if execute_process fails.

# Motivation

An error in fetch_elfutils/fetch_libddprof is currently silently ignored.