### PR TITLE
Fix static initialization order in allocation profiler

### DIFF
--- a/src/lib/dd_profiling.cc
+++ b/src/lib/dd_profiling.cc
@@ -62,7 +62,7 @@ void set_profiler_library_inactive() {
 
 void allocation_profiling_stop() {
   if (g_state.allocation_profiling_started) {
-    ddprof::allocation_tracking_free();
+    ddprof::AllocationTracker::allocation_tracking_free();
     g_state.allocation_profiling_started = false;
   }
 }
@@ -217,8 +217,8 @@ static int ddprof_start_profiling_internal() {
     auto info = client.get_profiler_info();
     g_state.profiler_pid = info.pid;
     if (info.allocation_profiling_rate > 0) {
-      ddprof::allocation_tracking_init(info.allocation_profiling_rate, false,
-                                       info.ring_buffer);
+      ddprof::AllocationTracker::allocation_tracking_init(
+          info.allocation_profiling_rate, false, info.ring_buffer);
       g_state.allocation_profiling_started = true;
     }
   } catch (const ddprof::DDException &e) { return -1; }
@@ -229,7 +229,6 @@ static int ddprof_start_profiling_internal() {
   }
   g_state.started = true;
   set_profiler_library_active();
-
   return 0;
 }
 

--- a/src/lib/malloc_wrapper.cc
+++ b/src/lib/malloc_wrapper.cc
@@ -83,7 +83,8 @@ void init() {
 
 void *malloc(size_t size) {
   void *ptr = s_malloc(size);
-  ddprof::track_allocation(reinterpret_cast<uintptr_t>(ptr), size);
+  ddprof::AllocationTracker::track_allocation(reinterpret_cast<uintptr_t>(ptr),
+                                              size);
   return ptr;
 }
 
@@ -97,7 +98,8 @@ void free(void *ptr) {
     return;
   }
 
-  ddprof::track_deallocation(reinterpret_cast<uintptr_t>(ptr));
+  ddprof::AllocationTracker::track_deallocation(
+      reinterpret_cast<uintptr_t>(ptr));
   s_free(ptr);
 }
 
