### PR TITLE
Add support for allocation profiling in wrapper mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,9 +146,40 @@ endif()
 list(APPEND DDPROF_LIBRARY_LIST libcap)
 list(APPEND DDPROF_INCLUDE_LIST ${LIBCAP_INCLUDE_DIR})
 
+set(DD_PROFILING_SOURCES src/lib/dd_profiling.cc src/daemonize.cc src/ddprof_cmdline.c src/logger.c src/logger_setup.cc 
+                         src/ipc.cc src/pevent_lib.cc src/perf.cc src/perf_ringbuffer.c src/perf_watcher.cc src/ringbuffer_utils.cc
+                         src/user_override.c src/ddres_list.c src/savecontext.cc src/lib/malloc_wrapper.cc src/lib/allocation_tracker.cc)
+
+add_library(dd_profiling-embedded SHARED ${DD_PROFILING_SOURCES})
+target_include_directories(dd_profiling-embedded PUBLIC ${CMAKE_SOURCE_DIR}/include/lib ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/third_party)
+set_target_properties(dd_profiling-embedded PROPERTIES
+   PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/lib/dd_profiling.h")
+
+# Link libstdc++/libgcc statically and export only profiler API
+static_link_cxx(TARGET dd_profiling-embedded)
+set_target_properties(dd_profiling-embedded PROPERTIES LINK_DEPENDS "${CMAKE_SOURCE_DIR}/cmake/dd_profiling.version")
+target_link_options(dd_profiling-embedded PRIVATE "LINKER:--version-script=${CMAKE_SOURCE_DIR}/cmake/dd_profiling.version")
+# Fix for link error in sanitizeddebug build mode with gcc:
+# /usr/bin/ld: ./libdd_profiling.so: undefined reference to `__dynamic_cast'
+# /usr/bin/ld: ./libdd_profiling.so: undefined reference to `typeinfo for __cxxabiv1::__vmi_class_type_info'
+# The cause of the error is that gcc puts `-lstdc++` before `-lubsan` in the linker invocation
+# Workaround is add another `-lstdc++` after `-lubsan` at the end, we cannot use `-static-libstdc++` because it does not force gcc to another `-lstdc++` at the end
+target_link_libraries(dd_profiling-embedded PRIVATE "$<$<AND:$<C_COMPILER_ID:GNU>,$<CONFIG:SanitizedDebug>>:-Wl,-Bstatic;-lubsan;-lasan;-lstdc++;-Wl,-Bdynamic>")
+target_link_libraries(dd_profiling-embedded PUBLIC dl pthread)
+
+set(LIBDDPROFILING_OBJECT "libdd_profiling.o")
+add_custom_command(OUTPUT ${LIBDDPROFILING_OBJECT}
+  # taken from https://dvdhrm.wordpress.com/2013/03/08/linking-binary-data/
+  COMMAND ld -r -o ${LIBDDPROFILING_OBJECT} -z noexecstack --format=binary $<TARGET_FILE_NAME:dd_profiling-embedded>
+  COMMAND objcopy --rename-section .data=.rodata,alloc,load,readonly,data,contents ${LIBDDPROFILING_OBJECT}
+  DEPENDS dd_profiling-embedded
+)
+add_library(libddprofiling_object OBJECT IMPORTED GLOBAL)
+set_target_properties(libddprofiling_object PROPERTIES IMPORTED_OBJECTS "${LIBDDPROFILING_OBJECT}")
+
 # It is important to force most libraries as static
 add_exe(ddprof
-        ${DDPROF_GLOBAL_SRC}
+        ${DDPROF_GLOBAL_SRC} $<TARGET_OBJECTS:libddprofiling_object>
         LIBRARIES ${DDPROF_LIBRARY_LIST}
         DEFINITIONS ${DDPROF_DEFINITION_LIST})
 target_include_directories(ddprof PRIVATE ${DDPROF_INCLUDE_LIST})
@@ -163,33 +194,28 @@ message(STATUS "Install destination " ${CMAKE_INSTALL_PREFIX})
 install(FILES LICENSE LICENSE-3rdparty.csv LICENSE.LGPLV3 NOTICE DESTINATION ddprof)
 
 set(DDPROF_EXE_OBJECT "ddprof.o")
-set(EXE_OBJECT_PATH "${CMAKE_CURRENT_BINARY_DIR}/${DDPROF_EXE_OBJECT}")
 add_custom_command(OUTPUT ${DDPROF_EXE_OBJECT}
   # taken from https://dvdhrm.wordpress.com/2013/03/08/linking-binary-data/
-  COMMAND ld -r -o ${DDPROF_EXE_OBJECT} -z noexecstack --format=binary ddprof
+  COMMAND ld -r -o ${DDPROF_EXE_OBJECT} -z noexecstack --format=binary $<TARGET_FILE_NAME:ddprof>
   COMMAND objcopy --rename-section .data=.rodata,alloc,load,readonly,data,contents ${DDPROF_EXE_OBJECT}
   DEPENDS ddprof
 )
 
-set(DD_PROFILING_SOURCES src/lib/dd_profiling.cc src/ddprof_cmdline.c src/logger.c src/logger_setup.cc src/ipc.cc 
-                         src/pevent_lib.cc src/perf.cc src/perf_ringbuffer.c src/perf_watcher.cc src/ringbuffer_utils.cc
-                         src/user_override.c src/ddres_list.c src/savecontext.cc src/lib/malloc_wrapper.cc src/lib/allocation_tracker.cc
-                         $<TARGET_OBJECTS:ddprof_exe_object>)
 add_library(ddprof_exe_object OBJECT IMPORTED GLOBAL)
 set_target_properties(ddprof_exe_object PROPERTIES IMPORTED_OBJECTS "${DDPROF_EXE_OBJECT}")
 
-add_library(dd_profiling-static STATIC ${DD_PROFILING_SOURCES})
+add_library(dd_profiling-static STATIC ${DD_PROFILING_SOURCES} $<TARGET_OBJECTS:ddprof_exe_object>)
 set_target_properties(dd_profiling-static PROPERTIES OUTPUT_NAME dd_profiling)
 target_include_directories(dd_profiling-static PUBLIC ${CMAKE_SOURCE_DIR}/include/lib ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/third_party)
 set_target_properties(dd_profiling-static PROPERTIES
    PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/lib/dd_profiling.h")
+target_link_libraries(dd_profiling-static PUBLIC dl pthread)
 
-add_library(dd_profiling-shared SHARED ${DD_PROFILING_SOURCES})
+add_library(dd_profiling-shared SHARED ${DD_PROFILING_SOURCES} $<TARGET_OBJECTS:ddprof_exe_object>)
 set_target_properties(dd_profiling-shared PROPERTIES OUTPUT_NAME dd_profiling)
 target_include_directories(dd_profiling-shared PUBLIC ${CMAKE_SOURCE_DIR}/include/lib ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/third_party)
-set_target_properties(dd_profiling-static PROPERTIES
+set_target_properties(dd_profiling-shared PROPERTIES
    PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/lib/dd_profiling.h")
-target_link_libraries(dd_profiling-static PUBLIC dl pthread)
 
 # Link libstdc++/libgcc statically and export only profiler API
 static_link_cxx(TARGET dd_profiling-shared)

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
 #pragma once
 
 // Env variable used to mark profiler as active in library mode

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+// Env variable used to mark profiler as active in library mode
+// Prevents reactivation of the profiler in child processes
+// (since profiler will follow children)
+inline constexpr const char *k_profiler_active_env_variable =
+    "DD_PROFILING_NATIVE_LIBRARY_ACTIVE";
+
+// Env variable to request autostart of profiler in library mode
+inline constexpr const char *k_profiler_auto_start_env_variable =
+    "DD_PROFILING_NATIVE_AUTOSTART";
+
+// Env variable to override ddprof exe used in library mode
+// By default exe embedded in library is use
+inline constexpr const char *k_profiler_ddprof_exe_env_variable =
+    "DD_PROFILING_NATIVE_DDPROF_EXE";
+
+// Env variable set by ddprof to pass socket to injected library
+// for memory allocation profiling (when initiated in wrapper mode)
+inline constexpr const char *k_profiler_lib_socket_env_variable =
+    "DD_PROFILING_NATIVE_LIB_SOCKET";
+
+// Env variable to override events to activate (-e option)
+inline constexpr const char *k_events_env_variable =
+    "DD_PROFILING_NATIVE_EVENTS";
+
+inline constexpr const char *k_libdd_profiling_name = "libdd_profiling.so";

--- a/include/daemonize.hpp
+++ b/include/daemonize.hpp
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#pragma once
+
+#include <functional>
+#include <sys/types.h>
+
+namespace ddprof {
+
+struct DaemonizeResult {
+  pid_t
+      temp_pid; // -1 on failure, 0 for initial process, > 0 for daemon process
+  pid_t parent_pid; // pid of process initiating daemonize
+  pid_t daemon_pid; // pid of daemon process
+};
+
+// Daemonization function
+// cleanup_function is a callable invoked in the context of the intermediate,
+// short-lived process that will be killed by daemon process.
+DaemonizeResult daemonize(std::function<void()> cleanup_function = {});
+} // namespace ddprof

--- a/include/ddres_list.h
+++ b/include/ddres_list.h
@@ -54,7 +54,8 @@ extern "C" {
   X(UNHANDLED_DSO, "ignore dso type")                                          \
   X(WORKERLOOP_INIT, "error initializing the worker loop")                     \
   X(UNITTEST, "unit test error")                                               \
-  X(SOCKET, "error during socket operation")
+  X(SOCKET, "error during socket operation")                                   \
+  X(TEMP_FILE, "error during temporary file creation")
 
 // generic erno errors available from /usr/include/asm-generic/errno.h
 

--- a/include/lib/ddprof_output.hpp
+++ b/include/lib/ddprof_output.hpp
@@ -1,5 +1,7 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
 
 #pragma once
 

--- a/src/daemonize.cc
+++ b/src/daemonize.cc
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include "daemonize.hpp"
+
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace ddprof {
+DaemonizeResult daemonize(std::function<void()> cleanup_function) {
+  int pipefd[2];
+  if (pipe2(pipefd, O_CLOEXEC) == -1) {
+    return {-1, -1, -1};
+  }
+
+  pid_t parent_pid = getpid();
+  pid_t temp_pid = fork(); // "middle" (temporary) PID
+
+  if (temp_pid == -1) {
+    return {-1, -1, -1};
+  }
+
+  if (!temp_pid) { // If I'm the temp PID enter branch
+    close(pipefd[0]);
+
+    temp_pid = getpid();
+    if (pid_t child_pid = fork();
+        child_pid) { // If I'm the temp PID again, enter branch
+      if (cleanup_function) {
+        cleanup_function();
+      }
+
+      // Block until our child exits or sends us a kill signal
+      // NOTE, current process is NOT expected to unblock here; rather it
+      // ends by SIGTERM.  Exiting here is an error condition.
+      waitpid(child_pid, NULL, 0);
+      exit(1);
+    } else {
+      child_pid = getpid();
+      if (write(pipefd[1], &child_pid, sizeof(child_pid)) !=
+          sizeof(child_pid)) {
+        exit(1);
+      }
+      close(pipefd[1]);
+      // If I'm the child PID, then leave and attach profiler
+      return {temp_pid, parent_pid, child_pid};
+    }
+  } else {
+    close(pipefd[1]);
+
+    pid_t grandchild_pid;
+    if (read(pipefd[0], &grandchild_pid, sizeof(grandchild_pid)) !=
+        sizeof(grandchild_pid)) {
+      return {-1, -1, -1};
+    }
+
+    // If I'm the target PID, then now it's time to wait until my
+    // child, the middle PID, returns.
+    waitpid(temp_pid, NULL, 0);
+    return {0, parent_pid, grandchild_pid};
+  }
+}
+
+} // namespace ddprof

--- a/src/ddprof_input.cc
+++ b/src/ddprof_input.cc
@@ -17,6 +17,8 @@ extern "C" {
 #include "version.h"
 }
 
+#include "constants.hpp"
+
 /************************ Options Table Helper Macros *************************/
 #define X_FREE(a, b, c, d, e, f, g, h, i) FREE_EXP(i b, f);
 #define X_LOPT(a, b, c, d, e, f, g, h, i) {#b, e, 0, d},
@@ -143,7 +145,7 @@ const char* help_str[DD_KLEN] = {
 const char *help_key[DD_KLEN] = {OPT_TABLE(X_HLPK)};
 
 static void ddprof_input_default_events(DDProfInput *input) {
-  const char *events = getenv("DD_PROFILING_NATIVE_EVENTS");
+  const char *events = getenv(k_events_env_variable);
   if (!events) {
     return;
   }

--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -137,7 +137,7 @@ static InputResult parse_input(int *argc, char ***argv, DDProfContext *ctx) {
     return InputResult::kError;
   }
 
-  if (ddprof_context_allocation_profiling_watcher_idx(ctx) != 1 &&
+  if (ddprof_context_allocation_profiling_watcher_idx(ctx) != -1 &&
       ctx->params.pid && ctx->params.sockfd == -1) {
     LG_ERR("Memory allocation profiling is not supported in PID mode");
     return InputResult::kError;

--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -3,6 +3,9 @@
 // developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
 // Datadog, Inc.
 
+#include "arraysize.h"
+#include "constants.hpp"
+#include "daemonize.hpp"
 #include "ddprof_input.h"
 #include "ddres.h"
 #include "defer.hpp"
@@ -17,16 +20,71 @@ extern "C" {
 
 #include <cassert>
 #include <errno.h>
+#include <fcntl.h>
+#include <filesystem>
 #include <functional>
 #include <string.h>
+#include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
+namespace fs = std::filesystem;
+
 enum class InputResult { kSuccess, kStop, kError };
 
+// address of embedded libddprofiling shared library
+extern const char
+    _binary_libdd_profiling_embedded_so_start[]; // NOLINT cert-dcl51-cpp
+extern const char
+    _binary_libdd_profiling_embedded_so_end[]; // NOLINT cert-dcl51-cpp
+
+static constexpr const char k_pid_place_holder[] = "{pid}";
+
+static DDRes get_library_path(std::string &path) {
+  auto exe_path = fs::read_symlink("/proc/self/exe");
+  auto lib_path = exe_path.parent_path() / k_libdd_profiling_name;
+  // first check if libdd_profiling.so exists in same diorectory as exe or in
+  // <exe_path>/../lib/
+  if (fs::exists(lib_path)) {
+    path = lib_path;
+    return {};
+  }
+  lib_path =
+      exe_path.parent_path().parent_path() / "lib" / k_libdd_profiling_name;
+  if (fs::exists(lib_path)) {
+    path = lib_path;
+    return {};
+  }
+
+  // Did not find libdd_profiling.so, use the one emebedded in ddprof exe
+  path = std::string{fs::temp_directory_path() / k_libdd_profiling_name} +
+      ".XXXXXX";
+
+  int fd = mkostemp(path.data(), O_CLOEXEC);
+  DDRES_CHECK_ERRNO(fd, DD_WHAT_TEMP_FILE, "Failed to create temporary file");
+  // cppcheck-suppress comparePointers
+  ssize_t lib_sz = _binary_libdd_profiling_embedded_so_end -
+      _binary_libdd_profiling_embedded_so_start;
+  if (write(fd, _binary_libdd_profiling_embedded_so_start, lib_sz) != lib_sz) {
+    DDRES_CHECK_ERRNO(fd, DD_WHAT_TEMP_FILE, "Failed to write temporary file");
+  }
+  unlink(path.data());
+  char buffer[1024];
+  sprintf(buffer, "/proc/%s/fd/%d", k_pid_place_holder, fd);
+  path = buffer;
+  return {};
+}
+
+// Replace pid place holder in path if present by pid argument
+static void fixup_library_path(std::string &path, pid_t pid) {
+  if (size_t pos = path.find(k_pid_place_holder); pos != std::string::npos) {
+    path.replace(pos, ARRAY_SIZE(k_pid_place_holder) - 1, std::to_string(pid));
+  }
+}
+
 // Parse input and initialize context
-InputResult parse_input(int *argc, char ***argv, DDProfContext *ctx) {
+static InputResult parse_input(int *argc, char ***argv, DDProfContext *ctx) {
   //---- Inititiate structs
   *ctx = {};
   // Set temporary logger for argument parsing
@@ -69,41 +127,16 @@ InputResult parse_input(int *argc, char ***argv, DDProfContext *ctx) {
     return InputResult::kError;
   }
 
+  if (ddprof_context_allocation_profiling_watcher_idx(ctx) != 1 &&
+      ctx->params.pid && ctx->params.sockfd == -1) {
+    LG_ERR("Memory allocation profiling is not supported in PID mode");
+    return InputResult::kError;
+  }
+
   return InputResult::kSuccess;
 }
 
-// Daemonization function return some pid for daemon process, 0 for control
-// (non-daemon) process, -1 for error.
-// cleanup_function is a callable invoked in the context of the intermediate,
-// short-lived process that will be killed by daemon process.
-pid_t daemonize(std::function<void()> cleanup_function = {}) {
-  pid_t temp_pid = fork(); // "middle" (temporary) PID
-
-  if (!temp_pid) { // If I'm the temp PID enter branch
-    temp_pid = getpid();
-    if (pid_t child_pid = fork();
-        child_pid) { // If I'm the temp PID again, enter branch
-      if (cleanup_function) {
-        cleanup_function();
-      }
-      // Block until our child exits or sends us a kill signal
-      // NOTE, current process is NOT expected to unblock here; rather it
-      // ends by SIGTERM.  Exiting here is an error condition.
-      waitpid(child_pid, NULL, 0);
-      return -1;
-    } else {
-      // If I'm the child PID, then leave and attach profiler
-      return temp_pid;
-    }
-  } else {
-    // If I'm the target PID, then now it's time to wait until my
-    // child, the middle PID, returns.
-    waitpid(temp_pid, NULL, 0);
-    return 0;
-  }
-}
-
-int start_profiler_internal(DDProfContext *ctx, bool &is_profiler) {
+static int start_profiler_internal(DDProfContext *ctx, bool &is_profiler) {
   defer { ddprof_context_free(ctx); };
 
   is_profiler = true;
@@ -116,18 +149,69 @@ int start_profiler_internal(DDProfContext *ctx, bool &is_profiler) {
   pid_t temp_pid = 0;
   if (!ctx->params.pid) {
     // If no PID was specified earlier, we autodaemonize and target current pid
-    ctx->params.pid = getpid();
-    temp_pid = daemonize([ctx] { ddprof_context_free(ctx); });
 
-    if (temp_pid == -1) {
+    // determine if library should be injected into target
+    bool allocation_profiling_started_from_wrapper =
+        ddprof_context_allocation_profiling_watcher_idx(ctx) != -1 &&
+        ctx->params.sockfd == -1;
+
+    std::string dd_profiling_lib_path;
+
+    enum { kParentIdx, kChildIdx };
+    int sockfds[2] = {-1, -1};
+
+    auto defer_child_socket_close = make_defer([&sockfds]() {
+      if (sockfds[kChildIdx] != -1)
+        close(sockfds[kChildIdx]);
+    });
+    auto defer_parent_socket_close = make_defer([&sockfds]() {
+      if (sockfds[kParentIdx] != -1)
+        close(sockfds[kParentIdx]);
+    });
+
+    if (allocation_profiling_started_from_wrapper) {
+      if (socketpair(AF_UNIX, SOCK_DGRAM, 0, sockfds) == -1) {
+        return -1;
+      }
+      if (!IsDDResOK(get_library_path(dd_profiling_lib_path))) {
+        return -1;
+      }
+      ctx->params.sockfd = sockfds[kChildIdx];
+      ctx->params.wait_on_socket = true;
+    }
+
+    ctx->params.pid = getpid();
+    auto daemonize_res = ddprof::daemonize([ctx] { ddprof_context_free(ctx); });
+
+    if (daemonize_res.temp_pid == -1) {
       return -1;
     }
 
-    // non-daemon process: return control to caller
+    temp_pid = daemonize_res.temp_pid;
     if (!temp_pid) {
+      // non-daemon process: return control to caller
+      defer_child_socket_close.reset();
       is_profiler = false;
+
+      // Allocation profiling activated, inject dd_profiling library with
+      // LD_PRELOAD
+      if (allocation_profiling_started_from_wrapper) {
+        fixup_library_path(dd_profiling_lib_path, daemonize_res.daemon_pid);
+        std::string preload_str = dd_profiling_lib_path;
+        if (const char *s = getenv("LD_PRELOAD"); s) {
+          preload_str.append(";");
+          preload_str.append(s);
+        }
+        setenv("LD_PRELOAD", preload_str.c_str(), 1);
+        auto sock_str = std::to_string(sockfds[kParentIdx]);
+        setenv(k_profiler_lib_socket_env_variable, sock_str.c_str(), 1);
+      }
+
+      defer_parent_socket_close.release();
       return 0;
     }
+    defer_child_socket_close.release();
+    defer_parent_socket_close.reset();
   }
 
   // Attach the profiler
@@ -156,14 +240,15 @@ int start_profiler_internal(DDProfContext *ctx, bool &is_profiler) {
       ddprof::span pevents{ctx->worker_ctx.pevent_hdr.pes,
                            ctx->worker_ctx.pevent_hdr.size};
       auto event_it = std::find_if(pevents.begin(), pevents.end(),
-                   [alloc_watcher_idx](const auto &pevent) {
-                     return pevent.pos == alloc_watcher_idx;
-                   });
+                                   [alloc_watcher_idx](const auto &pevent) {
+                                     return pevent.pos == alloc_watcher_idx;
+                                   });
       if (event_it != pevents.end()) {
         reply.ring_buffer.event_fd = event_it->fd;
         reply.ring_buffer.ring_fd = event_it->mapfd;
-        reply.ring_buffer.mem_size = perf_mmap_size(DEFAULT_BUFF_SIZE_SHIFT);
-        reply.allocation_profiling_rate = ctx->watchers[alloc_watcher_idx].sample_period;
+        reply.ring_buffer.mem_size = event_it->ring_buffer_size;
+        reply.allocation_profiling_rate =
+            ctx->watchers[alloc_watcher_idx].sample_period;
       }
     }
 
@@ -196,7 +281,7 @@ int start_profiler_internal(DDProfContext *ctx, bool &is_profiler) {
 }
 
 // This function only returns in daemon mode for control (non-daemon) process
-void start_profiler(DDProfContext *ctx) {
+static void start_profiler(DDProfContext *ctx) {
   bool is_profiler = false;
   // ownership of context is passed to start_profiler_internal
   int res = start_profiler_internal(ctx, is_profiler);

--- a/src/lib/malloc_wrapper.cc
+++ b/src/lib/malloc_wrapper.cc
@@ -152,7 +152,8 @@ int temp_posix_memalign(void **memptr, size_t alignment, size_t size) noexcept {
 
 void *aligned_alloc(size_t alignment, size_t size) {
   void *ptr = s_aligned_alloc(alignment, size);
-  ddprof::AllocationTracker::track_allocation(reinterpret_cast<uintptr_t>(ptr), size);
+  ddprof::AllocationTracker::track_allocation(reinterpret_cast<uintptr_t>(ptr),
+                                              size);
   return ptr;
 }
 

--- a/src/pprof/ddprof_pprof.cc
+++ b/src/pprof/ddprof_pprof.cc
@@ -215,7 +215,7 @@ DDRes pprof_aggregate(const UnwindOutput *uw_output,
     labels[labels_num].str = to_CharSlice(pid_str);
     ++labels_num;
   }
-  if (!watcher->suppress_tid ) {
+  if (!watcher->suppress_tid) {
     snprintf(tid_str, sizeof(tid_str), "%d", uw_output->tid);
     labels[labels_num].key = to_CharSlice("thread id");
     labels[labels_num].str = to_CharSlice(tid_str);

--- a/test/ddprof_input-ut.cc
+++ b/test/ddprof_input-ut.cc
@@ -10,6 +10,7 @@ extern "C" {
 }
 
 #include "arraysize.h"
+#include "constants.hpp"
 #include "defer.hpp"
 #include "loghandle.hpp"
 
@@ -101,12 +102,12 @@ TEST_F(InputTest, dump_fixed) {
 }
 
 TEST_F(InputTest, event_from_env) {
-  defer { unsetenv("DD_PROFILING_NATIVE_EVENTS"); };
+  defer { unsetenv(k_events_env_variable); };
   {
     DDProfInput input;
     bool contine_exec = true;
     const char *input_values[] = {MYNAME, "my_program"};
-    setenv("DD_PROFILING_NATIVE_EVENTS", "sCPU,1000", 1);
+    setenv(k_events_env_variable, "sCPU,1000", 1);
     DDRes res = ddprof_input_parse(
         ARRAY_SIZE(input_values), (char **)input_values, &input, &contine_exec);
 
@@ -125,7 +126,7 @@ TEST_F(InputTest, event_from_env) {
     DDProfInput input;
     bool contine_exec = true;
     const char *input_values[] = {MYNAME, "my_program"};
-    setenv("DD_PROFILING_NATIVE_EVENTS", ";", 1);
+    setenv(k_events_env_variable, ";", 1);
     DDRes res = ddprof_input_parse(
         ARRAY_SIZE(input_values), (char **)input_values, &input, &contine_exec);
 
@@ -139,7 +140,7 @@ TEST_F(InputTest, event_from_env) {
     DDProfInput input;
     bool contine_exec = true;
     const char *input_values[] = {MYNAME, "my_program"};
-    setenv("DD_PROFILING_NATIVE_EVENTS", ";sCPU,1000;", 1);
+    setenv(k_events_env_variable, ";sCPU,1000;", 1);
     DDRes res = ddprof_input_parse(
         ARRAY_SIZE(input_values), (char **)input_values, &input, &contine_exec);
 
@@ -159,7 +160,7 @@ TEST_F(InputTest, event_from_env) {
     DDProfInput input;
     bool contine_exec = true;
     const char *input_values[] = {MYNAME, "-e", "hINST,456", "my_program"};
-    setenv("DD_PROFILING_NATIVE_EVENTS", "sCPU,1000;hCPU,123", 1);
+    setenv(k_events_env_variable, "sCPU,1000;hCPU,123", 1);
     DDRes res = ddprof_input_parse(
         ARRAY_SIZE(input_values), (char **)input_values, &input, &contine_exec);
 

--- a/test/self_unwind/stackchecker.cpp
+++ b/test/self_unwind/stackchecker.cpp
@@ -1,5 +1,7 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
 
 #include "stackchecker.hpp"
 

--- a/test/self_unwind/stackchecker.hpp
+++ b/test/self_unwind/stackchecker.hpp
@@ -1,5 +1,7 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
 
 #pragma once
 

--- a/tools/style-check.sh
+++ b/tools/style-check.sh
@@ -5,7 +5,9 @@
 
 set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cd "$SCRIPT_DIR/.."
 
 # Find most recent clang-format, defaulting to an unqualified default
 CLANG_FORMAT=$(command -v clang-format{-13,-12,-11,-10,-9,} | head -n 1)


### PR DESCRIPTION
# What does this PR do?
Add support for allocation profiling in wrapper mode
-  In wrapper mode, when allocation profiling is requested, inject with LD_PRELOAD a shared library into target process
- ddprof first looks for libdd_profiling.so in its directory and ../lib, if not found, ddprof uses a library embedded and creates a temp file
- ddprof creates a socket pair and sets DD_PROFILING_NATIVE_LIB_SOCKET env variable with socket fd
 - library when it detects that DD_PROFILING_NATIVE_LIB_SOCKET is set, connects to existing ddprof instead of spawning a new profiler

Other changes:
- Make sure that style-check.sh checks all the source files
- Move constants to their own file (`constants.hpp`)