### PR TITLE
Fix profiler activation logic

### DIFF
--- a/include/ddprof_input.h
+++ b/include/ddprof_input.h
@@ -86,7 +86,7 @@ typedef struct DDProfInput {
   XX(DD_PROFILING_AGENTLESS,            agentless,          L, 'L', 1, input, NULL, "",                     )  \
   XX(DD_TAGS,                           tags,               T, 'T', 1, input, NULL, "", )                      \
   XX(DD_PROFILING_ENABLED,              enable,             d, 'd', 1, input, NULL, "yes", )                   \
-  XX(DD_PROFILING_NATIVE_ENABLED,       native_enable,      n, 'n', 1, input, NULL, "yes", )                   \
+  XX(DD_PROFILING_NATIVE_ENABLED,       native_enable,      n, 'n', 1, input, NULL, "", )                      \
   XX(DD_PROFILING_UPLOAD_PERIOD,        upload_period,      u, 'u', 1, input, NULL, "59", )                    \
   XX(DD_PROFILING_NATIVE_WORKER_PERIOD, worker_period,      w, 'w', 1, input, NULL, "240", )                   \
   XX(DD_PROFILING_NATIVE_FAULT_INFO,    fault_info,         s, 's', 1, input, NULL, "yes", )                   \

--- a/src/ddprof_context_lib.c
+++ b/src/ddprof_context_lib.c
@@ -36,7 +36,6 @@ DDRes ddprof_context_set(DDProfInput *input, DDProfContext *ctx) {
   DDRES_CHECK_FWD(exporter_input_copy(&input->exp_input, &ctx->exp_input));
 
   // Set defaults
-  ctx->params.enable = true;
   ctx->params.upload_period = 60.0;
 
   // Process enable.  Note that we want the effect to hit an inner profile.
@@ -48,7 +47,9 @@ DDRes ddprof_context_set(DDProfInput *input, DDProfContext *ctx) {
     setenv("DD_PROFILING_ENABLED", "false", true);
 
   // Process native profiler enablement override
-  ctx->params.enable = !arg_yesno(input->native_enable, 0);
+  if (input->native_enable) {
+    ctx->params.enable = arg_yesno(input->native_enable, 1);
+  }
 
   // Process enablement for agent mode
   ctx->exp_input.agentless = arg_yesno(input->agentless, 1); // default no


### PR DESCRIPTION
# What does this PR do?

If generic profiling is disabled (`-d no`) and native profiling is not explicitly set, native profiler should probably be disabled.
