### PR TITLE
Cause printargs to always print

### DIFF
--- a/include/logger.h
+++ b/include/logger.h
@@ -20,8 +20,16 @@ typedef enum LOG_OPTS {
   LOG_FILE = 4,
 } LOG_OPTS;
 
+
 typedef enum LOG_LVL {
-  LL_EMERGENCY = 0,
+  LL_FORCE_ALERT = -1,
+  LL_FORCE_CRITICAL = -2,
+  LL_FORCE_ERROR = -3,
+  LL_FORCE_WARNING = -4,
+  LL_FORCE_NOTICE = -5,
+  LL_FORCE_INFORMATIONAL = -6,
+  LL_FORCE_DEBUG = -7,
+  LL_EMERGENCY = 0, // No force override because always printed
   LL_ALERT = 1,
   LL_CRITICAL = 2,
   LL_ERROR = 3,
@@ -29,7 +37,7 @@ typedef enum LOG_LVL {
   LL_NOTICE = 5,
   LL_INFORMATIONAL = 6,
   LL_DEBUG = 7,
-  LL_LENGTH
+  LL_LENGTH,
 } LOG_LVL;
 
 typedef enum LOG_FACILITY {
@@ -86,11 +94,16 @@ int LOG_getlevel();
 void LOG_setfacility(int);
 
 /******************************* Logging Macros *******************************/
+#define ABS(__x) ({                                                            \
+  typeof(__x) _x = (__x);                                                      \
+  _x < 0 ? -1 * _x : _x;                                                           \
+})
+
 // Avoid calling arguments (which can have CPU costs unless level is OK)
 #define LG_IF_LVL_OK(level, ...)                                               \
   do {                                                                         \
-    if (unlikely(level <= LOG_getlevel() && level >= 0)) {                     \
-      olprintfln(level, -1, MYNAME, __VA_ARGS__);                              \
+    if (unlikely(level <= LOG_getlevel())) {                                   \
+      olprintfln(ABS(level), -1, MYNAME, __VA_ARGS__);                         \
     }                                                                          \
   } while (false)
 
@@ -99,3 +112,4 @@ void LOG_setfacility(int);
 #define LG_NTC(...) LG_IF_LVL_OK(LL_NOTICE, __VA_ARGS__)
 #define LG_NFO(...) LG_IF_LVL_OK(LL_INFORMATIONAL, __VA_ARGS__)
 #define LG_DBG(...) LG_IF_LVL_OK(LL_DEBUG, __VA_ARGS__)
+#define PRINT_NFO(...) LG_IF_LVL_OK(-1 * LL_INFORMATIONAL, __VA_ARGS__)

--- a/src/ddprof_context_lib.cc
+++ b/src/ddprof_context_lib.cc
@@ -198,22 +198,22 @@ DDRes ddprof_context_set(DDProfInput *input, DDProfContext *ctx) {
 
   // Process input printer (do this right before argv/c modification)
   if (input->show_config && arg_yesno(input->show_config, 1)) {
-    LG_NFO("Printing parameters -->");
+    PRINT_NFO("Printing parameters -->");
     ddprof_print_params(input);
 
-    LG_NFO("  Native profiler enabled: %s",
+    PRINT_NFO("  Native profiler enabled: %s",
            ctx->params.enable ? "true" : "false");
 
     // Tell the user what mode is being used
-    LG_NFO("  Profiling mode: %s",
+    PRINT_NFO("  Profiling mode: %s",
            -1 == ctx->params.pid ? "global"
                : pid_tmp         ? "target"
                                  : "wrapper");
 
     // Show watchers
-    LG_NFO("  Instrumented with %d watchers:", ctx->num_watchers);
+    PRINT_NFO("  Instrumented with %d watchers:", ctx->num_watchers);
     for (int i = 0; i < ctx->num_watchers; i++) {
-      LG_NFO("    ID: %s, Pos: %d, Index: %lu, Label: %s",
+      PRINT_NFO("    ID: %s, Pos: %d, Index: %lu, Label: %s",
              ctx->watchers[i].desc, i, ctx->watchers[i].config,
              sample_type_name_from_idx(ctx->watchers[i].sample_type_id));
     }

--- a/src/ddprof_input.cc
+++ b/src/ddprof_input.cc
@@ -63,7 +63,7 @@ extern "C" {
 #define X_PRNT(a, b, c, d, e, f, g, h, i)                                      \
   {                                                                            \
     if ((f)->i b) {                                                            \
-      LG_NFO("  " #b ": %s", (f)->i b);                                        \
+      PRINT_NFO("  " #b ": %s", (f)->i b);                                     \
     }                                                                          \
   }
 


### PR DESCRIPTION
# What does this PR do?

Two things
 * Allow the logging interfaces to print, regardless of the user's specified log level
 * Have the printargs interfaces always print, presuming that the user's indication to log means they want the configuration regardless of their specified log level

# Motivation

Right now it's really annoying to get the configuration without also signing up for very verbose logs.

# Additional Notes

Questions
* Should configuration be printed _also_ when the user has informational level or greater for logs?  Right now it only prints when the user requests it
* Are there other obvious places where output should be forced (not necessarily at the INFORMATIONAL level)
* Is INFORMATIONAL the correct level for printargs?

# How to test the change?

idk lol (will add)