### PR TITLE
Fix worker restart issue

### DIFF
--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -365,7 +365,7 @@ DDRes ddprof_worker_maybe_export(DDProfContext *ctx, int64_t now_ns) {
     if (now_ns > ctx->worker_ctx.send_nanos) {
       // restart worker if number of uploads is reached
       ctx->worker_ctx.persistent_worker_state->restart_worker =
-          (ctx->params.worker_period <= ctx->worker_ctx.count_worker);
+          (ctx->worker_ctx.count_worker + 1 >= ctx->params.worker_period);
       // when restarting worker, do a synchronous export
       DDRES_CHECK_FWD(ddprof_worker_cycle(
           ctx, now_ns,

--- a/src/perf_mainloop.cc
+++ b/src/perf_mainloop.cc
@@ -276,8 +276,7 @@ static void worker(DDProfContext *ctx, const WorkerAttr *attr,
     if (IsDDResNotOK(res)) {
       LG_WRN("Worker warning (what:%s).", ddres_error_message(res._what));
     }
-    LG_NFO("Shutting down worker gracefully");
-    persistent_worker_state->restart_worker = false;
+    LG_NTC("Shutting down worker gracefully");
     persistent_worker_state->errors = false;
   }
 }


### PR DESCRIPTION
# What does this PR do?

Worker was not restarting because `persistent_worker_state->restart_worker` was unconditionally set to false upon worker exit.