### PR TITLE
Reduce number of backpopulates

### DIFF
--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -116,7 +116,7 @@ public:
   // find or parse procfs if allowed
   DsoFindRes dso_find_or_backpopulate(pid_t pid, ElfAddress_t addr);
 
-  void reset_backpopulate_state() { _backpopulate_state_map.clear(); }
+  void reset_backpopulate_state();
   /******* HELPERS **********/
   // Find the dso if same
   static DsoFindRes dso_find_adjust_same(DsoMap &map, const Dso &dso);
@@ -160,6 +160,7 @@ private:
 
   struct BackpopulateState {
     BackpopulateState() : _nbUnfoundDsos(), _perm(kAllowed) {}
+    static const int _k_nb_requests_between_backpopulates = 10;
     int _nbUnfoundDsos;
     BackpopulatePermission _perm;
   };

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -525,4 +525,14 @@ int DsoHdr::get_nb_dso() const {
   });
   return total_nb_elts;
 }
+
+void DsoHdr::reset_backpopulate_state() {
+  for (auto &el : _backpopulate_state_map) {
+    if (el.second._nbUnfoundDsos >
+        BackpopulateState::_k_nb_requests_between_backpopulates) {
+      el.second = BackpopulateState();
+    }
+  }
+}
+
 } // namespace ddprof


### PR DESCRIPTION

# What does this PR do?
Avoid clearing the full state for backpopulates. Instead indicate it is allowed
Also only clear for elements that were requested in backpopulate.

# Motivation

 The aim is to prevent 
- full backpopulate for all pids
- backpopulate on pids that have few / no samples

# Additional Notes

This was spoted by @nsavoire as a bug introduced in previous PR forcing a backpopulate if we did not see the element in the maps

# How to test the change?

Describe here in detail how the change can be validated.  This is a great section to call out specific tests you've added or improved, or to acknowledge code sections which are particularly difficult to test.
