### PR TITLE
Ignore sample if ABI is set to PERF_SAMPLE_REGS_ABI_NONE

### DIFF
--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -451,7 +451,9 @@ DDRes ddprof_worker_process_event(struct perf_event_header *hdr, int pos,
     case PERF_RECORD_SAMPLE:
       if (wpid->pid) {
         perf_event_sample *sample = hdr2samp(hdr, DEFAULT_SAMPLE_TYPE);
-        DDRES_CHECK_FWD(ddprof_pr_sample(ctx, sample, pos));
+        if (sample) {
+          DDRES_CHECK_FWD(ddprof_pr_sample(ctx, sample, pos));
+        }
       }
       break;
     case PERF_RECORD_MMAP:

--- a/src/perf_mainloop.cc
+++ b/src/perf_mainloop.cc
@@ -87,7 +87,7 @@ DDRes spawn_workers(MLWorkerFlags *flags, bool *is_worker) {
   while (!g_termination_requested && (child_pid = fork())) {
     g_child_pid = child_pid;
     {
-      LG_WRN("Created child %d", child_pid);
+      LG_NTC("Created child %d", child_pid);
       // unblock signals, we can now forward signals to child
       modify_sigprocmask(SIG_UNBLOCK);
       waitpid(g_child_pid, NULL, 0);

--- a/src/perf_ringbuffer.c
+++ b/src/perf_ringbuffer.c
@@ -241,6 +241,10 @@ perf_event_sample *hdr2samp(struct perf_event_header *hdr, uint64_t mask) {
   if (PERF_SAMPLE_BRANCH_STACK & mask) {}
   if (PERF_SAMPLE_REGS_USER & mask) {
     sample.abi = *buf++;
+    // In case regs are not available, ignore this sample
+    if (sample.abi == PERF_SAMPLE_REGS_ABI_NONE) {
+      return NULL;
+    }
     sample.regs = buf;
     buf += PERF_REGS_COUNT;
   }


### PR DESCRIPTION
# What does this PR do?

When investigating issues with tracepoints, we noticed that some samples did not have valid registers.
This change adds a check on the sample's ABI.

# Motivation

Errors noticed in tracepoint mode.

# Additional Notes

N/A

# How to test the change?

The usual test suite will cover this change as it goes through the standard sample function.
I do not expect any impact.
