### PR TITLE
[PROTO] User override when reading proc maps

### DIFF
--- a/include/ddres_def.h
+++ b/include/ddres_def.h
@@ -64,6 +64,11 @@ static inline DDRes ddres_warn(int16_t what) {
   return ddres_create(DD_SEVWARN, what);
 }
 
+/// Creates a DDRes with a notice taking an error code (what)
+static inline DDRes ddres_notice(int16_t what) {
+  return ddres_create(DD_SEVNOTICE, what);
+}
+
 /// Create an OK DDRes
 static inline DDRes ddres_init(void) {
   DDRes ddres = {};

--- a/include/user_override.h
+++ b/include/user_override.h
@@ -13,6 +13,8 @@ typedef struct UIDInfo {
   uid_t previous_user;
 } UIDInfo;
 
-DDRes user_override(UIDInfo *user_override);
+DDRes user_override_if_root(UIDInfo *override_info);
 
-DDRes revert_override(UIDInfo *user_override);
+DDRes user_override(uid_t uid, UIDInfo *override_info);
+
+DDRes revert_override(UIDInfo *override_info);

--- a/src/pevent_lib.cc
+++ b/src/pevent_lib.cc
@@ -175,7 +175,7 @@ DDRes pevent_mmap(PEventHdr *pevent_hdr, bool use_override) {
   // hence we use a different user
   UIDInfo info;
   if (use_override) {
-    DDRES_CHECK_FWD(user_override(&info));
+    DDRES_CHECK_FWD(user_override_if_root(&info));
   }
 
   defer {

--- a/src/procutils.c
+++ b/src/procutils.c
@@ -62,7 +62,6 @@ bool check_file_type(const char *pathname, int file_type) {
 
 bool get_file_inode(const char *pathname, inode_t *inode, int64_t *size) {
   struct stat info;
-
   if (stat(pathname, &info) != 0) {
     *inode = 0;
     *size = 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -249,8 +249,9 @@ add_unit_test(
     ../src/dso_hdr.cc
     ../src/ddprof_file_info.cc
     ../src/procutils.c
-    ../src/signal_helper.c
     ../src/region_holder.cc
+    ../src/signal_helper.c
+    ../src/user_override.c
     dso-ut.cc
     DEFINITIONS MYNAME="dso-ut")
 target_include_directories(dso-ut PRIVATE ${LIBCAP_INCLUDE_DIR})
@@ -284,6 +285,7 @@ add_unit_test(
     ../src/procutils.c
     ../src/signal_helper.c
     ../src/region_holder.cc
+    ../src/user_override.c
     LIBRARIES ${ELFUTILS_LIBRARIES}
     DEFINITIONS MYNAME="dwfl_symbol-ut"
 )
@@ -316,6 +318,7 @@ add_unit_test(
     ../src/unwind_helpers.cc
     ../src/unwind_metrics.c
     ../src/unwind_output.c
+    ../src/user_override.c
     LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle
     DEFINITIONS MYNAME="savecontext-ut"
 )
@@ -355,6 +358,7 @@ add_unit_test(
     ../src/unwind_helpers.cc
     ../src/unwind_metrics.c
     ../src/unwind_output.c
+    ../src/user_override.c
     LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle
     DEFINITIONS ${DDPROF_DEFINITION_LIST})
 

--- a/test/user_id-ut.cc
+++ b/test/user_id-ut.cc
@@ -60,7 +60,7 @@ TEST(UserIDTest, api) {
   UIDInfo info;
   uid_t old_user = getuid();
 
-  DDRes res = user_override(&info);
+  DDRes res = user_override_if_root(&info);
   EXPECT_TRUE(IsDDResOK(res));
 
   uid_t new_user = getuid();


### PR DESCRIPTION
# What does this PR do?

When accessing proc maps and receiving a failure opening the file, attempt to switch to the user that owns this file.
This was raised by an internal user. The bug occurs when a gitlab runner was using a different user to run the app.

# Motivation

A User reported a bug

# Additional Notes

We were previously hitting this as we were catching the important mappings at startup.

# How to test the change?

Find an app that switches user
