### PR TITLE
Fix ring buffer bug and malloc wrapper init deadlock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,8 +172,8 @@ add_custom_command(OUTPUT ${DDPROF_EXE_OBJECT}
 )
 
 set(DD_PROFILING_SOURCES src/lib/dd_profiling.cc src/ddprof_cmdline.c src/logger.c src/logger_setup.cc src/ipc.cc 
-                         src/pevent_lib.cc src/perf.cc src/perf_ringbuffer.c src/perf_watcher.cc src/user_override.c
-                         src/ddres_list.c src/savecontext.cc src/lib/malloc_wrapper.cc src/lib/allocation_tracker.cc
+                         src/pevent_lib.cc src/perf.cc src/perf_ringbuffer.c src/perf_watcher.cc src/ringbuffer_utils.cc
+                         src/user_override.c src/ddres_list.c src/savecontext.cc src/lib/malloc_wrapper.cc src/lib/allocation_tracker.cc
                          $<TARGET_OBJECTS:ddprof_exe_object>)
 add_library(ddprof_exe_object OBJECT IMPORTED GLOBAL)
 set_target_properties(ddprof_exe_object PROPERTIES IMPORTED_OBJECTS "${DDPROF_EXE_OBJECT}")

--- a/include/ddprof_buffer.hpp
+++ b/include/ddprof_buffer.hpp
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include "span.hpp"
+
+namespace ddprof {
+using Buffer = ddprof::span<std::byte>;
+using ConstBuffer = ddprof::span<const std::byte>;
+} // namespace ddprof

--- a/include/ipc.hpp
+++ b/include/ipc.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "ddprof_buffer.hpp"
 #include "ddres.h"
 #include "span.hpp"
 
@@ -22,9 +23,6 @@ static constexpr size_t kMaxFD = 253;
 static constexpr auto kDefaultSocketTimeout = std::chrono::seconds{2};
 
 using socket_t = int;
