### PR TITLE
Perform a test for PID namespace compatibility

### DIFF
--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -117,7 +117,7 @@ DsoHdr::DsoHdr() {
   // A given procfs can only work if its PID namespace is the same as mine.
   // Fortunately, `/proc/self` will return a symlink to my process ID in the
   // corresponding namespace, so this is easy to check
-  char pid_str[sizeof("42949672960")] = {};
+  char pid_str[sizeof("1073741824")] = {}; // Linux max pid/tid is 2^30
   if (-1 != readlink("/host/proc/self", pid_str, sizeof(pid_str)) &&
       getpid() == strtol(pid_str, NULL, 10)) {
     // @Datadog we often mount to /host the /proc files

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -6,12 +6,12 @@
 #include "dso_hdr.hpp"
 
 extern "C" {
-#include <fcntl.h>
-#include <unistd.h>
 #include "ddprof_defs.h"
 #include "logger.h"
 #include "procutils.h"
 #include "signal_helper.h"
+#include <fcntl.h>
+#include <unistd.h>
 }
 #include "ddres.h"
 #include "defer.hpp"
@@ -118,11 +118,11 @@ DsoHdr::DsoHdr() {
   // Fortunately, `/proc/self` will return a symlink to my process ID in the
   // corresponding namespace, so this is easy to check
   char pid_str[sizeof("42949672960")] = {};
-   if (-1 != readlink("/host/proc/self", pid_str, sizeof(pid_str)) &&
-       getpid() == strtol(pid_str, NULL, 10)) {
-     // @Datadog we often mount to /host the /proc files
-     _path_to_proc = "/host";
-   }
+  if (-1 != readlink("/host/proc/self", pid_str, sizeof(pid_str)) &&
+      getpid() == strtol(pid_str, NULL, 10)) {
+    // @Datadog we often mount to /host the /proc files
+    _path_to_proc = "/host";
+  }
   // 0 element is error element
   _file_info_vector.emplace_back(FileInfo(), 0, true);
 }


### PR DESCRIPTION
# What does this PR do?

If a `/host/proc` mountpoint is provided and acts like procfs in the sense that`readlink()` is implemented at the `/host/proc/self` VFS node in a way that returns a _relative_ `/host/proc/<PID>` link, for which `PID` (as an integer) is equal to the current process `getpid()`, then prefer to use `/host/proc`.

If any of this is untrue, then proceed as though `/proc` was available, even if it is not.
# Motivation

Previously, when `/host/proc` was available and determined to be a directory, the profiler would replace many calls to `/proc` with calls to `/host/proc` instead.  This appears to be broken when the profiler is not operating within the root PID namespace, since the PID returned by `perf_event_open()` events will be bound to the PID namespace of the instrumenting process (the profiler), and thus `/host/proc/<PID>` will be invalid (or, at worst, a _different_ process).

Confusingly, `/host/proc` works in many situations.  It appears to work when `/host/proc` is provided _and_ the calling process is in the root PID namespace (actually, this is common in the scenarios where full-host profiling is desired and deployed).  Since `/host/proc` is mounted _from_ that PID namespace, `/proc` and `/host/proc` agree.  This actually makes `/host/proc` irrelevant.

# Additional Notes

None :)

# How to test the change?

The system-probe dockerfile for the agent can repro this.  Will send privately.