### PR TITLE
Fix deadlock in pthread_getattr_np

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ list(APPEND DDPROF_INCLUDE_LIST ${LIBCAP_INCLUDE_DIR})
 set(DD_PROFILING_SOURCES src/lib/dd_profiling.cc src/daemonize.cc src/ddprof_cmdline.cc src/logger.cc src/logger_setup.cc 
                          src/ipc.cc src/pevent_lib.cc src/perf.cc src/perf_ringbuffer.cc src/perf_watcher.cc src/ringbuffer_utils.cc src/sys_utils.cc
                          src/user_override.cc src/ddres_list.cc src/savecontext.cc src/saveregisters.cc src/signal_helper.cc
-                         src/lib/malloc_wrapper.cc src/lib/allocation_tracker.cc)
+                         src/lib/malloc_wrapper.cc src/lib/allocation_tracker.cc src/lib/pthread_hook.cc )
 
 add_library(dd_profiling-embedded SHARED ${DD_PROFILING_SOURCES})
 target_include_directories(dd_profiling-embedded PUBLIC ${CMAKE_SOURCE_DIR}/include/lib ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/third_party)

--- a/cmake/dd_profiling.version
+++ b/cmake/dd_profiling.version
@@ -1,4 +1,4 @@
 {
-  global: ddprof_start_profiling; ddprof_stop_profiling; malloc; realloc; free; calloc; reallocarray; posix_memalign; memalign; aligned_alloc; pvalloc; valloc;
+  global: ddprof_start_profiling; ddprof_stop_profiling; malloc; realloc; free; calloc; reallocarray; posix_memalign; memalign; aligned_alloc; pvalloc; valloc; pthread_create;
   local: *;
 };

