### PR TITLE
Align on backend Max Stack depth which is 512

### DIFF
--- a/include/ddprof_defs.hpp
+++ b/include/ddprof_defs.hpp
@@ -11,7 +11,7 @@
 #define MAX_TYPE_WATCHER 10
 
 // Maximum depth for a single stack
-#define DD_MAX_STACK_DEPTH 1024
+#define DD_MAX_STACK_DEPTH 512
 
 // Linux Inode type
 typedef uint64_t inode_t;


### PR DESCRIPTION
# What does this PR do?

Align on backend Max Stack depth which is 512

# Motivation

Avoid having a max depth that is above what we are able to compute on backend side

# Additional Notes

N/A

# How to test the change?

This is something for which we would need a test
