### PR TITLE
Fix LD_PRELOAD failure due to permissions on /proc/<ddprof_pid>/fd/

### DIFF
--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -211,6 +211,7 @@ static int start_profiler_internal(DDProfContext *ctx, bool &is_profiler) {
           preload_str.append(";");
           preload_str.append(s);
         }
+        LG_DBG("Setting LD_PRELOAD=%s", preload_str.c_str());
         setenv("LD_PRELOAD", preload_str.c_str(), 1);
         auto sock_str = std::to_string(sockfds[kParentIdx]);
         setenv(k_profiler_lib_socket_env_variable, sock_str.c_str(), 1);

--- a/src/user_override.cc
+++ b/src/user_override.cc
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <pwd.h>
 #include <string.h>
+#include <sys/prctl.h>
 #include <unistd.h>
 
 static char const *const s_user_nobody = "nobody";
@@ -23,6 +24,28 @@ static const uid_t s_root_user = 0;
 void init_uidinfo(UIDInfo *user_override) {
   user_override->override = false;
   user_override->previous_user = getuid();
+}
+
+static DDRes setresuid_wrapper(uid_t ruid, uid_t euid, uid_t suid) {
+  int dumpable = prctl(PR_GET_DUMPABLE);
+  DDRES_CHECK_INT(setresuid(ruid, euid, suid), DD_WHAT_USERID,
+                  "Unable to set user %s (%s)", s_user_nobody, strerror(errno));
+  // Changing the effective user id causes the dumpable attribute of the process
+  // to be reset to the value of /proc/sys/fs/suid_dumpable (usually 0, cf.
+  // https://man7.org/linux/man-pages/man2/prctl.2.html), which in turn makes
+  // /proc/self/fd/* files unreadable by parent processes.
+  // Note that this is quite strange since with dumpable
+  // attribute set to 0, ownership of /proc<pid>/ is set to root, this should
+  // to be an issue since we change euid only when root, but strangely doing
+  // this, parent process loses the permission to read /proc/<ddprof_pid>/fd/*
+  // (but not /proc/<ddprof_pid>/maps).
+  // When injecting libdd_profiling.so into target process, we use
+  // LD_PRELOAD=/proc/<ddprof_pid>/fd/<temp_file>, and therefore target process
+  // (ie. parent process) needs to be able to read ddprof /proc/<pid>/fd/*,
+  // that's why we set dumpable attribute back to its intial value at each
+  // effective user id change.
+  prctl(PR_SET_DUMPABLE, dumpable);
+  return {};
 }
 
 DDRes user_override(UIDInfo *user_override) {
@@ -39,8 +62,7 @@ DDRes user_override(UIDInfo *user_override) {
                            s_user_nobody);
   }
   uid_t nobodyuid = pwd->pw_uid;
-  DDRES_CHECK_INT(setresuid(nobodyuid, nobodyuid, -1), DD_WHAT_USERID,
-                  "Unable to set user %s (%s)", s_user_nobody, strerror(errno));
+  DDRES_CHECK_FWD(setresuid_wrapper(nobodyuid, nobodyuid, -1));
   user_override->override = true;
 
   return ddres_init();
@@ -52,8 +74,8 @@ DDRes revert_override(UIDInfo *user_override) {
     return ddres_init();
   }
   uid_t uid_old = user_override->previous_user;
-  DDRES_CHECK_INT(setresuid(uid_old, uid_old, -1), DD_WHAT_USERID,
-                  "Unable to set user %s (%s)", s_user_nobody, strerror(errno));
+  DDRES_CHECK_FWD(setresuid_wrapper(uid_old, uid_old, -1));
   init_uidinfo(user_override);
+
   return ddres_init();
 }


### PR DESCRIPTION
# What does this PR do?

Permissions to read /proc/<pid>/fd are influenced by process's dumpable attribute
(cf. https://man7.org/linux/man-pages/man5/proc.5.html).
When changing the effective user ID, dumpable attribute is reset to /proc/sys/fs/suid_dumpable
(usually 0, cf. https://man7.org/linux/man-pages/man2/prctl.2.html). With dumpable
attribute set to 0, ownership of /proc<pid>/ is set to root, this should to be an issue
since we change euid only when root, but strangely doing this, parent process loses the permission
to read /proc/<ddprof_pid>/fd/* (but not /proc/<ddprof_pid>/maps).
The workaround is to reset dumpable attribute to its initial value after each effective
user ID change.
