### PR TITLE
libdatadog 0.7.0 - Use the latest release of the shared library

### DIFF
--- a/cmake/Findlibddprof.cmake
+++ b/cmake/Findlibddprof.cmake
@@ -1,12 +1,12 @@
 # Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
-# libddprof : common profiler imported libraries
-## Associated https://gitlab.ddbuild.io/DataDog/libddprof-build/-/jobs/90384402
-set(TAG_LIBDDPROF "v0.6.0-rc.1" CACHE STRING "libddprof github tag")
+# libdatadog : common profiler imported libraries
+# https://github.com/DataDog/libdatadog/releases/tag/v0.7.0-rc.1
+set(TAG_LIBDDPROF "v0.7.0-rc.1" CACHE STRING "libdatadog github tag")
 
-set(SHA256_LIBDDPROF_X86 "448e14a29fc4f4c432757e637aa64dc56d45ee5bad4fb26b6fafbabef466324d" CACHE STRING "libddprof sha256")
-set(SHA256_LIBDDPROF_ARM "564d5bbe45192cf031d2e963f049626dfb66a959c0d1ee3e5ad95ae91b1e3650" CACHE STRING "libddprof sha256")
+set(SHA256_LIBDDPROF_X86 "9b43711b23e42e76684eeced9e8d25183d350060d087d755622fa6748fa79aa5" CACHE STRING "libddprof sha256")
+set(SHA256_LIBDDPROF_ARM "e792c923d5cdc6d581da87d12ab789ae578fa588fb2a220f72660f8d25df6de8" CACHE STRING "libddprof sha256")
 
 set(LIBDDPROF_ROOT ${VENDOR_PATH}/libddprof-${TAG_LIBDDPROF})
 if ( "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64" )

--- a/src/exporter/ddprof_exporter.cc
+++ b/src/exporter/ddprof_exporter.cc
@@ -243,7 +243,7 @@ DDRes ddprof_exporter_export(const ddprof_ffi_Profile *profile,
                              uint32_t profile_seq, DDProfExporter *exporter) {
   DDRes res = ddres_init();
   ddprof_ffi_SerializeResult serialized_result =
-      ddprof_ffi_Profile_serialize(profile);
+      ddprof_ffi_Profile_serialize(profile, nullptr, nullptr);
   defer { ddprof_ffi_SerializeResult_drop(serialized_result); };
   if (serialized_result.tag != DDPROF_FFI_SERIALIZE_RESULT_OK) {
     DDRES_RETURN_ERROR_LOG(DD_WHAT_EXPORTER, "Failed to serialize");
@@ -286,10 +286,10 @@ DDRes ddprof_exporter_export(const ddprof_ffi_Profile *profile,
           exporter->_exporter, request, nullptr);
       defer { ddprof_ffi_SendResult_drop(result); };
 
-      if (result.tag == DDPROF_FFI_SEND_RESULT_FAILURE) {
+      if (result.tag == DDPROF_FFI_SEND_RESULT_ERR) {
         LG_WRN("Failure to establish connection, check url %s", exporter->_url);
-        LG_WRN("Failure to send profiles (%.*s)", (int)result.failure.len,
-               result.failure.ptr);
+        LG_WRN("Failure to send profiles (%.*s)", (int)result.err.len,
+               result.err.ptr);
         // Free error buffer (prefer this API to the free API)
         if (exporter->_nb_consecutive_errors++ >=
             K_NB_CONSECUTIVE_ERRORS_ALLOWED) {

--- a/src/pprof/ddprof_pprof.cc
+++ b/src/pprof/ddprof_pprof.cc
@@ -112,7 +112,7 @@ DDRes pprof_create_profile(DDProfPProf *pprof, DDProfContext *ctx) {
     };
   }
   pprof->_profile = ddprof_ffi_Profile_new(
-      sample_types, num_sample_type_ids > 0 ? &period : nullptr);
+      sample_types, num_sample_type_ids > 0 ? &period : nullptr, nullptr);
   if (!pprof->_profile) {
     DDRES_RETURN_ERROR_LOG(DD_WHAT_PPROF, "Unable to create profile");
   }
@@ -252,7 +252,7 @@ DDRes pprof_aggregate(const UnwindOutput *uw_output,
 }
 
 DDRes pprof_reset(DDProfPProf *pprof) {
-  if (!ddprof_ffi_Profile_reset(pprof->_profile)) {
+  if (!ddprof_ffi_Profile_reset(pprof->_profile, nullptr)) {
     DDRES_RETURN_ERROR_LOG(DD_WHAT_PPROF, "Unable to reset profile");
   }
   return ddres_init();

--- a/test/ddprof_pprof-ut.cc
+++ b/test/ddprof_pprof-ut.cc
@@ -41,7 +41,7 @@ void test_pprof(const DDProfPProf *pprofs) {
   const ddprof_ffi_Profile *profile = pprofs->_profile;
 
   struct ddprof_ffi_SerializeResult serialized_result =
-      ddprof_ffi_Profile_serialize(profile);
+      ddprof_ffi_Profile_serialize(profile, nullptr, nullptr);
 
   ASSERT_EQ(serialized_result.tag, DDPROF_FFI_SERIALIZE_RESULT_OK);
 

--- a/tools/fetch_libddprof.sh
+++ b/tools/fetch_libddprof.sh
@@ -26,8 +26,9 @@ TAG_LIBDDPROF=$1
 SHA256_LIBDDPROF=$2
 TARGET_EXTRACT=$3
 
-TAR_LIBDDPROF=libddprof-${MARCH}-unknown-linux-gnu.tar.gz
-GITHUB_URL_LIBDDPROF=https://github.com/DataDog/libddprof/releases/download/${TAG_LIBDDPROF}/${TAR_LIBDDPROF}
+# https://github.com/DataDog/libdatadog/releases/download/v0.7.0-rc.1/libdatadog-aarch64-alpine-linux-musl.tar.gz
+TAR_LIBDDPROF=libdatadog-${MARCH}-unknown-linux-gnu.tar.gz
+GITHUB_URL_LIBDDPROF=https://github.com/DataDog/libdatadog/releases/download/${TAG_LIBDDPROF}/${TAR_LIBDDPROF}
 
 mkdir -p "$TARGET_EXTRACT"
 cd "$TARGET_EXTRACT"


### PR DESCRIPTION
# What does this PR do?

- Repository was moved to libdatadog (instead of libddprof)
- APIs now allow specifying time (instead of taking the current time)

A brief description of the change being made with this pull request.

# Motivation

- Test the new changes.
- Ensure we point to the new libdatadog repository

# Additional Notes

Some more renaming could help, thoough libddprof still exists within libdatadog. Our downstream naming should be fixed first.

# How to test the change?

Relenv and our usual tests should ensure we upload profiles.