@@ -108,7 +110,8 @@ void temp_free(void *ptr) noexcept {
 
 void *calloc(size_t nmemb, size_t size) {
   void *ptr = s_calloc(nmemb, size);
-  ddprof::track_allocation(reinterpret_cast<uintptr_t>(ptr), size * nmemb);
+  ddprof::AllocationTracker::track_allocation(reinterpret_cast<uintptr_t>(ptr),
+                                              size * nmemb);
   return ptr;
 }
 
@@ -119,10 +122,12 @@ void *temp_calloc(size_t nmemb, size_t size) noexcept {
 
 void *realloc(void *ptr, size_t size) {
   if (ptr) {
-    ddprof::track_deallocation(reinterpret_cast<uintptr_t>(ptr));
+    ddprof::AllocationTracker::track_deallocation(
+        reinterpret_cast<uintptr_t>(ptr));
   }
   void *newptr = s_realloc(ptr, size);
-  ddprof::track_allocation(reinterpret_cast<uintptr_t>(ptr), size);
+  ddprof::AllocationTracker::track_allocation(reinterpret_cast<uintptr_t>(ptr),
+                                              size);
   return newptr;
 }
 
@@ -134,7 +139,8 @@ void *temp_realloc(void *ptr, size_t size) noexcept {
 int posix_memalign(void **memptr, size_t alignment, size_t size) {
   int ret = s_posix_memalign(memptr, alignment, size);
   if (likely(!ret)) {
-    ddprof::track_allocation(reinterpret_cast<uintptr_t>(*memptr), size);
+    ddprof::AllocationTracker::track_allocation(
+        reinterpret_cast<uintptr_t>(*memptr), size);
   }
   return ret;
 }
@@ -146,7 +152,7 @@ int temp_posix_memalign(void **memptr, size_t alignment, size_t size) noexcept {
 
 void *aligned_alloc(size_t alignment, size_t size) {
   void *ptr = s_aligned_alloc(alignment, size);
-  ddprof::track_allocation(reinterpret_cast<uintptr_t>(ptr), size);
+  ddprof::AllocationTracker::track_allocation(reinterpret_cast<uintptr_t>(ptr), size);
   return ptr;
 }
 
@@ -157,7 +163,8 @@ void *temp_aligned_alloc(size_t alignment, size_t size) noexcept {
 
 void *memalign(size_t alignment, size_t size) {
   void *ptr = s_memalign(alignment, size);
-  ddprof::track_allocation(reinterpret_cast<uintptr_t>(ptr), size);
+  ddprof::AllocationTracker::track_allocation(reinterpret_cast<uintptr_t>(ptr),
+                                              size);
   return ptr;
 }
 void *temp_memalign(size_t alignment, size_t size) noexcept {
@@ -167,7 +174,8 @@ void *temp_memalign(size_t alignment, size_t size) noexcept {
 
 void *pvalloc(size_t size) {
   void *ptr = s_pvalloc(size);
-  ddprof::track_allocation(reinterpret_cast<uintptr_t>(ptr), size);
+  ddprof::AllocationTracker::track_allocation(reinterpret_cast<uintptr_t>(ptr),
+                                              size);
   return ptr;
 }
 
@@ -178,7 +186,8 @@ void *temp_pvalloc(size_t size) noexcept {
 
 void *valloc(size_t size) {
   void *ptr = s_valloc(size);
-  ddprof::track_allocation(reinterpret_cast<uintptr_t>(ptr), size);
+  ddprof::AllocationTracker::track_allocation(reinterpret_cast<uintptr_t>(ptr),
+                                              size);
   return ptr;
 }
 
@@ -189,10 +198,12 @@ void *temp_valloc(size_t size) noexcept {
 
 void *reallocarray(void *ptr, size_t nmemb, size_t size) noexcept {
   if (ptr) {
-    ddprof::track_deallocation(reinterpret_cast<uintptr_t>(ptr));
+    ddprof::AllocationTracker::track_deallocation(
+        reinterpret_cast<uintptr_t>(ptr));
   }
   void *newptr = s_reallocarray(ptr, nmemb, size);
-  ddprof::track_allocation(reinterpret_cast<uintptr_t>(ptr), size * nmemb);
+  ddprof::AllocationTracker::track_allocation(reinterpret_cast<uintptr_t>(ptr),
+                                              size * nmemb);
   return newptr;
 }
 

--- a/test/allocation_tracker-ut.cc
+++ b/test/allocation_tracker-ut.cc
@@ -17,7 +17,7 @@
 #include <unistd.h>
 
 __attribute__((noinline)) void my_malloc(size_t size) {
-  ddprof::track_allocation(0xdeadbeef, size);
+  ddprof::AllocationTracker::track_allocation(0xdeadbeef, size);
   // prevent tail call optimization
   getpid();
 }
@@ -58,10 +58,8 @@ TEST(allocation_tracker, start_stop) {
   const uint64_t rate = 1;
   const size_t buf_size_order = 5;
   RingBufferHolder ring_buffer{buf_size_order};
-  ddprof::allocation_tracking_init(
-      rate,
-      static_cast<uint32_t>(
-          ddprof::AllocationTrackingFlags::kDeterministicSampling),
+  ddprof::AllocationTracker::allocation_tracking_init(
+      rate, ddprof::AllocationTracker::kDeterministicSampling,
       ring_buffer.get_buffer_info());
 
   my_func_calling_malloc(1);
@@ -91,6 +89,6 @@ TEST(allocation_tracker, start_stop) {
       symbol_table[state.output.locs[NB_FRAMES_TO_SKIP]._symbol_idx];
   ASSERT_EQ(symbol._symname, "my_func_calling_malloc");
 
-  ddprof::allocation_tracking_free();
+  ddprof::AllocationTracker::allocation_tracking_free();
 #endif
 }


### PR DESCRIPTION
# What does this PR do?

Compiler was generating a constructor for TrackerStaticState that is called before main and could be called after constructor of g_autostart that is starting allocation profiling.
This commit moves TrackerStaticState inside AllocationTracker as a non-static member. This adds an indirection to access this state, but overhead should be very low.
Also moves all free functions inside AllocationTracker, and exposes only the required functions.
Avoid writing events twice to ring buffer.