-
-using Buffer = ddprof::span<std::byte>;
-using ConstBuffer = ddprof::span<const std::byte>;
 
 class UnixSocket {
 public:

--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -81,7 +81,7 @@ private:
   TrackerState _state;
   uint64_t _sampling_interval;
   std::mt19937 _gen;
-  PEventHdr _pevent_hdr;
+  PEvent _pevent;
   bool _deterministic_sampling;
 
   static thread_local TrackerThreadLocalState _tl_state;

--- a/include/perf.h
+++ b/include/perf.h
@@ -117,7 +117,6 @@ int perf_event_open(struct perf_event_attr *, pid_t, int, int, unsigned long);
 int perfopen(pid_t pid, const PerfWatcher *opt, int cpu, bool extras);
 size_t perf_mmap_size(int buf_size_shift);
 void *perfown_sz(int fd, size_t size_of_buffer, bool mirror);
-void *perfown(int fd, bool mirror, size_t *size);
 int perfdisown(void *region, size_t size, bool is_mirrored);
 long get_page_size(void);
 size_t get_mask_from_size(size_t size);

--- a/include/pevent.h
+++ b/include/pevent.h
@@ -19,7 +19,8 @@ typedef struct PEvent {
   int pos; // Index into the sample
   int fd; // Underlying perf event FD for perf_events, otherwise an eventfd that
           // signals data is available in ring buffer
-  int mapfd;         // FD for ring buffer, same as `fd` for perf events
+  int mapfd;               // FD for ring buffer, same as `fd` for perf events
+  size_t ring_buffer_size; // size of the ring buffer
   bool custom_event; // true if custom event (not handled by perf, eg. memory
                      // allocations)
   RingBuffer rb;     // metadata and buffers for processing perf ringbuffer

--- a/include/pevent.h
+++ b/include/pevent.h
@@ -7,6 +7,10 @@
 
 #include <sys/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "perf_ringbuffer.h"
 
 #define MAX_NB_WATCHERS 450
@@ -26,3 +30,7 @@ typedef struct PEventHdr {
   size_t size;
   size_t max_size;
 } PEventHdr;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/pevent_lib.h
+++ b/include/pevent_lib.h
@@ -20,9 +20,6 @@ void pevent_init(PEventHdr *pevent_hdr);
 DDRes pevent_open(DDProfContext *ctx, pid_t pid, int num_cpu,
                   PEventHdr *pevent_hdr);
 
-DDRes pevent_create_custom_ring_buffer(PEvent *pevent,
-                                       size_t ring_buffer_size_order);
-
 /// Setup mmap buffers according to content of peventhdr
 DDRes pevent_mmap(PEventHdr *pevent_hdr, bool use_override);
 
@@ -41,6 +38,12 @@ DDRes pevent_close(PEventHdr *pevent_hdr);
 
 /// cleanup watchers = cleanup perfevent + cleanup mmap (clean everything)
 DDRes pevent_cleanup(PEventHdr *pevent_hdr);
+
+DDRes pevent_mmap_event(PEvent *pevent);
+
+DDRes pevent_munmap_event(PEvent *pevent);
+
+DDRes pevent_close_event(PEvent *pevent);
 
 #ifdef __cplusplus
 }

--- a/include/ringbuffer_holder.hpp
+++ b/include/ringbuffer_holder.hpp
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#pragma once
+
+#include "ddres_exception.hpp"
+#include "ipc.hpp"
+#include "pevent.h"
+#include "ringbuffer_utils.hpp"
+
+namespace ddprof {
+class RingBufferHolder {
+public:
+  explicit RingBufferHolder(size_t buffer_size_order) : _pevent{} {
+    DDRES_CHECK_THROW_EXCEPTION(
+        ddprof::ring_buffer_setup(buffer_size_order, &_pevent));
+  }
+
+  ~RingBufferHolder() { ring_buffer_cleanup(_pevent); }
+
+  RingBufferInfo get_buffer_info() const {
+    return {static_cast<int64_t>(_pevent.rb.size), _pevent.mapfd, _pevent.fd};
+  }
+
+  RingBuffer &get_ring_buffer() { return _pevent.rb; }
+
+private:
+  PEvent _pevent;
+};
+} // namespace ddprof

--- a/include/ringbuffer_utils.hpp
+++ b/include/ringbuffer_utils.hpp
@@ -5,13 +5,19 @@
 
 #pragma once
 
+#include "ddprof_buffer.hpp"
 extern "C" {
 #include "perf_ringbuffer.h"
 }
 
 #include <cassert>
+#include <cstring>
+
+struct PEvent;
 
 namespace ddprof {
+
+struct RingBufferInfo;
 
 class RingBufferWriter {
 public:
@@ -84,7 +90,7 @@ public:
     __atomic_store_n(&_rb.region->data_tail, _tail, __ATOMIC_RELEASE);
   }
 
-  inline size_t available_size() const { return _head - _tail; }
+  inline size_t available_for_read() const { return _head - _tail; }
 
   ConstBuffer read_all_available() {
     uint64_t tail_linear = _tail & _rb.mask;

--- a/include/ringbuffer_utils.hpp
+++ b/include/ringbuffer_utils.hpp
@@ -37,11 +37,13 @@ public:
   RingBufferWriter &operator=(const RingBufferWriter &) = delete;
 
   inline size_t available_size() const {
-    return _rb.data_size - (_head - _tail);
+    // Always leave one free char, as a completely full buffer is
+    // indistinguishable from an empty one
+    return _rb.data_size - (_head + 1 - _tail);
   }
 
   Buffer reserve(size_t n) {
-    assert(n < available_size());
+    assert(n <= available_size());
 
     uint64_t head_linear = _head & _rb.mask;
     std::byte *dest = (std::byte *)(_rb.start + head_linear);

--- a/include/ringbuffer_utils.hpp
+++ b/include/ringbuffer_utils.hpp
@@ -101,10 +101,37 @@ public:
     return {start, n};
   }
 
+  void check_for_new_data() {
+    _head = __atomic_load_n(&_rb.region->data_head, __ATOMIC_ACQUIRE);
+  }
+
 private:
   RingBuffer &_rb;
   uint64_t _tail;
   uint64_t _head;
 };
+
+// Initialize event from ring buffer info and mmap ring buffer into process
+DDRes ring_buffer_attach(const RingBufferInfo &info, PEvent *event);
+
+// Mmap ring buffer into process from already initialized event
+DDRes ring_buffer_attach(PEvent &event);
+
+// Unmap ring buffer
+DDRes ring_buffer_detach(PEvent &event);
+
+// Create ring buffer (create memfd and eventfd)
+// Ring buffer is not mapped upon return from this function, ring_buffer_attach
+// needs to be called to map it
+DDRes ring_buffer_create(size_t buffer_size_page_order, PEvent *event);
+
+// Destroy ring buffer: close memfd / eventfd
+DDRes ring_buffer_close(PEvent &event);
+
+// Create and attach ring buffer
+DDRes ring_buffer_setup(size_t buffer_size_page_order, PEvent *event);
+
+// Unmap and close ring buffer
+DDRes ring_buffer_cleanup(PEvent &event);
 
 } // namespace ddprof

--- a/src/ddprof.c
+++ b/src/ddprof.c
@@ -58,6 +58,8 @@ DDRes ddprof_setup(DDProfContext *ctx) {
     LG_ERR("Error when printing capabilities, continuing...");
   }
 
+  // Do not mmap events yet because mmap'ings from perf fds are lost after
+  // fork
   DDRES_CHECK_FWD(
       pevent_open(ctx, ctx->params.pid, ctx->params.num_cpu, pevent_hdr));
 

--- a/src/lib/allocation_tracker.cc
+++ b/src/lib/allocation_tracker.cc
@@ -105,21 +105,19 @@ DDRes AllocationTracker::init(uint64_t mem_profile_interval,
                               const RingBufferInfo &ring_buffer) {
   _sampling_interval = mem_profile_interval;
   _deterministic_sampling = deterministic_sampling;
-  pevent_init(&_pevent_hdr);
-  _pevent_hdr.size = 1;
-  PEvent &pe = _pevent_hdr.pes[0];
-  pe.fd = ring_buffer.event_fd;
-  pe.mapfd = ring_buffer.ring_fd;
-  pe.pos = -1;
-  pe.custom_event = true;
-  return pevent_mmap(&_pevent_hdr, true);
+  _pevent = {.pos = -1,
+             .fd = ring_buffer.event_fd,
+             .mapfd = ring_buffer.ring_fd,
+             .ring_buffer_size = static_cast<size_t>(ring_buffer.mem_size),
+             .custom_event = true};
+  return pevent_mmap_event(&_pevent);
 }
 
 void AllocationTracker::free() {
   _state.track_allocations = false;
   _state.track_deallocations = false;
 
-  pevent_munmap(&_pevent_hdr);
+  pevent_munmap_event(&_pevent);
 
   // Do not destroy the object:
   // there is an inherent race condition between checking
@@ -192,7 +190,7 @@ void AllocationTracker::track_allocation(uintptr_t, size_t size,
 
 DDRes AllocationTracker::push_sample(uint64_t allocated_size,
                                      TrackerThreadLocalState &tl_state) {
-  RingBufferWriter writer{_pevent_hdr.pes[0].rb};
+  RingBufferWriter writer{_pevent.rb};
   auto needed_size = sizeof(AllocationEvent);
 
   if (_state.lost_count) {
@@ -244,7 +242,7 @@ DDRes AllocationTracker::push_sample(uint64_t allocated_size,
 
   if (writer.commit()) {
     uint64_t count = 1;
-    if (write(_pevent_hdr.pes[0].fd, &count, sizeof(count)) != sizeof(count)) {
+    if (write(_pevent.fd, &count, sizeof(count)) != sizeof(count)) {
       DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFRB,
                              "Error writing to memory allocation eventfd (%s)",
                              strerror(errno));

--- a/src/lib/allocation_tracker.cc
+++ b/src/lib/allocation_tracker.cc
@@ -20,6 +20,7 @@ extern "C" {
 #include <atomic>
 #include <cassert>
 #include <cstdint>
+#include <cstdlib>
 #include <linux/perf_event.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -89,6 +90,11 @@ DDRes AllocationTracker::allocation_tracking_init(
   if (state.track_allocations) {
     DDRES_RETURN_ERROR_LOG(DD_WHAT_UKNW, "Allocation profiler already started");
   }
+
+  // force initialization of malloc wrappers if not done yet
+  // volatile prevents compiler from optimizing out calls to malloc/free
+  void *volatile p = ::malloc(1);
+  ::free(p);
 
   DDRES_CHECK_FWD(instance->init(allocation_profiling_rate,
                                  flags & kDeterministicSampling, ring_buffer));

--- a/src/lib/malloc_wrapper.cc
+++ b/src/lib/malloc_wrapper.cc
@@ -90,7 +90,7 @@ void *malloc(size_t size) {
 
 void *temp_malloc(size_t size) noexcept {
   check_init();
-  return malloc(size);
+  return s_malloc(size);
 }
 
 void free(void *ptr) {
@@ -105,7 +105,7 @@ void free(void *ptr) {
 
 void temp_free(void *ptr) noexcept {
   check_init();
-  return free(ptr);
+  return s_free(ptr);
 }
 
 void *calloc(size_t nmemb, size_t size) {
@@ -117,7 +117,7 @@ void *calloc(size_t nmemb, size_t size) {
 
 void *temp_calloc(size_t nmemb, size_t size) noexcept {
   check_init();
-  return calloc(nmemb, size);
+  return s_calloc(nmemb, size);
 }
 
 void *realloc(void *ptr, size_t size) {
@@ -133,7 +133,7 @@ void *realloc(void *ptr, size_t size) {
 
 void *temp_realloc(void *ptr, size_t size) noexcept {
   check_init();
-  return realloc(ptr, size);
+  return s_realloc(ptr, size);
 }
 
 int posix_memalign(void **memptr, size_t alignment, size_t size) {
@@ -147,7 +147,7 @@ int posix_memalign(void **memptr, size_t alignment, size_t size) {
 
 int temp_posix_memalign(void **memptr, size_t alignment, size_t size) noexcept {
   check_init();
-  return posix_memalign(memptr, alignment, size);
+  return s_posix_memalign(memptr, alignment, size);
 }
 
 void *aligned_alloc(size_t alignment, size_t size) {
@@ -158,7 +158,7 @@ void *aligned_alloc(size_t alignment, size_t size) {
 
 void *temp_aligned_alloc(size_t alignment, size_t size) noexcept {
   check_init();
-  return aligned_alloc(alignment, size);
+  return s_aligned_alloc(alignment, size);
 }
 
 void *memalign(size_t alignment, size_t size) {
@@ -169,7 +169,7 @@ void *memalign(size_t alignment, size_t size) {
 }
 void *temp_memalign(size_t alignment, size_t size) noexcept {
   check_init();
-  return memalign(alignment, size);
+  return s_memalign(alignment, size);
 }
 
 void *pvalloc(size_t size) {
@@ -181,7 +181,7 @@ void *pvalloc(size_t size) {
 
 void *temp_pvalloc(size_t size) noexcept {
   check_init();
-  return pvalloc(size);
+  return s_pvalloc(size);
 }
 
 void *valloc(size_t size) {
@@ -193,7 +193,7 @@ void *valloc(size_t size) {
 
 void *temp_valloc(size_t size) noexcept {
   check_init();
-  return valloc(size);
+  return s_valloc(size);
 }
 
 void *reallocarray(void *ptr, size_t nmemb, size_t size) noexcept {
@@ -209,5 +209,5 @@ void *reallocarray(void *ptr, size_t nmemb, size_t size) noexcept {
 
 void *temp_reallocarray(void *ptr, size_t nmemb, size_t size) noexcept {
   check_init();
-  return reallocarray(ptr, nmemb, size);
+  return s_reallocarray(ptr, nmemb, size);
 }

--- a/src/perf.cc
+++ b/src/perf.cc
@@ -141,13 +141,6 @@ void *perfown_sz(int fd, size_t size_of_buffer, bool mirror) {
   return region;
 }
 
-// returns region, size is updated with the mmaped size
-// On failure, returns NULL
-void *perfown(int fd, bool mirror, size_t *size) {
-  *size = perf_mmap_size(DEFAULT_BUFF_SIZE_SHIFT);
-  return perfown_sz(fd, *size, mirror);
-}
-
 int perfdisown(void *region, size_t size, bool is_mirrored) {
   std::byte *ptr = static_cast<std::byte *>(region);
 

--- a/src/pevent_lib.cc
+++ b/src/pevent_lib.cc
@@ -12,13 +12,13 @@ extern "C" {
 }
 
 #include "defer.hpp"
+#include "ringbuffer_utils.hpp"
 #include "syscalls.hpp"
 
 #include <assert.h>
 #include <errno.h>
 #include <stddef.h>
 #include <string.h>
-#include <sys/eventfd.h>
 #include <sys/ioctl.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -38,32 +38,10 @@ static DDRes pevent_create(PEventHdr *pevent_hdr, int watcher_idx,
 void pevent_init(PEventHdr *pevent_hdr) {
   memset(pevent_hdr, 0, sizeof(PEventHdr));
   pevent_hdr->max_size = MAX_NB_WATCHERS;
-  for (size_t k = 0; k < pevent_hdr->max_size; ++k)
+  for (size_t k = 0; k < pevent_hdr->max_size; ++k) {
     pevent_hdr->pes[k].fd = -1;
-}
-
-DDRes pevent_create_custom_ring_buffer(PEvent *pevent,
-                                       size_t ring_buffer_size_order) {
-  pevent->mapfd =
-      ddprof::memfd_create("allocation_ring_buffer", 1U /*MFD_CLOEXEC*/);
-  if (pevent->mapfd == -1) {
-    DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFOPEN,
-                           "Error calling memfd_create on watcher %d (%s)",
-                           pevent->pos, strerror(errno));
+    pevent_hdr->pes[k].mapfd = -1;
   }
-  if (ftruncate(pevent->mapfd, perf_mmap_size(ring_buffer_size_order)) == -1) {
-    DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFOPEN,
-                           "Error calling ftruncate on watcher %d (%s)",
-                           pevent->pos, strerror(errno));
-  }
-  pevent->fd = eventfd(0, 0);
-  if (pevent->fd == -1) {
-    DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFOPEN,
-                           "Error calling evenfd on watcher %d (%s)",
-                           pevent->pos, strerror(errno));
-  }
-  pevent->custom_event = true;
-  return {};
 }
 
 DDRes pevent_open(DDProfContext *ctx, pid_t pid, int num_cpu,
@@ -84,17 +62,41 @@ DDRes pevent_open(DDProfContext *ctx, pid_t pid, int num_cpu,
                                  watcher_idx, cpu_idx, strerror(errno));
         }
         pes[pevent_idx].mapfd = pes[pevent_idx].fd;
+        pevent_hdr->pes[pevent_idx].ring_buffer_size =
+            perf_mmap_size(DEFAULT_BUFF_SIZE_SHIFT);
         pes[pevent_idx].custom_event = false;
       }
     } else {
       // cutom event, eg.allocation profiling
       size_t pevent_idx = 0;
       DDRES_CHECK_FWD(pevent_create(pevent_hdr, watcher_idx, &pevent_idx));
-      DDRES_CHECK_FWD(pevent_create_custom_ring_buffer(
-          &pevent_hdr->pes[pevent_idx], DEFAULT_BUFF_SIZE_SHIFT));
+      DDRES_CHECK_FWD(ddprof::ring_buffer_create(DEFAULT_BUFF_SIZE_SHIFT,
+                                                 &pevent_hdr->pes[pevent_idx]));
     }
   }
   return ddres_init();
+}
+
+DDRes pevent_mmap_event(PEvent *event) {
+  if (event->mapfd != -1) {
+    // Do not mirror perf ring buffer because this doubles the amount of
+    // mlocked pages
+    bool mirror = event->custom_event;
+
+    perf_event_mmap_page *region = static_cast<perf_event_mmap_page *>(
+        perfown_sz(event->mapfd, event->ring_buffer_size, mirror));
+    if (!region) {
+      DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFMMAP,
+                             "Could not mmap memory for watcher #%d: %s",
+                             event->pos, strerror(errno));
+    }
+    if (!rb_init(&event->rb, region, event->ring_buffer_size, mirror)) {
+      DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFMMAP,
+                             "Could not allocate memory for watcher #%d",
+                             event->pos);
+    }
+  }
+  return {};
 }
 
 DDRes pevent_mmap(PEventHdr *pevent_hdr, bool use_override) {
@@ -113,26 +115,7 @@ DDRes pevent_mmap(PEventHdr *pevent_hdr, bool use_override) {
 
   PEvent *pes = pevent_hdr->pes;
   for (size_t k = 0; k < pevent_hdr->size; ++k) {
-    if (pes[k].mapfd != -1) {
-      size_t reg_sz = 0;
-      // Do not mirror perf ring buffer because this doubles the amount of
-      // mlocked pages
-      bool mirror = pes[k].custom_event;
-
-      perf_event_mmap_page *region = static_cast<perf_event_mmap_page *>(
-          perfown(pes[k].mapfd, mirror, &reg_sz));
-      if (!region) {
-        DDRES_RETURN_ERROR_LOG(
-            DD_WHAT_PERFMMAP,
-            "Could not finalize watcher (idx#%zu): registration (%s)", k,
-            strerror(errno));
-      }
-      if (!rb_init(&pes[k].rb, region, reg_sz, mirror)) {
-        DDRES_RETURN_ERROR_LOG(
-            DD_WHAT_PERFMMAP,
-            "Could not allocate storage for watcher (idx#%zu)", k);
-      }
-    }
+    DDRES_CHECK_FWD(pevent_mmap_event(&pes[k]));
   }
 
   defer_munmap.release();
@@ -160,46 +143,65 @@ DDRes pevent_enable(PEventHdr *pevent_hdr) {
   return ddres_init();
 }
 
+DDRes pevent_munmap_event(PEvent *event) {
+  if (event->rb.region) {
+    if (perfdisown(event->rb.region, event->rb.size, event->rb.is_mirrored) !=
+        0) {
+      DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFMMAP,
+                             "Error when using perfdisown for watcher #%d",
+                             event->pos);
+    }
+    event->rb.region = NULL;
+  }
+  rb_free(&event->rb);
+  return {};
+}
+
 /// Clean the mmap buffer
 DDRes pevent_munmap(PEventHdr *pevent_hdr) {
-
   PEvent *pes = pevent_hdr->pes;
+  DDRes res{};
+
   for (size_t k = 0; k < pevent_hdr->size; ++k) {
-    if (pes[k].rb.region) {
-      if (perfdisown(pes[k].rb.region, pes[k].rb.size, pes[k].rb.is_mirrored) !=
-          0) {
-        DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFMMAP,
-                               "Error when using perfdisown %zu", k);
-      }
-      pes[k].rb.region = NULL;
+    DDRes local_res = pevent_munmap_event(&pes[k]);
+    if (!IsDDResOK(local_res)) {
+      res = local_res;
     }
-    rb_free(&pevent_hdr->pes[k].rb);
   }
 
-  return ddres_init();
+  return res;
+}
+
+DDRes pevent_close_event(PEvent *event) {
+  if (event->fd != -1) {
+    if (close(event->fd) == -1) {
+      DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFOPEN,
+                             "Error when closing fd=%d (watcher #%d) (%s)",
+                             event->fd, event->pos, strerror(errno));
+    }
+    event->fd = -1;
+  }
+  if (event->custom_event && event->mapfd != -1) {
+    if (close(event->mapfd) == -1) {
+      DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFOPEN,
+                             "Error when closing mapfd=%d (watcher #%d) (%s)",
+                             event->mapfd, event->pos, strerror(errno));
+    }
+  }
+  return {};
 }
 
 DDRes pevent_close(PEventHdr *pevent_hdr) {
   PEvent *pes = pevent_hdr->pes;
+  DDRes res{};
   for (size_t k = 0; k < pevent_hdr->size; ++k) {
-    if (pes[k].fd != -1) {
-      if (close(pes[k].fd) == -1) {
-        DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFOPEN,
-                               "Error when closing fd=%d (idx#%zu) (%s)",
-                               pes[k].fd, k, strerror(errno));
-      }
-      pes[k].fd = -1;
-    }
-    if (pes[k].custom_event && pes[k].mapfd != -1) {
-      if (close(pes[k].mapfd) == -1) {
-        DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFOPEN,
-                               "Error when closing mapfd=%d (idx#%zu) (%s)",
-                               pes[k].mapfd, k, strerror(errno));
-      }
+    DDRes local_res = pevent_close_event(&pes[k]);
+    if (!IsDDResOK(local_res)) {
+      res = local_res;
     }
   }
   pevent_hdr->size = 0;
-  return ddres_init();
+  return res;
 }
 
 // returns the number of successful cleans

--- a/src/ringbuffer_utils.cc
+++ b/src/ringbuffer_utils.cc
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include "ringbuffer_utils.hpp"
+
+#include "ddres_helpers.h"
+#include "ipc.hpp"
+#include "pevent.h"
+#include "pevent_lib.h"
+#include "syscalls.hpp"
+
+#include <sys/eventfd.h>
+
+namespace ddprof {
+
+DDRes ring_buffer_attach(const RingBufferInfo &info, PEvent *pevent) {
+  pevent->fd = info.event_fd;
+  pevent->mapfd = info.ring_fd;
+  pevent->ring_buffer_size = info.mem_size;
+  pevent->custom_event = true;
+  return pevent_mmap_event(pevent);
+}
+
+DDRes ring_buffer_attach(PEvent &pe) { return pevent_mmap_event(&pe); }
+
+DDRes ring_buffer_create(size_t buffer_size_page_order, PEvent *pevent) {
+  size_t buffer_size = perf_mmap_size(buffer_size_page_order);
+  pevent->mapfd =
+      ddprof::memfd_create("allocation_ring_buffer", 1U /*MFD_CLOEXEC*/);
+  if (pevent->mapfd == -1) {
+    DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFOPEN,
+                           "Error calling memfd_create on watcher %d (%s)",
+                           pevent->pos, strerror(errno));
+  }
+  if (ftruncate(pevent->mapfd, buffer_size) == -1) {
+    DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFOPEN,
+                           "Error calling ftruncate on watcher %d (%s)",
+                           pevent->pos, strerror(errno));
+  }
+  pevent->fd = eventfd(0, 0);
+  if (pevent->fd == -1) {
+    DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFOPEN,
+                           "Error calling evenfd on watcher %d (%s)",
+                           pevent->pos, strerror(errno));
+  }
+  pevent->custom_event = true;
+  pevent->ring_buffer_size = buffer_size;
+  return {};
+}
+
+DDRes ring_buffer_close(PEvent &pevent) { return pevent_close_event(&pevent); }
+
+DDRes ring_buffer_detach(PEvent &event) { return pevent_munmap_event(&event); }
+
+DDRes ring_buffer_setup(size_t buffer_size_page_order, PEvent *event) {
+  DDRES_CHECK_FWD(ring_buffer_create(buffer_size_page_order, event));
+  DDRES_CHECK_FWD(ring_buffer_attach(*event));
+  return {};
+}
+
+DDRes ring_buffer_cleanup(PEvent &event) {
+  DDRes res = ring_buffer_detach(event);
+  DDRes res2 = ring_buffer_close(event);
+
+  return !IsDDResOK(res) ? res : res2;
+}
+
+} // namespace ddprof

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -357,6 +357,17 @@ add_unit_test(
     LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle
     DEFINITIONS ${DDPROF_DEFINITION_LIST})
 
+
+add_unit_test(
+    ringbuffer-ut
+    ringbuffer-ut.cc
+    ../src/perf.cc
+    ../src/perf_ringbuffer.c
+    ../src/pevent_lib.cc
+    ../src/ringbuffer_utils.cc
+    ../src/user_override.c
+)
+
 add_benchmark(savecontext-bench savecontext-bench.cc ../src/savecontext.cc)
 
 add_exe(simple_malloc-static simple_malloc.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -209,6 +209,7 @@ add_unit_test(
     ../src/perf.cc
     ../src/perf_watcher.cc
     ../src/perf_ringbuffer.c
+    ../src/ringbuffer_utils.cc
     pevent-ut.cc
     DEFINITIONS MYNAME="pevent-ut"
 )
@@ -340,6 +341,7 @@ add_unit_test(
     ../src/perf.cc
     ../src/perf_ringbuffer.c
     ../src/perf_watcher.cc
+    ../src/ringbuffer_utils.cc
     ../src/savecontext.cc
     ../src/mapinfo_lookup.cc
     ../src/procutils.c

--- a/test/ringbuffer-ut.cc
+++ b/test/ringbuffer-ut.cc
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include "pevent_lib.h"
+#include "ringbuffer_holder.hpp"
+#include "ringbuffer_utils.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace ddprof;
+
+TEST(ringbuffer, full) {
+  const size_t buf_size_order = 1;
+  RingBufferHolder ring_buffer{buf_size_order};
+  RingBufferWriter writer{ring_buffer.get_ring_buffer()};
+  RingBufferReader reader{ring_buffer.get_ring_buffer()};
+  EXPECT_EQ(reader.available_for_read(), 0);
+
+  auto sz = writer.available_size();
+  EXPECT_GT(sz, 0);
+  auto buffer = writer.reserve(sz);
+  std::fill(buffer.begin(), buffer.end(), std::byte{0xff});
+
+  EXPECT_EQ(writer.available_size(), 0);
+  writer.commit();
+
+  reader.check_for_new_data();
+  EXPECT_EQ(reader.available_for_read(), sz);
+  auto buffer2 = reader.read_all_available();
+  EXPECT_EQ(reader.available_for_read(), 0);
+  EXPECT_TRUE(
+      std::equal(buffer.begin(), buffer.end(), buffer2.begin(), buffer2.end()));
+}


### PR DESCRIPTION
# What does this PR do?

*  Fix computation for ringbuffer available size
 
    Available size should return one less than the actual available space in the ring buffer,
    because a completely full ringbuffer is indistinguishable from an empty one.
* Fix deadlock when allocation tracker is activated before malloc wrappers

    If allocation tracker is activated before first allocation (and therefore before malloc wrappers are initalized), then upon first allocation,
    AllocationTracker::track_allocation would be called during check_init, triggering an allocation that would reenter check_init and cause a
    deadlock.
    Fix is to call malloc before activation of AllocationTracker to force init of malloc wrappers if not done yet.
* Add unit test for ringbuffer
* Extract utils for custom ring buffer into their own file
