### PR TITLE
Invert pid/tid_send to suppression

### DIFF
--- a/include/perf_watcher.h
+++ b/include/perf_watcher.h
@@ -37,8 +37,8 @@ typedef struct PerfWatcher {
   const char *tracepoint_name;
   const char *tracepoint_group;
   // Other configs
-  bool send_pid;
-  bool send_tid;
+  bool suppress_pid;
+  bool suppress_tid;
   int pprof_sample_idx;       // index into the SampleType in the pprof
   int pprof_count_sample_idx; // index into the pprof for the count
 } PerfWatcher;

--- a/src/pprof/ddprof_pprof.cc
+++ b/src/pprof/ddprof_pprof.cc
@@ -202,22 +202,18 @@ DDRes pprof_aggregate(const UnwindOutput *uw_output,
   ddprof_ffi_Label labels[PPROF_MAX_LABELS] = {};
   size_t labels_num = 0;
 
-  // The max PID on Linux is approximately 2^22 (~4e6), which also limits TID
-  // cppcheck-suppress variableScope
-  char pid_str[7] = {};
-  // cppcheck-suppress variableScope
-  char tid_str[7] = {};
-
   // Add any configured labels.  Note that TID alone has the same cardinality as
   // (TID;PID) tuples, so except for symbol table overhead it doesn't matter
   // much if TID implies PID for clarity.
-  if (watcher->send_pid || watcher->send_tid) {
+  if (!watcher->suppress_pid || !watcher->suppress_tid) {
+    char pid_str[sizeof("536870912")] = {}; // reserve space up to 2^29 base-10
     snprintf(pid_str, sizeof(pid_str), "%d", uw_output->pid);
     labels[labels_num].key = to_CharSlice("process id");
     labels[labels_num].str = to_CharSlice(pid_str);
     ++labels_num;
   }
-  if (watcher->send_tid) {
+  if (!watcher->suppress_tid ) {
+    char tid_str[sizeof("536870912")] = {}; // reserve space up to 2^29 base-10
     snprintf(tid_str, sizeof(tid_str), "%d", uw_output->tid);
     labels[labels_num].key = to_CharSlice("thread id");
     labels[labels_num].str = to_CharSlice(tid_str);


### PR DESCRIPTION
This globally enabled sending PID and TID to the backend.  This can be
changed later once we determine whether this needs to be a
user-configurable setting.
