### PR TITLE
Remove backpopulate state reset every 200 samples

### DIFF
--- a/include/ddprof_worker_context.hpp
+++ b/include/ddprof_worker_context.hpp
@@ -30,5 +30,4 @@ struct DDProfWorkerContext {
       cycle_start_time;   // time at which current export cycle was started
   int64_t send_nanos;     // Last time an export was sent
   uint32_t count_worker;  // exports since last cache clear
-  uint32_t count_samples; // sample count to avoid bouncing on backpopulates
 };

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -44,7 +44,6 @@ static const DDPROF_STATS s_cycled_stats[] = {STATS_UNWIND_CPU_USAGE,
                                               STATS_TARGET_CPU_USAGE};
 
 static const long k_clock_ticks_per_sec = sysconf(_SC_CLK_TCK);
-static const unsigned s_nb_samples_per_backpopulate = 200;
 
 /// Human readable runtime information
 static void print_diagnostics(const DsoHdr &dso_hdr) {
@@ -527,13 +526,6 @@ DDRes ddprof_worker_process_event(struct perf_event_header *hdr,
       break;
     default:
       break;
-    }
-
-    // backpopulate if needed
-    if (++ctx->worker_ctx.count_samples > s_nb_samples_per_backpopulate) {
-      // allow new backpopulates and reset counter
-      ctx->worker_ctx.us->dso_hdr.reset_backpopulate_state();
-      ctx->worker_ctx.count_samples = 0;
     }
   }
   CatchExcept2DDRes();


### PR DESCRIPTION

# What does this PR do?

We were keeping a backpopulate state per PID. By reseting, were were looping over all PIDs every 200 samples, this was causing a large overhead. 

This is related to the recent update in the way we cleared backpopulate states which increased overhead.

The overhead was investigated on a large machine, where we need to consider 90 CPUs of activity.
We will now only clear backpopulate state at every cycle (59 seconds). 

# Motivation

Reduce overhead

# Additional Notes

This could reduce accuracy in mappings. 

# How to test the change?

I tested this in whole host mode (where the problem is the most obvious) on debug PODs
