### PR TITLE
Allow overriding exe used by libdd_profiling

### DIFF
--- a/src/lib/dd_profiling.cc
+++ b/src/lib/dd_profiling.cc
@@ -33,6 +33,8 @@ static constexpr const char *k_profiler_active_env_variable =
     "DD_PROFILING_NATIVE_LIBRARY_ACTIVE";
 static constexpr const char *k_profiler_auto_start_env_variable =
     "DD_PROFILING_NATIVE_AUTOSTART";
+static constexpr const char *k_profiler_ddprof_exe_env_variable =
+    "DD_PROFILING_NATIVE_DDPROF_EXE";
 
 // address of embedded ddprof executable
 extern const char _binary_ddprof_start[]; // NOLINT cert-dcl51-cpp
@@ -122,6 +124,7 @@ static int exec_ddprof(pid_t target_pid, pid_t parent_pid, int sock_fd) {
   char pid_opt_str[] = "-p";
   char sock_opt_str[] = "-Z";
 
+  // cppcheck-suppress variableScope
   char *argv[] = {ddprof_str,   pid_opt_str, pid_buf,
                   sock_opt_str, sock_buf,    NULL};
 
@@ -131,11 +134,13 @@ static int exec_ddprof(pid_t target_pid, pid_t parent_pid, int sock_fd) {
 
   kill(parent_pid, SIGTERM);
 
-  if (fexecve(fd, argv, environ) == -1) {
-    return -1;
+  if (const char *ddprof_exe = getenv(k_profiler_ddprof_exe_env_variable);
+      ddprof_exe) {
+    execve(ddprof_exe, argv, environ);
+  } else {
+    fexecve(fd, argv, environ);
   }
 
-  // unreachable
   return -1;
 }
 


### PR DESCRIPTION
If set, path stored in DD_PROFILING_NATIVE_DDPROF_EXE env variable is used instead of embedded binary.
