### PR TITLE
Avoid filtering mmap events

### DIFF
--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -367,7 +367,8 @@ DDRes ddprof_worker_cycle(DDProfContext *ctx, int64_t now,
 }
 
 void ddprof_pr_mmap(DDProfContext *ctx, perf_event_mmap *map, int watcher_pos) {
-  if (!(map->header.misc & PERF_RECORD_MISC_MMAP_DATA)) {
+  static constexpr std::string_view anon_str{"//anon"};
+  if (map->filename != anon_str) {
     LG_DBG("<%d>(MAP)%d: %s (%lx/%lx/%lx)", watcher_pos, map->pid,
            map->filename, map->addr, map->len, map->pgoff);
     ddprof::Dso new_dso(map->pid, map->addr, map->addr + map->len - 1,

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -367,14 +367,12 @@ DDRes ddprof_worker_cycle(DDProfContext *ctx, int64_t now,
 }
 
 void ddprof_pr_mmap(DDProfContext *ctx, perf_event_mmap *map, int watcher_pos) {
-  static constexpr std::string_view anon_str{"//anon"};
-  if (map->filename != anon_str) {
-    LG_DBG("<%d>(MAP)%d: %s (%lx/%lx/%lx)", watcher_pos, map->pid,
-           map->filename, map->addr, map->len, map->pgoff);
-    ddprof::Dso new_dso(map->pid, map->addr, map->addr + map->len - 1,
-                        map->pgoff, std::string(map->filename));
-    ctx->worker_ctx.us->dso_hdr.insert_erase_overlap(std::move(new_dso));
-  }
+  LG_DBG("<%d>(MAP)%d: %s (%lx/%lx/%lx)", watcher_pos, map->pid, map->filename,
+         map->addr, map->len, map->pgoff);
+  ddprof::Dso new_dso(map->pid, map->addr, map->addr + map->len - 1, map->pgoff,
+                      std::string(map->filename),
+                      !(map->header.misc & PERF_RECORD_MISC_MMAP_DATA));
+  ctx->worker_ctx.us->dso_hdr.insert_erase_overlap(std::move(new_dso));
 }
 
 void ddprof_pr_lost(DDProfContext *, perf_event_lost *lost, int) {

--- a/test/read_past_sp-ut.sh
+++ b/test/read_past_sp-ut.sh
@@ -12,10 +12,12 @@ while kill -0 "$p" 2> /dev/null; do sleep 0.05s; done
 
 v=$(grep "datadog[.]profiling[.]native[.]unwind[.]stack[.]incomplete: *[0-9]*" -o log | awk -F: '{print $2}')
 if [[ -z "$v" ]]; then
+    cat log
     echo "Could not find metrics"
     exit 1
 # allow at most 3 incomplete stacks
 elif [[ "$v" -gt 3 ]]; then
+    cat log
     echo "Found incomplete stacks"
     exit 1
 fi


### PR DESCRIPTION
Previously we were only processing mmap events with executable permissions,
but in order to correctly get module base address we also need data
section mmappings.
