### PR TITLE
Refactor ring buffer creation

### DIFF
--- a/include/ipc.hpp
+++ b/include/ipc.hpp
@@ -86,6 +86,7 @@ struct RingBufferInfo {
   int64_t mem_size = -1;
   int ring_fd = -1;
   int event_fd = -1;
+  int ring_buffer_type;
 };
 
 struct ReplyMessage {

--- a/include/perf.hpp
+++ b/include/perf.hpp
@@ -115,8 +115,8 @@ typedef struct perf_samplestacku {
 
 int perf_event_open(struct perf_event_attr *, pid_t, int, int, unsigned long);
 size_t perf_mmap_size(int buf_size_shift);
-void *perfown_sz(int fd, size_t size_of_buffer, bool mirror);
-int perfdisown(void *region, size_t size, bool is_mirrored);
+void *perfown_sz(int fd, size_t size_of_buffer);
+int perfdisown(void *region, size_t size);
 long get_page_size(void);
 size_t get_mask_from_size(size_t size);
 const char *perf_type_str(int type_id);

--- a/include/perf_ringbuffer.hpp
+++ b/include/perf_ringbuffer.hpp
@@ -7,8 +7,6 @@
 
 #include "perf.hpp"
 
-#include <atomic>
-
 enum class RingBufferType : uint8_t { kPerfRingBuffer };
 
 struct RingBuffer {

--- a/include/perf_ringbuffer.hpp
+++ b/include/perf_ringbuffer.hpp
@@ -7,26 +7,28 @@
 
 #include "perf.hpp"
 
-typedef struct RingBuffer {
-  const char *start;
-  unsigned long offset;
-  size_t mask;
-  size_t meta_size; // size of the metadata page
-  size_t data_size; // size of data pages
-  size_t size;      // size of the entire region (data + metadata)
-  struct perf_event_mmap_page *region;
-  bool is_mirrored;
-  unsigned char *wrbuf;
-} RingBuffer;
+#include <atomic>
 
-bool rb_init(RingBuffer *rb, struct perf_event_mmap_page *page, size_t size,
-             bool is_mirrored);
+enum class RingBufferType : uint8_t { kPerfRingBuffer };
+
+struct RingBuffer {
+  RingBufferType type;
+  uint64_t *writer_pos;
+  uint64_t *reader_pos;
+  uint64_t mask;
+
+  size_t meta_size; // size of the metadata
+  size_t data_size; // size of data
+  std::byte *data;
+  void *base;
+};
+
+bool rb_init(RingBuffer *rb, void *base, size_t size, RingBufferType type);
 void rb_free(RingBuffer *rb);
-void rb_clear(RingBuffer *rb); // does not deallocate the buffer storage
-uint64_t rb_next(RingBuffer *rb);
-struct perf_event_header *rb_seek(RingBuffer *rb, uint64_t offset);
+
 bool samp2hdr(struct perf_event_header *hdr, perf_event_sample *sample,
               size_t sz_hdr, uint64_t mask);
+
 perf_event_sample *hdr2samp(const struct perf_event_header *hdr, uint64_t mask);
 
 uint64_t hdr_time(struct perf_event_header *hdr, uint64_t mask);

--- a/include/pevent.hpp
+++ b/include/pevent.hpp
@@ -20,6 +20,7 @@ typedef struct PEvent {
   int mapfd;               // FD for ring buffer, same as `fd` for perf events
   int attr_idx;            // matching perf_event_attr
   size_t ring_buffer_size; // size of the ring buffer
+  RingBufferType ring_buffer_type;
   bool custom_event; // true if custom event (not handled by perf, eg. memory
                      // allocations)
   RingBuffer rb;     // metadata and buffers for processing perf ringbuffer

--- a/include/ringbuffer_holder.hpp
+++ b/include/ringbuffer_holder.hpp
@@ -13,15 +13,22 @@
 namespace ddprof {
 class RingBufferHolder {
 public:
-  explicit RingBufferHolder(size_t buffer_size_order) : _pevent{} {
-    DDRES_CHECK_THROW_EXCEPTION(
-        ddprof::ring_buffer_setup(buffer_size_order, &_pevent));
+  explicit RingBufferHolder(size_t buffer_size_order,
+                            RingBufferType ring_buffer_type,
+                            bool custom_event = true)
+      : _pevent{} {
+    DDRES_CHECK_THROW_EXCEPTION(ddprof::ring_buffer_setup(
+        buffer_size_order, ring_buffer_type, custom_event, &_pevent));
   }
 
   ~RingBufferHolder() { ring_buffer_cleanup(_pevent); }
 
+  RingBufferHolder(const RingBufferHolder &) = delete;
+  RingBufferHolder &operator=(const RingBufferHolder &) = delete;
+
   RingBufferInfo get_buffer_info() const {
-    return {static_cast<int64_t>(_pevent.rb.size), _pevent.mapfd, _pevent.fd};
+    return {static_cast<int64_t>(_pevent.ring_buffer_size), _pevent.mapfd,
+            _pevent.fd};
   }
 
   RingBuffer &get_ring_buffer() { return _pevent.rb; }

--- a/include/ringbuffer_utils.hpp
+++ b/include/ringbuffer_utils.hpp
@@ -20,15 +20,16 @@ struct RingBufferInfo;
 // Return `x` rounded up to next multiple of `y`
 // `y` must be a power of 2
 // Return 0 for x==0 or x > std::numeric_limits<uint64_t>::max()-7
-constexpr inline uint64_t round_up_to_mutiple_of_pow2(uint64_t x, uint64_t y) {
-  assert(y > 0 && (y & (y - 1)) == 0);
-  return ((x - 1) | (y - 1)) + 1;
+constexpr inline uint64_t round_up_to_mutiple_of_pow2(uint64_t x,
+                                                      uint64_t pow2) {
+  assert(pow2 > 0 && (pow2 & (pow2 - 1)) == 0);
+  return ((x - 1) | (pow2 - 1)) + 1;
 }
 
 constexpr inline uint64_t round_down_to_mutiple_of_pow2(uint64_t x,
-                                                        uint64_t y) {
-  assert(y > 0 && (y & (y - 1)) == 0);
-  return x & ~(y - 1);
+                                                        uint64_t pow2) {
+  assert(pow2 > 0 && (pow2 & (pow2 - 1)) == 0);
+  return x & ~(pow2 - 1);
 }
 
 class PerfRingBufferWriter {

--- a/include/ringbuffer_utils.hpp
+++ b/include/ringbuffer_utils.hpp
@@ -17,55 +17,78 @@ namespace ddprof {
 
 struct RingBufferInfo;
 
-class RingBufferWriter {
+// Return `x` rounded up to next multiple of `y`
+// `y` must be a power of 2
+// Return 0 for x==0 or x > std::numeric_limits<uint64_t>::max()-7
+constexpr inline uint64_t round_up_to_mutiple_of_pow2(uint64_t x, uint64_t y) {
+  assert(y > 0 && (y & (y - 1)) == 0);
+  return ((x - 1) | (y - 1)) + 1;
+}
+
+constexpr inline uint64_t round_down_to_mutiple_of_pow2(uint64_t x,
+                                                        uint64_t y) {
+  assert(y > 0 && (y & (y - 1)) == 0);
+  return x & ~(y - 1);
+}
+
+class PerfRingBufferWriter {
 public:
-  explicit RingBufferWriter(RingBuffer &rb) : _rb(rb) {
-    _tail = __atomic_load_n(&_rb.region->data_tail, __ATOMIC_ACQUIRE);
-    _head = _initial_head = _rb.region->data_head;
+  explicit PerfRingBufferWriter(RingBuffer &rb) : _rb(rb) {
+    assert(rb.type == RingBufferType::kPerfRingBuffer);
+    _tail = __atomic_load_n(_rb.reader_pos, __ATOMIC_ACQUIRE);
+    _head = _initial_head = *_rb.writer_pos;
     assert(_tail <= _head);
   }
 
-  ~RingBufferWriter() {
+  ~PerfRingBufferWriter() {
     if (_initial_head != _head) {
-      __atomic_store_n(&_rb.region->data_head, _head, __ATOMIC_RELEASE);
+      __atomic_store_n(_rb.writer_pos, _head, __ATOMIC_RELEASE);
     }
   }
 
-  RingBufferWriter(const RingBufferWriter &) = delete;
-  RingBufferWriter &operator=(const RingBufferWriter &) = delete;
+  PerfRingBufferWriter(const PerfRingBufferWriter &) = delete;
+  PerfRingBufferWriter &operator=(const PerfRingBufferWriter &) = delete;
+
+  size_t update_available() {
+    _tail = __atomic_load_n(_rb.reader_pos, __ATOMIC_ACQUIRE);
+    return available_size();
+  }
 
   inline size_t available_size() const {
     // Always leave one free char, as a completely full buffer is
     // indistinguishable from an empty one
-    return _rb.data_size - (_head + 1 - _tail);
+    return _rb.mask - (_head - _tail);
   }
 
   Buffer reserve(size_t n) {
-    assert(n <= available_size());
+    // Make sure to keep samples 8-byte aligned
+    size_t n_aligned = round_up_to_mutiple_of_pow2(n, 8);
+    if (n_aligned == 0 || n_aligned > available_size()) {
+      return {};
+    }
 
     uint64_t head_linear = _head & _rb.mask;
-    std::byte *dest = (std::byte *)(_rb.start + head_linear);
-    _head += n;
+    std::byte *dest = _rb.data + head_linear;
+    _head += n_aligned;
 
     return {dest, n};
   }
 
-  void write(Buffer buf) {
-    assert(buf.size() <= available_size());
-
-    uint64_t head_linear = _head & _rb.mask;
-    char *dest = const_cast<char *>(_rb.start) + head_linear;
-
-    memcpy(dest, buf.data(), buf.size());
-    _head += buf.size();
+  bool write(ConstBuffer buf) {
+    auto dest = reserve(buf.size());
+    if (dest.empty()) {
+      return false;
+    }
+    memcpy(dest.data(), buf.data(), buf.size());
+    return true;
   }
 
-  // return true if notification to consumer is necesssary
+  // Return true if notification to consumer is necesssary
   // Notification is necessary only if consumer has caught up with producer
   // (meaning tail afer commit is at or after head before commit)
   bool commit() {
-    __atomic_store_n(&_rb.region->data_head, _head, __ATOMIC_RELEASE);
-    _tail = __atomic_load_n(&_rb.region->data_tail, __ATOMIC_ACQUIRE);
+    __atomic_store_n(_rb.writer_pos, _head, __ATOMIC_RELEASE);
+    _tail = __atomic_load_n(_rb.reader_pos, __ATOMIC_ACQUIRE);
     bool consumer_has_caught_up = _tail >= _initial_head;
     _initial_head = _head;
     return consumer_has_caught_up;
@@ -78,36 +101,53 @@ private:
   uint64_t _head;
 };
 
-class RingBufferReader {
+class PerfRingBufferReader {
 public:
-  explicit RingBufferReader(RingBuffer &rb) : _rb(rb) {
-    _head = __atomic_load_n(&rb.region->data_head, __ATOMIC_ACQUIRE);
-    _tail = _rb.region->data_tail;
+  explicit PerfRingBufferReader(RingBuffer &rb) : _rb(rb) {
+    assert(rb.type == RingBufferType::kPerfRingBuffer);
+    _head = __atomic_load_n(rb.writer_pos, __ATOMIC_ACQUIRE);
+    _tail = *_rb.reader_pos;
+    _initial_tail = _tail;
     assert(_tail <= _head);
   }
 
-  ~RingBufferReader() {
-    __atomic_store_n(&_rb.region->data_tail, _tail, __ATOMIC_RELEASE);
+  ~PerfRingBufferReader() {
+    if (_initial_tail < _tail)
+      __atomic_store_n(_rb.reader_pos, _tail, __ATOMIC_RELEASE);
   }
 
-  inline size_t available_for_read() const { return _head - _tail; }
+  inline size_t available_size() const { return _head - _tail; }
 
   ConstBuffer read_all_available() {
     uint64_t tail_linear = _tail & _rb.mask;
-    const std::byte *start =
-        reinterpret_cast<const std::byte *>(_rb.start + tail_linear);
+    const std::byte *start = _rb.data + tail_linear;
     size_t n = _head - _tail;
     _tail = _head;
     return {start, n};
   }
 
-  void check_for_new_data() {
-    _head = __atomic_load_n(&_rb.region->data_head, __ATOMIC_ACQUIRE);
+  void advance(size_t n) {
+    // Need to round up size provided by user to recover actual sample size
+    n = round_up_to_mutiple_of_pow2(n, 8);
+    assert(_initial_tail + n <= _tail);
+    _initial_tail += n;
+    __atomic_store_n(_rb.reader_pos, _initial_tail, __ATOMIC_RELEASE);
+  }
+
+  void advance() {
+    _initial_tail = _tail;
+    __atomic_store_n(_rb.reader_pos, _initial_tail, __ATOMIC_RELEASE);
+  }
+
+  size_t update_available() {
+    _head = __atomic_load_n(_rb.writer_pos, __ATOMIC_ACQUIRE);
+    return available_size();
   }
 
 private:
   RingBuffer &_rb;
   uint64_t _tail;
+  uint64_t _initial_tail;
   uint64_t _head;
 };
 
@@ -123,13 +163,17 @@ DDRes ring_buffer_detach(PEvent &event);
 // Create ring buffer (create memfd and eventfd)
 // Ring buffer is not mapped upon return from this function, ring_buffer_attach
 // needs to be called to map it
-DDRes ring_buffer_create(size_t buffer_size_page_order, PEvent *event);
+DDRes ring_buffer_create(size_t buffer_size_page_order,
+                         RingBufferType ring_buffer_type, bool custom_event,
+                         PEvent *event);
 
 // Destroy ring buffer: close memfd / eventfd
 DDRes ring_buffer_close(PEvent &event);
 
 // Create and attach ring buffer
-DDRes ring_buffer_setup(size_t buffer_size_page_order, PEvent *event);
+DDRes ring_buffer_setup(size_t buffer_size_page_order,
+                        RingBufferType ring_buffer_type, bool custom_event,
+                        PEvent *event);
 
 // Unmap and close ring buffer
 DDRes ring_buffer_cleanup(PEvent &event);

--- a/src/lib/allocation_tracker.cc
+++ b/src/lib/allocation_tracker.cc
@@ -108,12 +108,7 @@ DDRes AllocationTracker::init(uint64_t mem_profile_interval,
                               const RingBufferInfo &ring_buffer) {
   _sampling_interval = mem_profile_interval;
   _deterministic_sampling = deterministic_sampling;
-  _pevent = {.watcher_pos = -1,
-             .fd = ring_buffer.event_fd,
-             .mapfd = ring_buffer.ring_fd,
-             .ring_buffer_size = static_cast<size_t>(ring_buffer.mem_size),
-             .custom_event = true};
-  return pevent_mmap_event(&_pevent);
+  return ddprof::ring_buffer_attach(ring_buffer, &_pevent);
 }
 
 void AllocationTracker::free() {
@@ -193,7 +188,7 @@ void AllocationTracker::track_allocation(uintptr_t, size_t size,
 
 DDRes AllocationTracker::push_sample(uint64_t allocated_size,
                                      TrackerThreadLocalState &tl_state) {
-  RingBufferWriter writer{_pevent.rb};
+  PerfRingBufferWriter writer{_pevent.rb};
   auto needed_size = sizeof(AllocationEvent);
 
   if (_state.lost_count) {

--- a/src/perf_ringbuffer.cc
+++ b/src/perf_ringbuffer.cc
@@ -9,73 +9,28 @@
 
 #include <stdlib.h>
 
-bool rb_init(RingBuffer *rb, struct perf_event_mmap_page *page, size_t size,
-             bool is_mirrored) {
-  // Assumes storage has already been allocated in rb->wrbuf
+bool rb_init(RingBuffer *rb, void *base, size_t size,
+             RingBufferType ring_buffer_type) {
   rb->meta_size = get_page_size();
-  rb->region = page;
-  rb->start = (const char *)page + rb->meta_size;
-  rb->size = size;
+  rb->base = base;
+  rb->data = reinterpret_cast<std::byte *>(base) + rb->meta_size;
   rb->data_size = size - rb->meta_size;
   rb->mask = get_mask_from_size(size);
-  rb->is_mirrored = is_mirrored;
-
-  // If already allocated just free it
-  if (rb->wrbuf)
-    free(rb->wrbuf);
-  rb->wrbuf = NULL; // in case alloc fails
-
-  if (!is_mirrored) {
-    // Allocate room for a watcher-held buffer.  This is for linearizing
-    // ringbuffer elements and depends on the per-watcher configuration for
-    // perf_event_open().  Eventually this size will be non-static.
-    uint64_t buf_sz =
-        sizeof(uint64_t) * PERF_REGS_COUNT + PERF_SAMPLE_STACK_SIZE;
-    buf_sz += sizeof(perf_event_sample);
-    unsigned char *wrbuf = static_cast<unsigned char *>(malloc(buf_sz));
-    if (!wrbuf)
-      return false;
-    rb->wrbuf = wrbuf;
+  rb->type = ring_buffer_type;
+  if (ring_buffer_type == RingBufferType::kPerfRingBuffer) {
+    perf_event_mmap_page *meta =
+        reinterpret_cast<perf_event_mmap_page *>(rb->base);
+    rb->reader_pos = reinterpret_cast<uint64_t *>(&meta->data_tail);
+    rb->writer_pos = reinterpret_cast<uint64_t *>(&meta->data_head);
+  } else {
+    return false;
   }
 
   return true;
 }
 
-void rb_clear(RingBuffer *rb) { memset(rb, 0, sizeof(*rb)); }
-void rb_free(RingBuffer *rb) {
-  if (rb->wrbuf)
-    free(rb->wrbuf);
-  rb->wrbuf = NULL;
-}
+void rb_free(RingBuffer *rb) {}
 
-uint64_t rb_next(RingBuffer *rb) {
-  rb->offset = (rb->offset + sizeof(uint64_t)) & (rb->mask);
-  return *(uint64_t *)(rb->start + rb->offset);
-}
-
-struct perf_event_header *rb_seek(RingBuffer *rb, uint64_t offset) {
-  rb->offset = (unsigned long)offset & (rb->mask);
-
-  struct perf_event_header *ret =
-      (struct perf_event_header *)(rb->start + rb->offset);
-  // If buffer is mirrored or we don't overrun the end, just return a pointer in
-  // the buffer
-  if (rb->is_mirrored || rb->data_size - rb->offset >= ret->size) {
-    return ret;
-  }
-
-  // We overrun the end of the ringbuffer, pass in a buffer rather than the raw
-  // event. The terms 'left' and 'right' below refer to the regions in the
-  // linearized buffer.  In the index space of the ringbuffer, these terms
-  // would be reversed.
-  uint64_t left_sz = rb->data_size - rb->offset;
-  uint64_t right_sz = ret->size - left_sz;
-  memcpy(rb->wrbuf, rb->start + rb->offset, left_sz);
-  memcpy(rb->wrbuf + left_sz, rb->start, right_sz);
-  return (struct perf_event_header *)rb->wrbuf;
-}
-
-// This union is an implementation trick to make splitting apart an 8-byte
 // aligned block into two 4-byte blocks easier
 typedef union flipper {
   uint64_t full;
@@ -85,8 +40,8 @@ typedef union flipper {
 #define SZ_CHECK                                                               \
   if ((sz += 8) >= sz_hdr)                                                     \
   return false
-bool samp2hdr(struct perf_event_header *hdr, perf_event_sample *sample,
-              size_t sz_hdr, uint64_t mask) {
+bool samp2hdr(perf_event_header *hdr, perf_event_sample *sample, size_t sz_hdr,
+              uint64_t mask) {
   // There is absolutely no point for this interface except testing
 
   // Presumes that the user has allocated enough room for the whole sample

--- a/src/pevent_lib.cc
+++ b/src/pevent_lib.cc
@@ -59,6 +59,7 @@ static void pevent_set_info(int fd, int attr_idx, PEvent &pevent) {
   pevent.mapfd = fd;
   pevent.ring_buffer_size = perf_mmap_size(DEFAULT_BUFF_SIZE_SHIFT);
   pevent.custom_event = false;
+  pevent.ring_buffer_type = RingBufferType::kPerfRingBuffer;
   pevent.attr_idx = attr_idx;
 }
 
@@ -137,8 +138,9 @@ DDRes pevent_open(DDProfContext *ctx, pid_t pid, int num_cpu,
       // custom event, eg.allocation profiling
       size_t pevent_idx = 0;
       DDRES_CHECK_FWD(pevent_create(pevent_hdr, watcher_idx, &pevent_idx));
-      DDRES_CHECK_FWD(ddprof::ring_buffer_create(DEFAULT_BUFF_SIZE_SHIFT,
-                                                 &pevent_hdr->pes[pevent_idx]));
+      DDRES_CHECK_FWD(ddprof::ring_buffer_create(
+          DEFAULT_BUFF_SIZE_SHIFT, RingBufferType::kPerfRingBuffer, true,
+          &pevent_hdr->pes[pevent_idx]));
     }
   }
   return ddres_init();
@@ -146,18 +148,16 @@ DDRes pevent_open(DDProfContext *ctx, pid_t pid, int num_cpu,
 
 DDRes pevent_mmap_event(PEvent *event) {
   if (event->mapfd != -1) {
-    const bool mirror = true;
-
-    perf_event_mmap_page *region = static_cast<perf_event_mmap_page *>(
-        perfown_sz(event->mapfd, event->ring_buffer_size, mirror));
+    void *region = perfown_sz(event->mapfd, event->ring_buffer_size);
     if (!region) {
       DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFMMAP,
                              "Could not mmap memory for watcher #%d: %s",
                              event->watcher_pos, strerror(errno));
     }
-    if (!rb_init(&event->rb, region, event->ring_buffer_size, mirror)) {
+    if (!rb_init(&event->rb, region, event->ring_buffer_size,
+                 event->ring_buffer_type)) {
       DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFMMAP,
-                             "Could not allocate memory for watcher #%d",
+                             "Could not initialize ring buffer for watcher #%d",
                              event->watcher_pos);
     }
   }
@@ -211,14 +211,13 @@ DDRes pevent_enable(PEventHdr *pevent_hdr) {
 }
 
 DDRes pevent_munmap_event(PEvent *event) {
-  if (event->rb.region) {
-    if (perfdisown(event->rb.region, event->rb.size, event->rb.is_mirrored) !=
-        0) {
+  if (event->rb.base) {
+    if (perfdisown(event->rb.base, event->ring_buffer_size) != 0) {
       DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFMMAP,
                              "Error when using perfdisown for watcher #%d",
                              event->watcher_pos);
     }
-    event->rb.region = NULL;
+    event->rb.base = NULL;
   }
   rb_free(&event->rb);
   return {};

--- a/src/ringbuffer_utils.cc
+++ b/src/ringbuffer_utils.cc
@@ -19,13 +19,22 @@ DDRes ring_buffer_attach(const RingBufferInfo &info, PEvent *pevent) {
   pevent->fd = info.event_fd;
   pevent->mapfd = info.ring_fd;
   pevent->ring_buffer_size = info.mem_size;
+  switch (info.ring_buffer_type) {
+  case static_cast<int>(RingBufferType::kPerfRingBuffer):
+    pevent->ring_buffer_type = RingBufferType::kPerfRingBuffer;
+    break;
+  default:
+    return ddres_error(DD_WHAT_PERFRB);
+  }
   pevent->custom_event = true;
   return pevent_mmap_event(pevent);
 }
 
 DDRes ring_buffer_attach(PEvent &pe) { return pevent_mmap_event(&pe); }
 
-DDRes ring_buffer_create(size_t buffer_size_page_order, PEvent *pevent) {
+DDRes ring_buffer_create(size_t buffer_size_page_order,
+                         RingBufferType ring_buffer_type, bool custom_event,
+                         PEvent *pevent) {
   size_t buffer_size = perf_mmap_size(buffer_size_page_order);
   pevent->mapfd =
       ddprof::memfd_create("allocation_ring_buffer", 1U /*MFD_CLOEXEC*/);
@@ -45,7 +54,8 @@ DDRes ring_buffer_create(size_t buffer_size_page_order, PEvent *pevent) {
                            "Error calling evenfd on watcher %d (%s)",
                            pevent->watcher_pos, strerror(errno));
   }
-  pevent->custom_event = true;
+  pevent->custom_event = custom_event;
+  pevent->ring_buffer_type = ring_buffer_type;
   pevent->ring_buffer_size = buffer_size;
   return {};
 }
@@ -54,8 +64,11 @@ DDRes ring_buffer_close(PEvent &pevent) { return pevent_close_event(&pevent); }
 
 DDRes ring_buffer_detach(PEvent &event) { return pevent_munmap_event(&event); }
 
-DDRes ring_buffer_setup(size_t buffer_size_page_order, PEvent *event) {
-  DDRES_CHECK_FWD(ring_buffer_create(buffer_size_page_order, event));
+DDRes ring_buffer_setup(size_t buffer_size_page_order,
+                        RingBufferType ring_buffer_type, bool custom_event,
+                        PEvent *event) {
+  DDRES_CHECK_FWD(ring_buffer_create(buffer_size_page_order, ring_buffer_type,
+                                     custom_event, event));
   DDRES_CHECK_FWD(ring_buffer_attach(*event));
   return {};
 }

--- a/test/allocation_tracker-ut.cc
+++ b/test/allocation_tracker-ut.cc
@@ -35,15 +35,16 @@ DDPROF_NOINLINE void my_func_calling_malloc(size_t size) {
 TEST(allocation_tracker, start_stop) {
   const uint64_t rate = 1;
   const size_t buf_size_order = 5;
-  ddprof::RingBufferHolder ring_buffer{buf_size_order};
+  ddprof::RingBufferHolder ring_buffer{buf_size_order,
+                                       RingBufferType::kPerfRingBuffer};
   ddprof::AllocationTracker::allocation_tracking_init(
       rate, ddprof::AllocationTracker::kDeterministicSampling,
       ring_buffer.get_buffer_info());
 
   my_func_calling_malloc(1);
 
-  ddprof::RingBufferReader reader{ring_buffer.get_ring_buffer()};
-  ASSERT_GT(reader.available_for_read(), 0);
+  ddprof::PerfRingBufferReader reader{ring_buffer.get_ring_buffer()};
+  ASSERT_GT(reader.available_size(), 0);
 
   auto buf = reader.read_all_available();
   const perf_event_header *hdr =

--- a/test/mmap-ut.cc
+++ b/test/mmap-ut.cc
@@ -65,7 +65,7 @@ TEST(MMapTest, PerfOpen) {
       std::cerr << "mmap size attempt --> " << mmap_size << "("
                 << buf_size_shift << ")";
 
-      region = perfown_sz(perf_fd, mmap_size, false);
+      region = perfown_sz(perf_fd, mmap_size);
 
       if (!region) {
         std::cerr << " = FAILURE !!!" << std::endl;
@@ -78,7 +78,7 @@ TEST(MMapTest, PerfOpen) {
       std::cerr << "FULL SUCCESS (size=" << mmap_size << ")" << std::endl;
     }
     ASSERT_TRUE(region);
-    ASSERT_EQ(perfdisown(region, mmap_size, false), 0);
+    ASSERT_EQ(perfdisown(region, mmap_size), 0);
     close(perf_fd);
   }
 }
@@ -91,7 +91,7 @@ TEST(MMapTest, Mirroring) {
   ASSERT_NE(fd, -1);
   ASSERT_EQ(ftruncate(fd, mmap_size), 0);
 
-  std::byte *region = static_cast<std::byte *>(perfown_sz(fd, mmap_size, true));
+  std::byte *region = static_cast<std::byte *>(perfown_sz(fd, mmap_size));
   ASSERT_TRUE(region);
 
   size_t usable_size = mmap_size - get_page_size();
@@ -103,5 +103,5 @@ TEST(MMapTest, Mirroring) {
   EXPECT_EQ(*end, std::byte{0xff});
 
   close(fd);
-  ASSERT_EQ(perfdisown(region, mmap_size, true), 0);
+  ASSERT_EQ(perfdisown(region, mmap_size), 0);
 }

--- a/test/read_past_sp-ut.sh
+++ b/test/read_past_sp-ut.sh
@@ -12,10 +12,12 @@ while kill -0 "$p" 2> /dev/null; do sleep 0.05s; done
 
 v=$(grep "datadog[.]profiling[.]native[.]unwind[.]stack[.]incomplete: *[0-9]*" -o log | awk -F: '{print $2}')
 if [[ -z "$v" ]]; then
+    cat log
     echo "Could not find metrics"
     exit 1
 # allow at most 3 incomplete stacks
 elif [[ "$v" -gt 3 ]]; then
+    cat log
     echo "Found incomplete stacks"
     exit 1
 fi

--- a/test/ringbuffer-ut.cc
+++ b/test/ringbuffer-ut.cc
@@ -8,28 +8,251 @@
 #include "ringbuffer_utils.hpp"
 
 #include <gtest/gtest.h>
+#include <thread>
 
 using namespace ddprof;
 
-TEST(ringbuffer, full) {
+struct MyElement {
+  perf_event_header hdr;
+  int64_t x, y, z;
+};
+
+class jthread {
+public:
+  using id = std::thread::id;
+  using native_handle_type = std::thread::native_handle_type;
+
+  jthread() noexcept {}
+
+  template <typename _Callable, typename... _Args,
+            typename = std::enable_if_t<
+                !std::is_same_v<std::remove_cvref_t<_Callable>, jthread>>>
+  explicit jthread(_Callable &&f, _Args &&...args)
+      : _thread{std::forward<_Callable>(f), std::forward<_Args>(args)...} {}
+
+  jthread(const jthread &) = delete;
+  jthread(jthread &&) noexcept = default;
+
+  ~jthread() {
+    if (joinable()) {
+      join();
+    }
+  }
+
+  jthread &operator=(const jthread &) = delete;
+
+  jthread &operator=(jthread &&other) noexcept {
+    jthread(std::move(other)).swap(*this);
+    return *this;
+  }
+
+  void swap(jthread &other) noexcept { std::swap(_thread, other._thread); }
+
+  [[nodiscard]] bool joinable() const noexcept { return _thread.joinable(); }
+
+  void join() { _thread.join(); }
+
+  void detach() { _thread.detach(); }
+
+  [[nodiscard]] id get_id() const noexcept { return _thread.get_id(); }
+
+  [[nodiscard]] native_handle_type native_handle() {
+    return _thread.native_handle();
+  }
+
+  [[nodiscard]] static unsigned hardware_concurrency() noexcept {
+    return std::thread::hardware_concurrency();
+  }
+
+  friend void swap(jthread &__lhs, jthread &__rhs) noexcept {
+    __lhs.swap(__rhs);
+  }
+
+private:
+  std::thread _thread;
+};
+
+void perf_reader_fun(RingBuffer *rb, size_t nb_elements, bool use_new_object,
+                     bool advance_eagerly) {
+  std::optional<PerfRingBufferReader> reader(*rb);
+
+  size_t count = 0;
+  while (count < nb_elements) {
+    if (use_new_object) {
+      reader.emplace(*rb);
+    }
+    while (reader->available_size() == 0) {
+      sched_yield();
+      reader->update_available();
+    }
+    auto buf = reader->read_all_available();
+    while (!buf.empty()) {
+      const MyElement *elem = reinterpret_cast<const MyElement *>(buf.data());
+
+      ASSERT_EQ(elem->hdr.size, sizeof(MyElement));
+      ASSERT_EQ(elem->hdr.misc, 5);
+      ASSERT_EQ(elem->hdr.type, 3);
+      ASSERT_EQ(elem->x, count);
+      ASSERT_EQ(elem->y, count * 2);
+      ASSERT_EQ(elem->z, count * 3);
+      ++count;
+      buf = remaining(buf, elem->hdr.size);
+      if (advance_eagerly) {
+        reader->advance(elem->hdr.size);
+      }
+    }
+    if (!advance_eagerly && !use_new_object) {
+      reader->advance();
+    }
+  }
+}
+
+void perf_writer_fun(RingBuffer *rb, size_t nb_elements, bool use_new_object,
+                     bool use_reserve) {
+  std::optional<PerfRingBufferWriter> writer(*rb);
+
+  for (int64_t i = 0; i < static_cast<int64_t>(nb_elements); ++i) {
+    if (use_new_object) {
+      writer.emplace(*rb);
+    }
+    while (writer->available_size() < sizeof(MyElement)) {
+      sched_yield();
+      writer->update_available();
+    }
+
+    if (use_reserve) {
+      auto buf = writer->reserve(sizeof(MyElement));
+      ASSERT_EQ(buf.size(), sizeof(MyElement));
+      MyElement *elem = reinterpret_cast<MyElement *>(buf.data());
+      elem->hdr.size = sizeof(MyElement);
+      elem->hdr.misc = 5;
+      elem->hdr.type = 3;
+
+      elem->x = i;
+      elem->y = 2 * i;
+      elem->z = 3 * i;
+
+    } else {
+      MyElement elem{.hdr = {.type = 3, .misc = 5, .size = sizeof(MyElement)},
+                     .x = i,
+                     .y = 2 * i,
+                     .z = 3 * i};
+      ASSERT_TRUE(writer->write(ddprof::ConstBuffer{
+          reinterpret_cast<std::byte *>(&elem), elem.hdr.size}));
+    }
+    if (!use_new_object) {
+      writer->commit();
+    }
+  }
+}
+
+TEST(ringbuffer, round) {
+  ASSERT_EQ(round_up_to_mutiple_of_pow2(0, 8), 0);
+  ASSERT_EQ(round_up_to_mutiple_of_pow2(1, 8), 8);
+  ASSERT_EQ(round_up_to_mutiple_of_pow2(7, 8), 8);
+  ASSERT_EQ(round_up_to_mutiple_of_pow2(8, 8), 8);
+  ASSERT_EQ(round_up_to_mutiple_of_pow2(9, 8), 16);
+  ASSERT_EQ(
+      round_up_to_mutiple_of_pow2(std::numeric_limits<uint64_t>::max() - 6, 8),
+      0);
+
+  ASSERT_EQ(round_down_to_mutiple_of_pow2(0, 8), 0);
+  ASSERT_EQ(round_down_to_mutiple_of_pow2(1, 8), 0);
+  ASSERT_EQ(round_down_to_mutiple_of_pow2(7, 8), 0);
+  ASSERT_EQ(round_down_to_mutiple_of_pow2(8, 8), 8);
+  ASSERT_EQ(round_down_to_mutiple_of_pow2(9, 8), 8);
+  ASSERT_EQ(round_down_to_mutiple_of_pow2(
+                std::numeric_limits<uint64_t>::max() - 6, 8),
+            std::numeric_limits<uint64_t>::max() - 7);
+}
+
+TEST(ringbuffer, perf_ring_buffer) {
   const size_t buf_size_order = 1;
-  RingBufferHolder ring_buffer{buf_size_order};
-  RingBufferWriter writer{ring_buffer.get_ring_buffer()};
-  RingBufferReader reader{ring_buffer.get_ring_buffer()};
-  EXPECT_EQ(reader.available_for_read(), 0);
+  RingBufferHolder ring_buffer{buf_size_order, RingBufferType::kPerfRingBuffer};
+  constexpr size_t nelem = 1000;
+  for (int producer_use_new_object = 0; producer_use_new_object < 2;
+       ++producer_use_new_object) {
+    for (int producer_use_reserve = 0; producer_use_reserve < 2;
+         ++producer_use_reserve) {
+      for (int consumer_use_new_object = 0; consumer_use_new_object < 2;
+           ++consumer_use_new_object) {
+        for (int consumer_advance_eagerly = 0; consumer_advance_eagerly < 2;
+             ++consumer_advance_eagerly) {
+          jthread producer{perf_writer_fun, &ring_buffer.get_ring_buffer(),
+                           nelem, producer_use_new_object,
+                           producer_use_reserve};
+          jthread consumer{perf_reader_fun, &ring_buffer.get_ring_buffer(),
+                           nelem, consumer_use_new_object,
+                           consumer_advance_eagerly};
+        }
+      }
+    }
+  }
+}
+
+TEST(ringbuffer, edge_cases) {
+  const size_t buf_size_order = 0;
+  RingBufferHolder ring_buffer{buf_size_order, RingBufferType::kPerfRingBuffer};
+  PerfRingBufferWriter writer{ring_buffer.get_ring_buffer()};
+
+  auto buf = writer.reserve(0);
+  ASSERT_TRUE(buf.empty());
+  ASSERT_EQ(buf.data(), nullptr);
+  buf = writer.reserve(4095);
+  ASSERT_TRUE(buf.empty());
+  ASSERT_EQ(buf.data(), nullptr);
+  buf = writer.reserve(std::numeric_limits<size_t>::max() - 1);
+  ASSERT_TRUE(buf.empty());
+  ASSERT_EQ(buf.data(), nullptr);
+
+  buf = writer.reserve(1);
+  ASSERT_FALSE(buf.empty());
+  ASSERT_EQ(buf.size(), 1);
+  *buf.data() = std::byte{'z'};
+  writer.commit();
+
+  PerfRingBufferReader reader{ring_buffer.get_ring_buffer()};
+  auto read_buf = reader.read_all_available();
+  ASSERT_FALSE(read_buf.empty());
+  ASSERT_EQ(*read_buf.data(), std::byte{'z'});
+  reader.advance(1);
+
+  buf = writer.reserve(1);
+  ASSERT_FALSE(buf.empty());
+  ASSERT_EQ(buf.size(), 1);
+  *buf.data() = std::byte{'y'};
+  writer.commit();
+
+  reader.update_available();
+  read_buf = reader.read_all_available();
+  ASSERT_FALSE(read_buf.empty());
+  ASSERT_EQ(*read_buf.data(), std::byte{'y'});
+}
+
+TEST(ringbuffer, full) {
+  const size_t buf_size_order = 0;
+  RingBufferHolder ring_buffer{buf_size_order, RingBufferType::kPerfRingBuffer};
+  PerfRingBufferWriter writer{ring_buffer.get_ring_buffer()};
+  PerfRingBufferReader reader{ring_buffer.get_ring_buffer()};
+  EXPECT_EQ(reader.available_size(), 0);
 
   auto sz = writer.available_size();
   EXPECT_GT(sz, 0);
-  auto buffer = writer.reserve(sz);
+
+  auto sz2 = round_down_to_mutiple_of_pow2(sz, 8);
+
+  // size is rounded up to mutliple of 8 by reserve
+  auto buffer = writer.reserve(round_down_to_mutiple_of_pow2(sz, 8));
+  ASSERT_FALSE(buffer.empty());
   std::fill(buffer.begin(), buffer.end(), std::byte{0xff});
 
-  EXPECT_EQ(writer.available_size(), 0);
+  EXPECT_EQ(writer.available_size(), sz - sz2);
   writer.commit();
 
-  reader.check_for_new_data();
-  EXPECT_EQ(reader.available_for_read(), sz);
+  reader.update_available();
+  EXPECT_EQ(reader.available_size(), sz2);
   auto buffer2 = reader.read_all_available();
-  EXPECT_EQ(reader.available_for_read(), 0);
+  EXPECT_EQ(reader.available_size(), 0);
   EXPECT_TRUE(
       std::equal(buffer.begin(), buffer.end(), buffer2.begin(), buffer2.end()));
 }

--- a/test/ringbuffer-ut.cc
+++ b/test/ringbuffer-ut.cc
@@ -147,22 +147,19 @@ void perf_writer_fun(RingBuffer *rb, size_t nb_elements, bool use_new_object,
 }
 
 TEST(ringbuffer, round) {
-  ASSERT_EQ(round_up_to_mutiple_of_pow2(0, 8), 0);
-  ASSERT_EQ(round_up_to_mutiple_of_pow2(1, 8), 8);
-  ASSERT_EQ(round_up_to_mutiple_of_pow2(7, 8), 8);
-  ASSERT_EQ(round_up_to_mutiple_of_pow2(8, 8), 8);
-  ASSERT_EQ(round_up_to_mutiple_of_pow2(9, 8), 16);
-  ASSERT_EQ(
-      round_up_to_mutiple_of_pow2(std::numeric_limits<uint64_t>::max() - 6, 8),
-      0);
+  ASSERT_EQ(align_up(0, 8), 0);
+  ASSERT_EQ(align_up(1, 8), 8);
+  ASSERT_EQ(align_up(7, 8), 8);
+  ASSERT_EQ(align_up(8, 8), 8);
+  ASSERT_EQ(align_up(9, 8), 16);
+  ASSERT_EQ(align_up(std::numeric_limits<uint64_t>::max() - 6, 8), 0);
 
-  ASSERT_EQ(round_down_to_mutiple_of_pow2(0, 8), 0);
-  ASSERT_EQ(round_down_to_mutiple_of_pow2(1, 8), 0);
-  ASSERT_EQ(round_down_to_mutiple_of_pow2(7, 8), 0);
-  ASSERT_EQ(round_down_to_mutiple_of_pow2(8, 8), 8);
-  ASSERT_EQ(round_down_to_mutiple_of_pow2(9, 8), 8);
-  ASSERT_EQ(round_down_to_mutiple_of_pow2(
-                std::numeric_limits<uint64_t>::max() - 6, 8),
+  ASSERT_EQ(align_down(0, 8), 0);
+  ASSERT_EQ(align_down(1, 8), 0);
+  ASSERT_EQ(align_down(7, 8), 0);
+  ASSERT_EQ(align_down(8, 8), 8);
+  ASSERT_EQ(align_down(9, 8), 8);
+  ASSERT_EQ(align_down(std::numeric_limits<uint64_t>::max() - 6, 8),
             std::numeric_limits<uint64_t>::max() - 7);
 }
 
@@ -238,11 +235,9 @@ TEST(ringbuffer, full) {
 
   auto sz = writer.available_size();
   EXPECT_GT(sz, 0);
-
-  auto sz2 = round_down_to_mutiple_of_pow2(sz, 8);
-
-  // size is rounded up to mutliple of 8 by reserve
-  auto buffer = writer.reserve(round_down_to_mutiple_of_pow2(sz, 8));
+  // size is rounded up to multiple of 8 by reserve
+  auto sz2 = align_down(sz, 8);
+  auto buffer = writer.reserve(sz2);
   ASSERT_FALSE(buffer.empty());
   std::fill(buffer.begin(), buffer.end(), std::byte{0xff});
 


### PR DESCRIPTION
# What does this PR do?

* Remove mirror option from ring buffer creation, ring buffers are always mirrored
* Add a ring buffer type to accommodate for different types of ring buffers
* Move all ring buffer read / write logic to ringbuffer_utils.hpp