--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -23,7 +23,7 @@ struct TrackerThreadLocalState {
   int64_t remaining_bytes; // remaining allocation bytes until next sample
   bool remaining_bytes_initialized; // false if remaining_bytes is not
                                     // initialized
-
+  const std::byte *stack_end;
   pid_t tid; // cache of tid
 
   bool reentry_guard; // prevent reentry in AllocationTracker (eg. when
@@ -32,6 +32,7 @@ struct TrackerThreadLocalState {
 
 class AllocationTracker {
 public:
+  friend class AllocationTrackerDisablerForCurrentThread;
   AllocationTracker(const AllocationTracker &) = delete;
   AllocationTracker &operator=(const AllocationTracker &) = delete;
 
@@ -39,6 +40,8 @@ public:
     kTrackDeallocations = 0x1,
     kDeterministicSampling = 0x2
   };
+
+  static void notify_thread_start();
 
   static DDRes allocation_tracking_init(uint64_t allocation_profiling_rate,
                                         uint32_t flags,

--- a/include/savecontext.hpp
+++ b/include/savecontext.hpp
@@ -12,7 +12,11 @@
 #include "perf_archmap.hpp"
 #include "span.hpp"
 
+/** Cache stack end from current thread in TLS for future use */
+DDPROF_NOIPO const std::byte *retrieve_stack_end_address();
+
 /** Save registers and stack for remote unwinding
  * Return saved stack size */
-DDPROF_NOIPO size_t save_context(ddprof::span<uint64_t, PERF_REGS_COUNT> regs,
+DDPROF_NOIPO size_t save_context(const std::byte *stack_end,
+                                 ddprof::span<uint64_t, PERF_REGS_COUNT> regs,
                                  ddprof::span<std::byte> buffer);

--- a/src/lib/malloc_wrapper.cc
+++ b/src/lib/malloc_wrapper.cc
@@ -3,16 +3,16 @@
 // developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
 // Datadog, Inc.
 
+#include "allocation_tracker.hpp"
+#include "ddprof_base.hpp"
+#include "unlikely.hpp"
+
 #include <atomic>
 #include <cassert>
 #include <cstddef>
 #include <cstdlib>
 #include <dlfcn.h>
 #include <malloc.h>
-
-#include "allocation_tracker.hpp"
-#include "ddprof_base.hpp"
-#include "unlikely.hpp"
 
 // Declaration of reallocarray is only available starting from glibc 2.28
 extern "C" {

--- a/src/lib/pthread_hook.cc
+++ b/src/lib/pthread_hook.cc
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include "allocation_tracker.hpp"
+
+#include <dlfcn.h>
+#include <pthread.h>
+#include <tuple>
+
+namespace {
+using Args = std::tuple<void *(*)(void *), void *>;
+
+void *mystart(void *arg) {
+  ddprof::AllocationTracker::notify_thread_start();
+  Args *args = reinterpret_cast<Args *>(arg);
+  auto [start_routine, start_arg] = *args;
+  delete args;
+  return start_routine(start_arg);
+}
+
+} // namespace
+
+/** Hook pthread_create to cache stack end address just after thread start.
+ *
+ * The rationale is to fix a deadlock that occurs when user code in created
+ * thread calls pthread_getattr:
+ * - pthread_getattr takes a lock in pthread object
+ * - pthread_getattr itself does an allocation
+ * - AllocationTracker tracks the allocation and calls savecontext
+ * - savecontext calls pthread_getattr to get stack end address
+ * - pthread_getattr is reentered and attempts to take the lock again leading to
+ * a deadlock.
+ *
+ * Workaround is to hook pthread_create and call `cache_stack_end` to
+ * cache stack end address while temporarily disabling allocation profiling for
+ * current thread before calling user code.
+ * */
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                   void *(*start_routine)(void *), void *arg) noexcept {
+  static decltype(&::pthread_create) s_pthread_create;
+  if (!s_pthread_create) {
+    s_pthread_create = reinterpret_cast<decltype(&::pthread_create)>(
+        dlsym(RTLD_NEXT, "pthread_create"));
+  }
+  Args *args = new (std::nothrow) Args{start_routine, arg};
+  return args ? s_pthread_create(thread, attr, &mystart, args)
+              : s_pthread_create(thread, attr, start_routine, arg);
+}

--- a/src/savecontext.cc
+++ b/src/savecontext.cc
@@ -6,6 +6,7 @@
 #include "savecontext.hpp"
 
 #include "ddprof_base.hpp"
+#include "defer.hpp"
 #include "saveregisters.hpp"
 #include "unlikely.hpp"
 
@@ -15,13 +16,18 @@
 
 // Return stack end address (stack end address is the start of the stack since
 // stack grows down)
-DDPROF_NOINLINE static const std::byte *get_stack_end_address() {
+DDPROF_NOINLINE const std::byte *retrieve_stack_end_address() {
   void *stack_addr;
   size_t stack_size;
   pthread_attr_t attrs;
-  pthread_getattr_np(pthread_self(), &attrs);
-  pthread_attr_getstack(&attrs, &stack_addr, &stack_size);
-  pthread_attr_destroy(&attrs);
+  if (pthread_getattr_np(pthread_self(), &attrs) != 0) {
+    return nullptr;
+  }
+  defer { pthread_attr_destroy(&attrs); };
+  if (pthread_attr_getstack(&attrs, &stack_addr, &stack_size) != 0) {
+    return nullptr;
+  }
+
   return static_cast<std::byte *>(stack_addr) + stack_size;
 }
 
@@ -30,29 +36,28 @@ DDPROF_NOINLINE static const std::byte *get_stack_end_address() {
 // intercepts memcpy and reports a satck underflow there, empirically it appears
 // that both attribute and a suppression are required.
 static DDPROF_NO_SANITIZER_ADDRESS size_t
-save_stack(const std::byte *stack_ptr, ddprof::span<std::byte> buffer) {
-  // Use a thread local variable to cache the stack end address per thread
-  thread_local static const std::byte *stack_end{};
-
-  if (unlikely(!stack_end)) {
-    // Slow path, takes ~30us
-    stack_end = get_stack_end_address();
-  }
-
+save_stack(const std::byte *stack_end, const std::byte *stack_ptr,
+           ddprof::span<std::byte> buffer) {
   // take the min of current stack size and requested stack sample size
-  size_t saved_stack_size =
+  int64_t saved_stack_size =
       std::min(static_cast<intptr_t>(buffer.size()), stack_end - stack_ptr);
+
+  if (saved_stack_size <= 0) {
+    return 0;
+  }
   // Use memmove to stay on the safe side on case caller put `buffer` on the
   // stack
   memmove(buffer.data(), stack_ptr, saved_stack_size);
   return saved_stack_size;
 }
 
-size_t save_context(ddprof::span<uint64_t, PERF_REGS_COUNT> regs,
+size_t save_context(const std::byte *stack_end,
+                    ddprof::span<uint64_t, PERF_REGS_COUNT> regs,
                     ddprof::span<std::byte> buffer) {
   save_registers(regs);
   // save the stack just after saving registers, stack part above saved SP must
   // no be changed between call to save_registers and call to save_stack
-  return save_stack(reinterpret_cast<const std::byte *>(regs[REGNAME(SP)]),
+  return save_stack(stack_end,
+                    reinterpret_cast<const std::byte *>(regs[REGNAME(SP)]),
                     buffer);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ enable_testing()
 # https://github.com/google/sanitizers/issues/703
 option(DDPROF_DETECT_LEAK "Parameter for leak detection." 1)
 
-### Code coverage
+# Code coverage
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Coverage")
     message(STATUS "Activating code coverage in tests")
     include(CodeCoverage)
@@ -21,7 +21,7 @@ if("${CMAKE_BUILD_TYPE}" STREQUAL "Coverage")
     )
 endif()
 
-#### Define functions ####
+# Define functions
 
 #[[ Create a unit test
 Syntax:
@@ -35,25 +35,25 @@ add_unit_test(myexe src1.cpp)
 add_unit_test(myexe src1.cpp DEFINITIONS UNIT_TEST)
 #]]
 function(add_unit_test name)
-   set(options NO_DETECT_LEAKS)
-   set(oneValueArgs)
-   set(multiValueArgs)
-   cmake_parse_arguments(PARSE_ARGV 1 MY "${options}" "${oneValueArgs}" "${multiValueArgs}")
-   message(STATUS "Creating unit test : " ${name})
+    set(options NO_DETECT_LEAKS)
+    set(oneValueArgs)
+    set(multiValueArgs)
+    cmake_parse_arguments(PARSE_ARGV 1 MY "${options}" "${oneValueArgs}" "${multiValueArgs}")
+    message(STATUS "Creating unit test : " ${name})
 
-   ## Create exe with sources. Always add logger and error management in the unit tests
-   add_exe(${name}
+    # # Create exe with sources. Always add logger and error management in the unit tests
+    add_exe(${name}
         ../src/ddres_list.cc
         ../src/logger.cc
         ${MY_UNPARSED_ARGUMENTS})
 
-   target_link_libraries(${name} PRIVATE gtest Threads::Threads gmock_main gmock)
-   target_include_directories(${name} PRIVATE ${DDPROF_INCLUDE_LIST} ${GTEST_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/include/lib)
+    target_link_libraries(${name} PRIVATE gtest Threads::Threads gmock_main gmock)
+    target_include_directories(${name} PRIVATE ${DDPROF_INCLUDE_LIST} ${GTEST_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/include/lib)
 
-   add_test(NAME ${name} COMMAND ${name})
-   set_tests_properties(${name} PROPERTIES
-                        ENVIRONMENT "UBSAN_OPTIONS=halt_on_error=1 abort_on_error=1 print_stacktrace=1;LSAN_OPTIONS=detect_leaks=$<BOOL:${DDPROF_DETECT_LEAK}> malloc_context_size=2 print_suppressions=0;ASAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/cmake/asan.supp")
-   disable_clangtidy(${name})
+    add_test(NAME ${name} COMMAND ${name})
+    set_tests_properties(${name} PROPERTIES
+        ENVIRONMENT "UBSAN_OPTIONS=halt_on_error=1 abort_on_error=1 print_stacktrace=1;LSAN_OPTIONS=detect_leaks=$<BOOL:${DDPROF_DETECT_LEAK}> malloc_context_size=2 print_suppressions=0;ASAN_OPTIONS=suppressions=${CMAKE_SOURCE_DIR}/cmake/asan.supp")
+    disable_clangtidy(${name})
 endfunction()
 
 #[[ Create a benchmark
@@ -68,24 +68,24 @@ add_benchmark(myexe src1.cpp)
 add_benchmark(myexe src1.cpp DEFINITIONS UNIT_TEST)
 #]]
 function(add_benchmark name)
-   set(options)
-   set(oneValueArgs)
-   set(multiValueArgs)
-   cmake_parse_arguments(PARSE_ARGV 1 MY "${options}" "${oneValueArgs}" "${multiValueArgs}")
-   message(STATUS "Creating unit test : " ${name})
+    set(options)
+    set(oneValueArgs)
+    set(multiValueArgs)
+    cmake_parse_arguments(PARSE_ARGV 1 MY "${options}" "${oneValueArgs}" "${multiValueArgs}")
+    message(STATUS "Creating unit test : " ${name})
 
-   ## Create exe with sources. Always add logger and error management in the unit tests
-   add_exe(${name}
+    # # Create exe with sources. Always add logger and error management in the unit tests
+    add_exe(${name}
         ../src/ddres_list.cc
         ../src/logger.cc
         ${MY_UNPARSED_ARGUMENTS})
 
-   target_link_libraries(${name} PRIVATE Threads::Threads benchmark::benchmark benchmark::benchmark_main)
-   target_include_directories(${name} PRIVATE ${DDPROF_INCLUDE_LIST})
-   disable_clangtidy(${name})
+    target_link_libraries(${name} PRIVATE Threads::Threads benchmark::benchmark benchmark::benchmark_main)
+    target_include_directories(${name} PRIVATE ${DDPROF_INCLUDE_LIST})
+    disable_clangtidy(${name})
 endfunction()
 
-#### Definition of unit tests ####
+# Definition of unit tests
 add_compile_definitions("UNIT_TEST_DATA=\"${CMAKE_CURRENT_SOURCE_DIR}/data\"")
 
 add_unit_test(
@@ -245,7 +245,6 @@ add_unit_test(
     DEFINITIONS MYNAME="dso-ut")
 target_include_directories(dso-ut PRIVATE ${LIBCAP_INCLUDE_DIR})
 
-
 add_unit_test(
     tags-ut
     tags-ut.cc
@@ -356,7 +355,7 @@ add_unit_test(
     sys_utils-ut
     sys_utils-ut.cc
     ../src/sys_utils.cc
-    )
+)
 
 add_unit_test(
     ringbuffer-ut
@@ -380,9 +379,15 @@ add_benchmark(savecontext-bench savecontext-bench.cc ../src/savecontext.cc ../sr
 add_benchmark(timer-bench timer-bench.cc ../src/timer.cc ../src/perf.cc)
 
 add_exe(simple_malloc-static simple_malloc.cc
-        LIBRARIES Threads::Threads dd_profiling-static)
+    LIBRARIES Threads::Threads dd_profiling-static)
 
-if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+if(NOT CMAKE_BUILD_TYPE STREQUAL "SanitizedDebug")
+    add_exe(pthread_deadlock pthread_deadlock.cc
+        LIBRARIES Threads::Threads)
+    add_test(NAME pthread_deadlock COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/pthread_deadlock-ut.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+endif()
+
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
     add_exe(read_past_sp read_past_sp.cc)
     target_include_directories(read_past_sp PRIVATE ${DDPROF_INCLUDE_LIST})
     add_test(NAME read_past_sp COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/read_past_sp-ut.sh WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/test/pthread_deadlock-ut.sh
+++ b/test/pthread_deadlock-ut.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+timeout 5s ./ddprof -X no -e sALLOC,1 ./test/pthread_deadlock

--- a/test/pthread_deadlock.cc
+++ b/test/pthread_deadlock.cc
@@ -1,0 +1,12 @@
+#include <thread>
+
+void func() {
+  pthread_attr_t attrs;
+  pthread_getattr_np(pthread_self(), &attrs);
+  pthread_attr_destroy(&attrs);
+}
+
+int main() {
+  std::thread t(func);
+  t.join();
+}

--- a/test/savecontext-bench.cc
+++ b/test/savecontext-bench.cc
@@ -36,9 +36,10 @@ DDPROF_NOINLINE static void *get_stack_start_tls() {
 static void BM_SaveContext(benchmark::State &state) {
   uint64_t regs[PERF_REGS_COUNT];
   std::byte stack[PERF_SAMPLE_STACK_SIZE];
+  auto *stack_end = retrieve_stack_end_address();
 
   for (auto _ : state) {
-    save_context(regs, stack);
+    save_context(stack_end, regs, stack);
   }
 }
 

--- a/test/savecontext-ut.cc
+++ b/test/savecontext-ut.cc
@@ -27,7 +27,7 @@ std::byte stack[PERF_SAMPLE_STACK_SIZE];
 void funcB() {
   UnwindState state;
   uint64_t regs[K_NB_REGS_UNWIND];
-  size_t stack_size = save_context(regs, stack);
+  size_t stack_size = save_context(retrieve_stack_end_address(), regs, stack);
 
   ddprof::unwind_init_sample(&state, regs, getpid(), stack_size,
                              reinterpret_cast<char *>(stack));
@@ -65,7 +65,7 @@ static uint64_t regs[K_NB_REGS_UNWIND];
 static size_t stack_size;
 
 DDPROF_NO_SANITIZER_ADDRESS void handler(int sig) {
-  stack_size = save_context(regs, stack);
+  stack_size = save_context(retrieve_stack_end_address(), regs, stack);
   stop = true;
 }
 


### PR DESCRIPTION
# What does this PR do?

Deadlock occurs when user code in created thread calls pthread_getattr:
 - pthread_getattr takes a lock in pthread object
 - pthread_getattr itself does an allocation
 - AllocationTracker tracks the allocation and calls savecontext
 - savecontext calls pthread_getattr to get stack end address
 - pthread_getattr is reentered and attempts to take the lock again leading to
   a deadlock.

Workaround is to hook pthread_create and call `cache_stack_end` to
cache stack end address while temporarily disabling allocation profiling for
current thread before calling user code.
