### PR TITLE
Add profile presets

### DIFF
--- a/include/ddprof_input.hpp
+++ b/include/ddprof_input.hpp
@@ -35,6 +35,7 @@ typedef struct DDProfInput {
   char *tags;
   char *url;
   char *socket;
+  char *preset;
   // Watcher presets
   PerfWatcher watchers[MAX_TYPE_WATCHER];
   int num_watchers;
@@ -95,7 +96,9 @@ typedef struct DDProfInput {
   XX(DD_PROFILING_NATIVE_TARGET_PID,    pid,                p, 'p', 1, input, NULL, "", )                      \
   XX(DD_PROFILING_NATIVE_GLOBAL,        global,             g, 'g', 1, input, NULL, "", )                      \
   XX(DD_PROFILING_INTERNAL_STATS,       internal_stats,     b, 'b', 1, input, NULL, "", )                      \
-  XX(DD_PROFILING_NATIVE_SOCKET,        socket,             Z, 'Z', 1, input, NULL, "", )
+  XX(DD_PROFILING_NATIVE_SOCKET,        socket,             Z, 'Z', 1, input, NULL, "", )                      \
+  XX(DD_PROFILING_NATIVE_PRESET,        preset,             D, 'D', 1, input, NULL, "", )
+
 // clang-format on
 
 #define X_ENUM(a, b, c, d, e, f, g, h, i) a,

--- a/include/perf_watcher.hpp
+++ b/include/perf_watcher.hpp
@@ -23,6 +23,7 @@ struct PerfWatcherOptions {
 };
 
 typedef struct PerfWatcher {
+  int ddprof_event_type; // ddprof event type from DDPROF_EVENT_NAMES enum
   const char *desc;
   uint64_t sample_type; // perf sample type: specifies values included in sample
   int type; // perf event type (software / hardware / tracepoint / ... or custom
@@ -125,6 +126,7 @@ enum DDProfCustomCountId { kDDPROF_COUNT_ALLOCATIONS = 0 };
 
 #define X_ENUM(a, b, c, d, e, f, g) DDPROF_PWE_##a,
 typedef enum DDPROF_EVENT_NAMES {
+  DDPROF_PWE_TRACEPOINT = -1,
   EVENT_CONFIG_TABLE(X_ENUM) DDPROF_PWE_LENGTH,
 } DDPROF_EVENT_NAMES;
 #undef X_ENUM
@@ -136,6 +138,7 @@ const PerfWatcher *twatcher_default();
 bool watcher_has_countable_sample_type(const PerfWatcher *watcher);
 bool watcher_has_tracepoint(const PerfWatcher *watcher);
 int watcher_to_count_sample_type_id(const PerfWatcher *watcher);
+const char *event_type_name_from_idx(int idx);
 
 // Helper functions for sample types
 const char *sample_type_name_from_idx(int idx);

--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -136,7 +136,7 @@ static InputResult parse_input(int *argc, char ***argv, DDProfContext *ctx) {
 
   if (ddprof_context_allocation_profiling_watcher_idx(ctx) != -1 &&
       ctx->params.pid && ctx->params.sockfd == -1) {
-    LG_ERR("Memory allocation profiling is not supported in PID mode");
+    LG_ERR("Memory allocation profiling is not supported in PID / global mode");
     return InputResult::kError;
   }
 

--- a/src/lib/dd_profiling.cc
+++ b/src/lib/dd_profiling.cc
@@ -208,8 +208,7 @@ static int ddprof_start_profiling_internal() {
     //  * library create socket pair and fork + exec into ddprof executable
     //  * library sends a message requesting profiler PID and waits for a reply
     //  * ddprof starts up, attaches itself to the target process, then waits
-    //  for
-    //    a PID request and replies
+    //    for a request and replies
     //  * both library and profiler close their socket and continue
     int sockfds[2];
     if (socketpair(AF_UNIX, SOCK_DGRAM, 0, sockfds) == -1) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -182,6 +182,8 @@ add_unit_test(
     ddprof_input-ut
     ../src/ddprof_cmdline.cc
     ../src/ddprof_input.cc
+    ../src/ddprof_context_lib.cc
+    ../src/logger_setup.cc
     ../src/perf_watcher.cc
     ddprof_input-ut.cc
     DEFINITIONS MYNAME="ddprof_input-ut"

--- a/test/ddprof_input-ut.cc
+++ b/test/ddprof_input-ut.cc
@@ -94,7 +94,6 @@ TEST_F(InputTest, dump_fixed) {
       ddprof_input_parse(argc, (char **)input_values, &input, &contine_exec);
   EXPECT_FALSE(IsDDResOK(res));
   EXPECT_FALSE(contine_exec);
-  EXPECT_EQ(input.nb_parsed_params, 2);
   ddprof_input_free(&input);
 }
 

--- a/test/ddprof_input-ut.cc
+++ b/test/ddprof_input-ut.cc
@@ -6,9 +6,12 @@
 #include "ddprof_input.hpp"
 
 #include "constants.hpp"
+#include "ddprof_context.hpp"
+#include "ddprof_context_lib.hpp"
 #include "defer.hpp"
 #include "loghandle.hpp"
 #include "perf_watcher.hpp"
+#include "span.hpp"
 #include "string_view.hpp"
 
 #include <gtest/gtest.h>
@@ -180,5 +183,196 @@ TEST_F(InputTest, event_from_env) {
     EXPECT_EQ(input.watchers[2].sample_period, 456);
 
     ddprof_input_free(&input);
+  }
+}
+
+TEST_F(InputTest, duplicate_events) {
+  defer { unsetenv(k_events_env_variable); };
+  {
+    // Duplicate events (except tracepoints) are disallowed
+    DDProfInput input;
+    bool contine_exec = true;
+    const char *input_values[] = {MYNAME, "-e",       "sCPU,456",
+                                  "-e",   "sCPU,123", "my_program"};
+    DDRes res = ddprof_input_parse(
+        std::size(input_values), (char **)input_values, &input, &contine_exec);
+
+    EXPECT_TRUE(IsDDResOK(res));
+    EXPECT_TRUE(contine_exec);
+
+    DDProfContext ctx;
+    res = ddprof_context_set(&input, &ctx);
+    EXPECT_FALSE(IsDDResOK(res));
+
+    ddprof_input_free(&input);
+    ddprof_context_free(&ctx);
+  }
+  {
+    // Duplicate events (except tracepoints) are disallowed
+    DDProfInput input;
+    bool contine_exec = true;
+    const char *input_values[] = {MYNAME, "-e", "sCPU,456", "my_program"};
+    setenv(k_events_env_variable, "sCPU,1000", 1);
+    DDRes res = ddprof_input_parse(
+        std::size(input_values), (char **)input_values, &input, &contine_exec);
+
+    EXPECT_TRUE(IsDDResOK(res));
+    EXPECT_TRUE(contine_exec);
+
+    DDProfContext ctx;
+    res = ddprof_context_set(&input, &ctx);
+    EXPECT_FALSE(IsDDResOK(res));
+
+    ddprof_input_free(&input);
+    ddprof_context_free(&ctx);
+  }
+}
+
+TEST_F(InputTest, presets) {
+  {
+    // Default preset should be CPU + ALLOC
+    DDProfInput input;
+    bool contine_exec = true;
+    const char *input_values[] = {MYNAME, "my_program"};
+    DDRes res = ddprof_input_parse(
+        std::size(input_values), (char **)input_values, &input, &contine_exec);
+
+    EXPECT_TRUE(IsDDResOK(res));
+    EXPECT_TRUE(contine_exec);
+
+    DDProfContext ctx;
+    res = ddprof_context_set(&input, &ctx);
+    EXPECT_TRUE(IsDDResOK(res));
+
+    ddprof::span watchers{ctx.watchers, static_cast<size_t>(ctx.num_watchers)};
+
+    EXPECT_EQ(watchers.size(), 2);
+    EXPECT_NE(std::find_if(watchers.begin(), watchers.end(),
+                           [](auto &w) {
+                             return w.ddprof_event_type == DDPROF_PWE_sCPU;
+                           }),
+              watchers.end());
+
+    EXPECT_NE(std::find_if(watchers.begin(), watchers.end(),
+                           [](auto &w) {
+                             return w.ddprof_event_type == DDPROF_PWE_sALLOC;
+                           }),
+              watchers.end());
+
+    ddprof_input_free(&input);
+    ddprof_context_free(&ctx);
+  }
+  {
+    // Default preset for PID mode should be CPU
+    DDProfInput input;
+    bool contine_exec = true;
+    const char *input_values[] = {MYNAME, "--pid", "1234", "my_program"};
+    DDRes res = ddprof_input_parse(
+        std::size(input_values), (char **)input_values, &input, &contine_exec);
+
+    EXPECT_TRUE(IsDDResOK(res));
+    EXPECT_TRUE(contine_exec);
+
+    DDProfContext ctx;
+    res = ddprof_context_set(&input, &ctx);
+    EXPECT_TRUE(IsDDResOK(res));
+
+    EXPECT_EQ(ctx.num_watchers, 1);
+    EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
+
+    ddprof_input_free(&input);
+    ddprof_context_free(&ctx);
+  }
+  {
+    // Check cpu_only preset
+    DDProfInput input;
+    bool contine_exec = true;
+    const char *input_values[] = {MYNAME, "--preset", "cpu_only", "my_program"};
+    DDRes res = ddprof_input_parse(
+        std::size(input_values), (char **)input_values, &input, &contine_exec);
+
+    EXPECT_TRUE(IsDDResOK(res));
+    EXPECT_TRUE(contine_exec);
+
+    DDProfContext ctx;
+    res = ddprof_context_set(&input, &ctx);
+    EXPECT_TRUE(IsDDResOK(res));
+
+    ddprof::span watchers{ctx.watchers, static_cast<size_t>(ctx.num_watchers)};
+
+    EXPECT_EQ(ctx.num_watchers, 1);
+    EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
+
+    ddprof_input_free(&input);
+    ddprof_context_free(&ctx);
+  }
+  {
+    // Check alloc_only preset
+    DDProfInput input;
+    bool contine_exec = true;
+    const char *input_values[] = {MYNAME, "--preset", "alloc_only",
+                                  "my_program"};
+    DDRes res = ddprof_input_parse(
+        std::size(input_values), (char **)input_values, &input, &contine_exec);
+
+    EXPECT_TRUE(IsDDResOK(res));
+    EXPECT_TRUE(contine_exec);
+
+    DDProfContext ctx;
+    res = ddprof_context_set(&input, &ctx);
+    EXPECT_TRUE(IsDDResOK(res));
+
+    EXPECT_EQ(ctx.num_watchers, 2);
+    EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sALLOC);
+    EXPECT_EQ(ctx.watchers[1].ddprof_event_type, DDPROF_PWE_sDUM);
+
+    ddprof_input_free(&input);
+    ddprof_context_free(&ctx);
+  }
+  {
+    // Default preset should not be loaded if an event is given in input
+    DDProfInput input;
+    bool contine_exec = true;
+    const char *input_values[] = {MYNAME, "-e", "sCPU", "my_program"};
+    DDRes res = ddprof_input_parse(
+        std::size(input_values), (char **)input_values, &input, &contine_exec);
+
+    EXPECT_TRUE(IsDDResOK(res));
+    EXPECT_TRUE(contine_exec);
+
+    DDProfContext ctx;
+    res = ddprof_context_set(&input, &ctx);
+    EXPECT_TRUE(IsDDResOK(res));
+
+    EXPECT_EQ(ctx.num_watchers, 1);
+    EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
+
+    ddprof_input_free(&input);
+    ddprof_context_free(&ctx);
+  }
+  {
+    // If preset is explicit given in input, then another event with the same
+    // name as one of the preset events should override the preset event values
+    DDProfInput input;
+    bool contine_exec = true;
+    const char *input_values[] = {MYNAME,     "-e",      "sCPU,1234",
+                                  "--preset", "default", "my_program"};
+    DDRes res = ddprof_input_parse(
+        std::size(input_values), (char **)input_values, &input, &contine_exec);
+
+    EXPECT_TRUE(IsDDResOK(res));
+    EXPECT_TRUE(contine_exec);
+
+    DDProfContext ctx;
+    res = ddprof_context_set(&input, &ctx);
+    EXPECT_TRUE(IsDDResOK(res));
+
+    EXPECT_EQ(ctx.num_watchers, 2);
+    EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
+    EXPECT_EQ(ctx.watchers[0].sample_frequency, 1234);
+    EXPECT_EQ(ctx.watchers[1].ddprof_event_type, DDPROF_PWE_sALLOC);
+
+    ddprof_input_free(&input);
+    ddprof_context_free(&ctx);
   }
 }


### PR DESCRIPTION
# What does this PR do?

Add preset profile configurations, at the moment: `default`, `cpu_only`, `alloc_only`
`default` preset includes cpu + allocations in lib mode and wrapper mode, and cpu only in global / pid mode.
`default` preset is used when no preset is given and no event are passed in input (`-e`).
Events defined by a preset set in input are added is not already present in events in input (`-e`).
Duplicated events (except tracepoint) is now an error.
