### PR TITLE
Fix Codeql warning: Potentially uninitialized local variable

### DIFF
--- a/src/lib/dd_profiling.cc
+++ b/src/lib/dd_profiling.cc
@@ -87,7 +87,7 @@ int get_ddprof_socket() {
   const char *socket_str = getenv(k_profiler_lib_socket_env_variable);
   if (socket_str) {
     std::string_view sv{socket_str};
-    int sockfd;
+    int sockfd = -1;
     if (auto [ptr, ec] = std::from_chars(sv.begin(), sv.end(), sockfd);
         ec == std::errc() && ptr == sv.end()) {
       return sockfd;

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -81,6 +81,8 @@ TEST(DSOTest, is_within) {
   fill_mock_hdr(dso_hdr);
   DsoFindRes find_res = dso_hdr.dso_find_closest(10, 1300);
   EXPECT_TRUE(find_res.second);
+  std::string dso_str = find_res.first->second.to_string();
+  EXPECT_EQ(dso_str, "PID[10] 3e8-5db 0 (bar.so.1)(T-Standard)(x)(ID#-1)");
   DsoHdr::DsoFindRes not_found = dso_hdr.find_res_not_found(10);
   ASSERT_FALSE(find_res == not_found);
   EXPECT_EQ(find_res.first->second._pid, 10);


### PR DESCRIPTION
# What does this PR do?

Fix Codeql warning: Potentially uninitialized local variable
- Although this should not happen, the init will suppress the security warning.

# Motivation

Cleanup security warnings

# Additional Notes

NA

# How to test the change?

No change expected.
