### PR TITLE
Compute ranges in mappings ignoring anonymous regions

### DIFF
--- a/include/ddprof_worker_context.hpp
+++ b/include/ddprof_worker_context.hpp
@@ -27,7 +27,7 @@ struct DDProfWorkerContext {
   UserTags *user_tags;
   ProcStatus proc_status;
   std::chrono::steady_clock::time_point
-      cycle_start_time;  // time at which current export cycle was started
-  int64_t send_nanos;    // Last time an export was sent
-  uint32_t count_worker; // exports since last cache clear
+      cycle_start_time;   // time at which current export cycle was started
+  int64_t send_nanos;     // Last time an export was sent
+  uint32_t count_worker;  // exports since last cache clear
 };

--- a/include/ddprof_worker_context.hpp
+++ b/include/ddprof_worker_context.hpp
@@ -27,7 +27,7 @@ struct DDProfWorkerContext {
   UserTags *user_tags;
   ProcStatus proc_status;
   std::chrono::steady_clock::time_point
-      cycle_start_time;   // time at which current export cycle was started
-  int64_t send_nanos;     // Last time an export was sent
-  uint32_t count_worker;  // exports since last cache clear
+      cycle_start_time;  // time at which current export cycle was started
+  int64_t send_nanos;    // Last time an export was sent
+  uint32_t count_worker; // exports since last cache clear
 };

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -243,21 +243,36 @@ DDProfModRange DsoHdr::compute_mod_range(DsoMapConstIt it, const DsoMap &map) {
     return DDProfModRange();
   }
   DsoMapConstIt first_el = it;
-  while (first_el != map.begin()) {
-    --first_el;
-    if (it->second._filename != first_el->second._filename) {
-      ++first_el;
-      break;
+  {
+    DsoMapConstIt loop_el = first_el;
+    while (loop_el != map.begin()) {
+      --loop_el;
+      // there can be anonymous regions in the middle of the mapping
+      if (loop_el->second._type != dso::DsoType::kAnon &&
+          it->second._filename != loop_el->second._filename) {
+        break;
+      }
+      if (it->second._filename == loop_el->second._filename) {
+        first_el = loop_el;
+      }
     }
   }
-  while (++it != map.end()) {
-    if (it->second._filename != first_el->second._filename) {
-      break;
+
+  DsoMapConstIt last_el = it;
+  {
+    DsoMapConstIt loop_el = last_el;
+    while (++loop_el != map.end()) {
+      if (loop_el->second._type != dso::DsoType::kAnon &&
+          it->second._filename != loop_el->second._filename) {
+        break;
+      }
+      if (it->second._filename == loop_el->second._filename) {
+        last_el = loop_el;
+      }
     }
   }
-  --it; // back up from end element (or different file)
   return DDProfModRange{._low_addr = first_el->second._start,
-                        ._high_addr = it->second._end};
+                        ._high_addr = last_el->second._end};
 }
 
 // Find the lowest and highest for this given DSO

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -242,19 +242,37 @@ DDProfModRange DsoHdr::compute_mod_range(DsoMapConstIt it, const DsoMap &map) {
   if (it == map.end()) {
     return DDProfModRange();
   }
-  const Dso *dso = nullptr;
-  auto func = [&](auto &x) {
-    if (x.second._filename == it->second._filename) {
-      dso = &x.second;
-      return false;
-    };
-    return x.second._type != dso::DsoType::kAnon;
-  };
-  std::find_if(it, std::end(map), func);
-  ProcessAddress_t high_addr = dso->_end;
-  std::find_if(std::make_reverse_iterator(std::next(it)), std::rend(map), func);
-  ProcessAddress_t low_addr = dso->_start;
-  return DDProfModRange{._low_addr = low_addr, ._high_addr = high_addr};
+  DsoMapConstIt first_el = it;
+  {
+    DsoMapConstIt loop_el = first_el;
+    while (loop_el != map.begin()) {
+      --loop_el;
+      // there can be anonymous regions in the middle of the mapping
+      if (loop_el->second._type != dso::DsoType::kAnon &&
+          it->second._filename != loop_el->second._filename) {
+        break;
+      }
+      if (it->second._filename == loop_el->second._filename) {
+        first_el = loop_el;
+      }
+    }
+  }
+
+  DsoMapConstIt last_el = it;
+  {
+    DsoMapConstIt loop_el = last_el;
+    while (++loop_el != map.end()) {
+      if (loop_el->second._type != dso::DsoType::kAnon &&
+          it->second._filename != loop_el->second._filename) {
+        break;
+      }
+      if (it->second._filename == loop_el->second._filename) {
+        last_el = loop_el;
+      }
+    }
+  }
+  return DDProfModRange{._low_addr = first_el->second._start,
+                        ._high_addr = last_el->second._end};
 }
 
 // Find the lowest and highest for this given DSO

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -380,4 +380,45 @@ TEST(DSOTest, exe_name) {
   EXPECT_TRUE(found_exe);
   LG_NTC("%s", exe_name.c_str());
 }
+
+// clang-format off
+
+// We need to find bounds regardless of anon regions in the middle
+// 7f8db8da9000-7f8db8dcb000 r-xp 00000000 00:3e 6559274                    /usr/lib64/ld-2.17.so
+// 7f8db8fc3000-7f8db8fc6000 rw-p 00000000 00:00 0
+// 7f8db8fc7000-7f8db8fca000 rw-p 00000000 00:00 0
+// 7f8db8fca000-7f8db8fcb000 r--p 00021000 00:3e 6559274                    /usr/lib64/ld-2.17.so
+// 7f8db8fcb000-7f8db8fcc000 rw-p 00022000 00:3e 6559274                    /usr/lib64/ld-2.17.so
+
+
+
+//   Dso no_exec =
+//      DsoHdr::dso_from_procline(10, const_cast<char *>(s_line_noexec));
+
+static const char *s_split_ld_line[] = {
+    "7f8db8da9000-7f8db8dcb000 r-xp 00000000 00:3e 6559274                    /usr/lib64/ld-2.17.so",
+    "7f8db8fc3000-7f8db8fc6000 rw-p 00000000 00:00 0",
+    "7f8db8fc7000-7f8db8fca000 rw-p 00000000 00:00 0",
+    "7f8db8fca000-7f8db8fcb000 r--p 00021000 00:3e 6559274                    /usr/lib64/ld-2.17.so",
+    "7f8db8fcb000-7f8db8fcc000 rw-p 00022000 00:3e 6559274                    /usr/lib64/ld-2.17.so",
+    "7f8db8fcc000-7f8db8fcf000 rw-p 00000000 00:3e 6559274                    //anon"
+  };
+// clang-format on
+
+TEST(DSOTest, split_range) {
+  LogHandle handle;
+  DsoHdr dso_hdr;
+  size_t  nb_dso = sizeof(s_split_ld_line) / (sizeof(*s_split_ld_line));
+  for (unsigned i = 0; i < nb_dso; ++i) {
+    dso_hdr.insert_erase_overlap(
+        DsoHdr::dso_from_procline(10, const_cast<char *>(s_split_ld_line[i])));
+  }
+  auto& map = dso_hdr._map[10];
+  auto find_res = dso_hdr.dso_find_closest(map, 10, 0x7f8db8fca0a0);
+  DDProfModRange mod_range = dso_hdr.compute_mod_range(find_res.first, map);
+  LG_DBG("%lx - %lx", mod_range._low_addr, mod_range._high_addr);
+  EXPECT_EQ(mod_range._low_addr, 0x7f8db8da9000);
+  EXPECT_EQ(mod_range._high_addr, 0x7f8db8fcbfff);
+}
+
 } // namespace ddprof


### PR DESCRIPTION
# What does this PR do?

Consider that the mappings can have anon regions that separate valid regions

# Motivation

Fix the computation of the range to avoid loading the modules at the bad address.

# Additional Notes

This was suggested by @nsavoire 

# How to test the change?

I added a unit test
