### PR TITLE
Fix for dd_profiling library not found in unwinding

### DIFF
--- a/include/ddprof_context.hpp
+++ b/include/ddprof_context.hpp
@@ -26,7 +26,7 @@ typedef struct DDProfContext {
     pid_t pid; // ! only use for perf attach (can be -1 in global mode)
     bool global;
     uint32_t worker_period; // exports between worker refreshes
-    int fd_dd_profiling;    // opened file descriptor to our internal lib
+    int dd_profiling_fd;    // opened file descriptor to our internal lib
     int sockfd;
     bool wait_on_socket;
     const char *internal_stats;

--- a/include/ddprof_context.hpp
+++ b/include/ddprof_context.hpp
@@ -26,6 +26,7 @@ typedef struct DDProfContext {
     pid_t pid; // ! only use for perf attach (can be -1 in global mode)
     bool global;
     uint32_t worker_period; // exports between worker refreshes
+    int fd_dd_profiling; // opened file descriptor to our internal lib
     int sockfd;
     bool wait_on_socket;
     const char *internal_stats;

--- a/include/ddprof_context.hpp
+++ b/include/ddprof_context.hpp
@@ -26,7 +26,7 @@ typedef struct DDProfContext {
     pid_t pid; // ! only use for perf attach (can be -1 in global mode)
     bool global;
     uint32_t worker_period; // exports between worker refreshes
-    int fd_dd_profiling; // opened file descriptor to our internal lib
+    int fd_dd_profiling;    // opened file descriptor to our internal lib
     int sockfd;
     bool wait_on_socket;
     const char *internal_stats;

--- a/include/ddprof_file_info-i.hpp
+++ b/include/ddprof_file_info-i.hpp
@@ -10,4 +10,5 @@ namespace ddprof {
 typedef int32_t FileInfoId_t;
 static const int k_file_info_undef = -1;
 static const int k_file_info_error = 0;
+static const int k_file_info_dd_profiling = 1;
 } // namespace ddprof

--- a/include/ddprof_file_info.hpp
+++ b/include/ddprof_file_info.hpp
@@ -59,7 +59,7 @@ public:
   /// Opens a file descriptor to the file
   FileInfoValue(FileInfo &&info, FileInfoId_t id);
   FileInfoValue(const FileInfoValue &other) = delete;
-  FileInfoValue &operator=(const FileInfoValue &other) = delete;;
+  FileInfoValue &operator=(const FileInfoValue &other) = delete;
   FileInfoValue(FileInfoValue &&other);
   FileInfoValue &operator=(FileInfoValue &&other);
   ~FileInfoValue();

--- a/include/ddprof_file_info.hpp
+++ b/include/ddprof_file_info.hpp
@@ -58,8 +58,8 @@ public:
   FileInfoValue(FileInfo &&info, FileInfoId_t id, int fd);
   /// Opens a file descriptor to the file
   FileInfoValue(FileInfo &&info, FileInfoId_t id);
-  FileInfoValue(const FileInfoValue &other);
-  FileInfoValue &operator=(const FileInfoValue &other);
+  FileInfoValue(const FileInfoValue &other) = delete;
+  FileInfoValue &operator=(const FileInfoValue &other) = delete;;
   FileInfoValue(FileInfoValue &&other);
   FileInfoValue &operator=(FileInfoValue &&other);
   ~FileInfoValue();

--- a/include/ddprof_file_info.hpp
+++ b/include/ddprof_file_info.hpp
@@ -54,16 +54,25 @@ struct FileInfo {
 /// Keeps metadata on the file associated to a key
 class FileInfoValue {
 public:
-  FileInfoValue(FileInfo &&info, FileInfoId_t id, bool errored = false)
-      : _info(info), _errored(errored), _id(id) {}
+  /// duplicates and holds the file descriptor
+  FileInfoValue(FileInfo &&info, FileInfoId_t id, int fd);
+  /// Opens a file descriptor to the file
+  FileInfoValue(FileInfo &&info, FileInfoId_t id);
+  FileInfoValue(const FileInfoValue& other);
+  FileInfoValue& operator=(const FileInfoValue& other);
+  FileInfoValue(FileInfoValue&& other);
+  FileInfoValue& operator=(FileInfoValue&& other);
+  ~FileInfoValue();
   FileInfoId_t get_id() const { return _id; }
   int64_t get_size() const { return _info._size; }
   const std::string &get_path() const { return _info._path; }
 
   FileInfo _info;
+  int      _fd;
 
-  mutable bool _errored; // a flag to avoid trying to read in a loop bad files
+  mutable bool _errored = false; // a flag to avoid trying to read in a loop bad files
 private:
+  void copy_values(const FileInfoValue& other);
   FileInfoId_t _id; // unique ID matching index in table
 };
 

--- a/include/ddprof_file_info.hpp
+++ b/include/ddprof_file_info.hpp
@@ -58,21 +58,22 @@ public:
   FileInfoValue(FileInfo &&info, FileInfoId_t id, int fd);
   /// Opens a file descriptor to the file
   FileInfoValue(FileInfo &&info, FileInfoId_t id);
-  FileInfoValue(const FileInfoValue& other);
-  FileInfoValue& operator=(const FileInfoValue& other);
-  FileInfoValue(FileInfoValue&& other);
-  FileInfoValue& operator=(FileInfoValue&& other);
+  FileInfoValue(const FileInfoValue &other);
+  FileInfoValue &operator=(const FileInfoValue &other);
+  FileInfoValue(FileInfoValue &&other);
+  FileInfoValue &operator=(FileInfoValue &&other);
   ~FileInfoValue();
   FileInfoId_t get_id() const { return _id; }
   int64_t get_size() const { return _info._size; }
   const std::string &get_path() const { return _info._path; }
 
   FileInfo _info;
-  int      _fd;
+  int _fd;
 
-  mutable bool _errored = false; // a flag to avoid trying to read in a loop bad files
+  mutable bool _errored =
+      false; // a flag to avoid trying to read in a loop bad files
 private:
-  void copy_values(const FileInfoValue& other);
+  void copy_values(const FileInfoValue &other);
   FileInfoId_t _id; // unique ID matching index in table
 };
 

--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -81,7 +81,7 @@ public:
   using DsoFindRes = std::pair<DsoMapConstIt, bool>;
 
   /******* MAIN APIS **********/
-  DsoHdr(int fd_dd_profiling = -1);
+  explicit DsoHdr(int dd_profiling_fd = -1);
 
   // Add the element check for overlap and remove them
   DsoFindRes insert_erase_overlap(Dso &&dso);
@@ -176,7 +176,7 @@ private:
   FileInfoVector _file_info_vector;
   // /proc files can be mounted at various places (whole host profiling)
   std::string _path_to_proc;
-  int _fd_dd_profiling;
+  int _dd_profiling_fd;
 };
 
 } // namespace ddprof

--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -103,8 +103,6 @@ public:
   static DsoFindRes dso_find_closest(const DsoMap &map, pid_t pid,
                                      ElfAddress_t addr);
 
-  bool dso_handled_type_read_dso(const Dso &dso);
-
   // parse procfs to look for dso elements
   bool pid_backpopulate(pid_t pid, int &nb_elts_added);
 

--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -167,7 +167,11 @@ private:
   // parse procfs to look for dso elements
   bool pid_backpopulate(DsoMap &map, pid_t pid, int &nb_elts_added);
 
-  FileInfoId_t update_id_and_path(const Dso &dso);
+  FileInfoId_t update_id_from_dso(const Dso &dso);
+
+  FileInfoId_t update_id_dd_profiling(const Dso &dso);
+
+  FileInfoId_t update_id_from_path(const Dso &dso);
 
   BackpopulateStateMap _backpopulate_state_map;
 
@@ -177,6 +181,9 @@ private:
   // /proc files can be mounted at various places (whole host profiling)
   std::string _path_to_proc;
   int _dd_profiling_fd;
+  // Assumption is that we have a single version of the dd_profiling library
+  // accross all PIDs.
+  FileInfoId_t _dd_profiling_file_info = k_file_info_undef;
 };
 
 } // namespace ddprof

--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -81,7 +81,7 @@ public:
   using DsoFindRes = std::pair<DsoMapConstIt, bool>;
 
   /******* MAIN APIS **********/
-  DsoHdr();
+  DsoHdr(int fd_dd_profiling = -1);
 
   // Add the element check for overlap and remove them
   DsoFindRes insert_erase_overlap(Dso &&dso);
@@ -178,6 +178,7 @@ private:
   FileInfoVector _file_info_vector;
   // /proc files can be mounted at various places (whole host profiling)
   std::string _path_to_proc;
+  int _fd_dd_profiling;
 };
 
 } // namespace ddprof

--- a/include/dso_type.hpp
+++ b/include/dso_type.hpp
@@ -20,6 +20,16 @@ enum DsoType {
   kNbDsoTypes
 };
 
+
+static inline bool has_relevant_path(dso::DsoType dso_type) {
+  if (dso_type == kDDProfiling) {
+    return true;
+  }
+  if (dso_type == kStandard) {
+    return true;
+  }
+  return false;
+}
 // todo : find an enum that supports to_str
 static inline const char *dso_type_str(DsoType path_type) {
   switch (path_type) {

--- a/include/dso_type.hpp
+++ b/include/dso_type.hpp
@@ -20,7 +20,6 @@ enum DsoType {
   kNbDsoTypes
 };
 
-
 static inline bool has_relevant_path(dso::DsoType dso_type) {
   if (dso_type == kDDProfiling) {
     return true;

--- a/include/dso_type.hpp
+++ b/include/dso_type.hpp
@@ -16,6 +16,7 @@ enum DsoType {
   kUndef,
   kAnon,
   kSocket,
+  kDDProfiling, // special case in which the library might be known internally
   kNbDsoTypes
 };
 
@@ -38,6 +39,8 @@ static inline const char *dso_type_str(DsoType path_type) {
     return "Anonymous";
   case kSocket:
     return "kSocket";
+  case kDDProfiling:
+    return "kDDProfiling";
   default:
     break;
   }

--- a/include/ipc.hpp
+++ b/include/ipc.hpp
@@ -86,7 +86,7 @@ struct RingBufferInfo {
   int64_t mem_size = -1;
   int ring_fd = -1;
   int event_fd = -1;
-  int ring_buffer_type;
+  int ring_buffer_type = 0;
 };
 
 struct ReplyMessage {

--- a/include/unwind_state.hpp
+++ b/include/unwind_state.hpp
@@ -37,8 +37,8 @@ struct UnwindRegisters {
 /// given through callbacks
 struct UnwindState {
   UnwindState(int fd_dd_profiling = -1)
-      : _dwfl_wrapper(nullptr), dso_hdr(fd_dd_profiling), pid(-1), stack(nullptr), stack_sz(0),
-        current_ip(0) {
+      : _dwfl_wrapper(nullptr), dso_hdr(fd_dd_profiling), pid(-1),
+        stack(nullptr), stack_sz(0), current_ip(0) {
     uw_output_clear(&output);
   }
 

--- a/include/unwind_state.hpp
+++ b/include/unwind_state.hpp
@@ -36,8 +36,8 @@ struct UnwindRegisters {
 /// Single structure with everything necessary in unwinding. The structure is
 /// given through callbacks
 struct UnwindState {
-  UnwindState(int fd_dd_profiling = -1)
-      : _dwfl_wrapper(nullptr), dso_hdr(fd_dd_profiling), pid(-1),
+  explicit UnwindState(int dd_profiling_fd = -1)
+      : _dwfl_wrapper(nullptr), dso_hdr(dd_profiling_fd), pid(-1),
         stack(nullptr), stack_sz(0), current_ip(0) {
     uw_output_clear(&output);
   }

--- a/include/unwind_state.hpp
+++ b/include/unwind_state.hpp
@@ -36,8 +36,8 @@ struct UnwindRegisters {
 /// Single structure with everything necessary in unwinding. The structure is
 /// given through callbacks
 struct UnwindState {
-  UnwindState()
-      : _dwfl_wrapper(nullptr), pid(-1), stack(nullptr), stack_sz(0),
+  UnwindState(int fd_dd_profiling = -1)
+      : _dwfl_wrapper(nullptr), dso_hdr(fd_dd_profiling), pid(-1), stack(nullptr), stack_sz(0),
         current_ip(0) {
     uw_output_clear(&output);
   }

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -16,11 +16,13 @@ EXTENSION_CC=${CC:-"gcc"}
 # strip version number from compiler
 EXTENSION_CC=${EXTENSION_CC%-*}
 
-LIBC_INFO=$(ldd  --version 2>&1  | grep musl || true)
-if [ ! -z "${LIBC_INFO}" ]; then
-  EXTENSION_OS="alpine-linux"
+LIBC_HAS_MUSL=$(ldd  --version 2>&1  | grep musl || true)
+if [ ! -z "${LIBC_HAS_MUSL}" ]; then
+  LIBC_VERSION=$(get_libc_version.sh musl)
+  EXTENSION_OS="alpine-linux-${LIBC_VERSION}"
 else
-  EXTENSION_OS="unknown-linux"
+  LIBC_VERSION=$(get_libc_version.sh gnu)
+  EXTENSION_OS="unknown-linux-${LIBC_VERSION}"
 fi
 
 COMMON_OPT="${COMPILER_SETTING} -DACCURACY_TEST=ON -DCMAKE_INSTALL_PREFIX=${DDPROF_INSTALL_PREFIX} -DBUILD_BENCHMARKS=${DDPROF_BUILD_BENCH} -DBUILD_NATIVE_LIB=${NATIVE_LIB}"

--- a/src/base_frame_symbol_lookup.cc
+++ b/src/base_frame_symbol_lookup.cc
@@ -25,7 +25,7 @@ BaseFrameSymbolLookup::insert_bin_symbol(pid_t pid, SymbolTable &symbol_table,
   SymbolIdx_t symbol_idx = -1;
 
   DsoHdr::DsoFindRes find_res = dso_hdr.dso_find_first_std_executable(pid);
-  if (find_res.second && find_res.first->second._type == dso::kStandard) {
+  if (find_res.second && dso::has_relevant_path(find_res.first->second._type)) {
     // todo : how to tie lifetime of DSO to this ?
     symbol_idx =
         dso_symbol_lookup.get_or_insert(find_res.first->second, symbol_table);

--- a/src/ddprof_context_lib.cc
+++ b/src/ddprof_context_lib.cc
@@ -268,6 +268,8 @@ DDRes ddprof_context_set(DDProfInput *input, DDProfContext *ctx) {
     }
   }
 
+  ctx->params.fd_dd_profiling = -1;
+
   const char *preset = input->preset;
   if (!preset && ctx->num_watchers == 0) {
     // use `default` preset when no preset and no events were given in input

--- a/src/ddprof_context_lib.cc
+++ b/src/ddprof_context_lib.cc
@@ -268,7 +268,7 @@ DDRes ddprof_context_set(DDProfInput *input, DDProfContext *ctx) {
     }
   }
 
-  ctx->params.fd_dd_profiling = -1;
+  ctx->params.dd_profiling_fd = -1;
 
   const char *preset = input->preset;
   if (!preset && ctx->num_watchers == 0) {

--- a/src/ddprof_file_info.cc
+++ b/src/ddprof_file_info.cc
@@ -5,14 +5,13 @@
 
 #include "ddprof_file_info.hpp"
 
+#include "ddres_exception.hpp"
 #include <fcntl.h>
 #include <unistd.h>
-#include "ddres_exception.hpp"
 
 #include "logger.hpp"
 
 namespace ddprof {
-
 
 bool FileInfoInodeKey::operator==(const FileInfoInodeKey &o) const {
   // default comparison is c++20
@@ -20,27 +19,34 @@ bool FileInfoInodeKey::operator==(const FileInfoInodeKey &o) const {
 }
 
 FileInfoValue::FileInfoValue(FileInfo &&info, FileInfoId_t id, int fd)
-    : _info(info), _id(id) {
-  _fd = dup(fd);
+    : _info(info), _fd(-1), _id(id) {
+  if (fd >= 0) {
+    LG_WRN("[FileInfo] yay got a FD(%d) to %s", fd, _info._path.c_str());
+    _fd = dup(fd);
+  }
   if (_fd < 0) { // acceptable value for dwfl
-    LG_WRN("[FileInfo] failed to duplicate %s", info._path.c_str());
+    LG_WRN("[FileInfo] failed to duplicate %s", _info._path.c_str());
     _errored = true;
   }
 }
 
 FileInfoValue::FileInfoValue(FileInfo &&info, FileInfoId_t id)
-    : _info(info),  _id(id) {
-  _fd = open (info._path.c_str(), O_RDONLY);
-  if (_fd < 0) { // acceptable value for dwfl
-    LG_WRN("[FileInfo] failed to open %s", info._path.c_str());
-    _errored = true;
+    : _info(info), _fd(-1),  _id(id) {
+  if (!_info._path.empty()) {
+    _fd = open(_info._path.c_str(), O_RDONLY);
+    if (_fd < 0) { // acceptable value for dwfl
+      LG_WRN("[FileInfo] failed to open %s", _info._path.c_str());
+    }
+    else {
+      LG_DBG("[FileInfo] Success opening %s, ", _info._path.c_str());
+    }
   }
-  else {
-    LG_DBG("[FileInfo] Success opening %s, ", info._path.c_str());
+  if (_fd < 0) { // acceptable value for dwfl
+    _errored = true;
   }
 }
 
-void FileInfoValue::copy_values(const FileInfoValue& other) {
+void FileInfoValue::copy_values(const FileInfoValue &other) {
   _info = other._info;
   _errored = other._errored;
   _id = other._id;
@@ -49,37 +55,37 @@ void FileInfoValue::copy_values(const FileInfoValue& other) {
 
 FileInfoValue::~FileInfoValue() {
   if (this->_fd != -1)
-      close(this->_fd);
+    close(this->_fd);
 }
 
-FileInfoValue::FileInfoValue(const FileInfoValue& other) {
+FileInfoValue::FileInfoValue(const FileInfoValue &other) {
   copy_values(other);
   if (other._fd >= 0) {
     this->_fd = dup(other._fd);
   }
 }
 
-FileInfoValue& FileInfoValue::operator=(const FileInfoValue& other) {
-    if (this != &other) {
-        close(this->_fd);
-        copy_values(other);
-        if (other._fd >= 0) {
-          this->_fd = dup(other._fd);
-        }
-    }
-    return *this;
-}
-
-FileInfoValue::FileInfoValue(FileInfoValue&& other) {
-    copy_values(other);
-    other._fd = -1;
-}
-
-FileInfoValue& FileInfoValue::operator=(FileInfoValue&& other) {
-    // move assignment operator
+FileInfoValue &FileInfoValue::operator=(const FileInfoValue &other) {
+  if (this != &other) {
     close(this->_fd);
     copy_values(other);
-    other._fd = -1;
-    return *this;
+    if (other._fd >= 0) {
+      this->_fd = dup(other._fd);
+    }
+  }
+  return *this;
+}
+
+FileInfoValue::FileInfoValue(FileInfoValue &&other) {
+  copy_values(other);
+  other._fd = -1;
+}
+
+FileInfoValue &FileInfoValue::operator=(FileInfoValue &&other) {
+  // move assignment operator
+  close(this->_fd);
+  copy_values(other);
+  other._fd = -1;
+  return *this;
 }
 } // namespace ddprof

--- a/src/ddprof_file_info.cc
+++ b/src/ddprof_file_info.cc
@@ -21,7 +21,8 @@ bool FileInfoInodeKey::operator==(const FileInfoInodeKey &o) const {
 FileInfoValue::FileInfoValue(FileInfo &&info, FileInfoId_t id, int fd)
     : _info(info), _fd(-1), _id(id) {
   if (fd >= 0) {
-    LG_WRN("[FileInfo] yay got a FD(%d) to %s", fd, _info._path.c_str());
+    LG_DBG("[FileInfo] using existing file descriptor(%d) to %s", fd,
+           _info._path.c_str());
     _fd = dup(fd);
   }
   if (_fd < 0) { // acceptable value for dwfl

--- a/src/ddprof_file_info.cc
+++ b/src/ddprof_file_info.cc
@@ -58,24 +58,6 @@ FileInfoValue::~FileInfoValue() {
     close(this->_fd);
 }
 
-FileInfoValue::FileInfoValue(const FileInfoValue &other) {
-  copy_values(other);
-  if (other._fd >= 0) {
-    this->_fd = dup(other._fd);
-  }
-}
-
-FileInfoValue &FileInfoValue::operator=(const FileInfoValue &other) {
-  if (this != &other) {
-    close(this->_fd);
-    copy_values(other);
-    if (other._fd >= 0) {
-      this->_fd = dup(other._fd);
-    }
-  }
-  return *this;
-}
-
 FileInfoValue::FileInfoValue(FileInfoValue &&other) {
   copy_values(other);
   other._fd = -1;

--- a/src/ddprof_file_info.cc
+++ b/src/ddprof_file_info.cc
@@ -31,13 +31,12 @@ FileInfoValue::FileInfoValue(FileInfo &&info, FileInfoId_t id, int fd)
 }
 
 FileInfoValue::FileInfoValue(FileInfo &&info, FileInfoId_t id)
-    : _info(info), _fd(-1),  _id(id) {
+    : _info(info), _fd(-1), _id(id) {
   if (!_info._path.empty()) {
     _fd = open(_info._path.c_str(), O_RDONLY);
     if (_fd < 0) { // acceptable value for dwfl
       LG_WRN("[FileInfo] failed to open %s", _info._path.c_str());
-    }
-    else {
+    } else {
       LG_DBG("[FileInfo] Success opening %s, ", _info._path.c_str());
     }
   }

--- a/src/ddprof_file_info.cc
+++ b/src/ddprof_file_info.cc
@@ -5,11 +5,81 @@
 
 #include "ddprof_file_info.hpp"
 
+#include <fcntl.h>
+#include <unistd.h>
+#include "ddres_exception.hpp"
+
+#include "logger.hpp"
+
 namespace ddprof {
+
 
 bool FileInfoInodeKey::operator==(const FileInfoInodeKey &o) const {
   // default comparison is c++20
   return _inode == o._inode && _sz == o._sz;
 }
 
+FileInfoValue::FileInfoValue(FileInfo &&info, FileInfoId_t id, int fd)
+    : _info(info), _id(id) {
+  _fd = dup(fd);
+  if (_fd < 0) { // acceptable value for dwfl
+    LG_WRN("[FileInfo] failed to duplicate %s", info._path.c_str());
+    _errored = true;
+  }
+}
+
+FileInfoValue::FileInfoValue(FileInfo &&info, FileInfoId_t id)
+    : _info(info),  _id(id) {
+  _fd = open (info._path.c_str(), O_RDONLY);
+  if (_fd < 0) { // acceptable value for dwfl
+    LG_WRN("[FileInfo] failed to open %s", info._path.c_str());
+    _errored = true;
+  }
+  else {
+    LG_DBG("[FileInfo] Success opening %s, ", info._path.c_str());
+  }
+}
+
+void FileInfoValue::copy_values(const FileInfoValue& other) {
+  _info = other._info;
+  _errored = other._errored;
+  _id = other._id;
+  _fd = other._fd;
+}
+
+FileInfoValue::~FileInfoValue() {
+  if (this->_fd != -1)
+      close(this->_fd);
+}
+
+FileInfoValue::FileInfoValue(const FileInfoValue& other) {
+  copy_values(other);
+  if (other._fd >= 0) {
+    this->_fd = dup(other._fd);
+  }
+}
+
+FileInfoValue& FileInfoValue::operator=(const FileInfoValue& other) {
+    if (this != &other) {
+        close(this->_fd);
+        copy_values(other);
+        if (other._fd >= 0) {
+          this->_fd = dup(other._fd);
+        }
+    }
+    return *this;
+}
+
+FileInfoValue::FileInfoValue(FileInfoValue&& other) {
+    copy_values(other);
+    other._fd = -1;
+}
+
+FileInfoValue& FileInfoValue::operator=(FileInfoValue&& other) {
+    // move assignment operator
+    close(this->_fd);
+    copy_values(other);
+    other._fd = -1;
+    return *this;
+}
 } // namespace ddprof

--- a/src/ddprof_module_lib.cc
+++ b/src/ddprof_module_lib.cc
@@ -21,7 +21,8 @@
 namespace ddprof {
 
 static bool get_elf_offsets(int fd, Offset_t &start_offset,
-                            Offset_t &bias_offset, const std::string &filepath){
+                            Offset_t &bias_offset,
+                            const std::string &filepath) {
   Elf *elf = elf_begin(fd, ELF_C_READ_MMAP, NULL);
   if (elf == NULL) {
     LG_WRN("Invalid elf %s", filepath.c_str());
@@ -137,9 +138,8 @@ DDRes report_module(Dwfl *dwfl, ProcessAddress_t pc, const Dso &dso,
   ProcessAddress_t start = dso._start - dso._pgoff - start_offset;
   Offset_t bias = dso._start - dso._pgoff - bias_offset;
 
-  ddprof_mod._mod =
-      dwfl_report_elf(dwfl, module_name, filepath.c_str(), fileInfoValue._fd,
-                      start, false);
+  ddprof_mod._mod = dwfl_report_elf(dwfl, module_name, filepath.c_str(),
+                                    fileInfoValue._fd, start, false);
 
   if (!ddprof_mod._mod) {
     // Ideally we would differentiate pid errors from file errors.

--- a/src/ddprof_module_lib.cc
+++ b/src/ddprof_module_lib.cc
@@ -21,8 +21,8 @@
 namespace ddprof {
 
 static bool get_elf_offsets(int fd, Offset_t &start_offset,
-                            Offset_t &bias_offset,
-                            const std::string &filepath) {
+                            const std::string &filepath,
+                            Offset_t &bias_offset) {
   Elf *elf = elf_begin(fd, ELF_C_READ_MMAP, NULL);
   if (elf == NULL) {
     LG_WRN("Invalid elf %s", filepath.c_str());
@@ -127,8 +127,8 @@ DDRes report_module(Dwfl *dwfl, ProcessAddress_t pc, const Dso &dso,
   // Load the file at a matching DSO address
   dwfl_errno(); // erase previous error
   Offset_t start_offset, bias_offset;
-  if (!get_elf_offsets(fileInfoValue._fd, start_offset, bias_offset,
-                       filepath)) {
+  if (!get_elf_offsets(fileInfoValue._fd, start_offset, filepath,
+                       bias_offset)) {
     fileInfoValue._errored = true;
     LG_WRN("Couldn't retrieve offsets from %s(%s)", module_name,
            fileInfoValue.get_path().c_str());
@@ -145,8 +145,8 @@ DDRes report_module(Dwfl *dwfl, ProcessAddress_t pc, const Dso &dso,
            fileInfoValue.get_path().c_str());
     return ddres_warn(DD_WHAT_MODULE);
   }
-  ddprof_mod._mod = dwfl_report_elf(dwfl, module_name, filepath.c_str(),
-                                    fd, start, false);
+  ddprof_mod._mod =
+      dwfl_report_elf(dwfl, module_name, filepath.c_str(), fd, start, false);
 
   if (!ddprof_mod._mod) {
     // Ideally we would differentiate pid errors from file errors.

--- a/src/ddprof_module_lib.cc
+++ b/src/ddprof_module_lib.cc
@@ -138,8 +138,15 @@ DDRes report_module(Dwfl *dwfl, ProcessAddress_t pc, const Dso &dso,
   ProcessAddress_t start = dso._start - dso._pgoff - start_offset;
   Offset_t bias = dso._start - dso._pgoff - bias_offset;
 
+  // libdwfl takes ownership (which is not 100% expected)
+  int fd = dup(fileInfoValue._fd);
+  if (fd < 0) {
+    LG_WRN("Couldn't duplicate fd to module %s(%s)", module_name,
+           fileInfoValue.get_path().c_str());
+    return ddres_warn(DD_WHAT_MODULE);
+  }
   ddprof_mod._mod = dwfl_report_elf(dwfl, module_name, filepath.c_str(),
-                                    fileInfoValue._fd, start, false);
+                                    fd, start, false);
 
   if (!ddprof_mod._mod) {
     // Ideally we would differentiate pid errors from file errors.

--- a/src/ddprof_module_lib.cc
+++ b/src/ddprof_module_lib.cc
@@ -20,14 +20,8 @@
 
 namespace ddprof {
 
-static bool get_elf_offsets(const std::string &filepath, Offset_t &start_offset,
-                            Offset_t &bias_offset) {
-  int fd = ::open(filepath.c_str(), O_RDONLY);
-  if (fd < 0) {
-    LG_WRN("Could not open %s", filepath.c_str());
-    return false;
-  }
-  defer { ::close(fd); };
+static bool get_elf_offsets(int fd, Offset_t &start_offset,
+                            Offset_t &bias_offset, const std::string &filepath){
   Elf *elf = elf_begin(fd, ELF_C_READ_MMAP, NULL);
   if (elf == NULL) {
     LG_WRN("Invalid elf %s", filepath.c_str());
@@ -132,7 +126,8 @@ DDRes report_module(Dwfl *dwfl, ProcessAddress_t pc, const Dso &dso,
   // Load the file at a matching DSO address
   dwfl_errno(); // erase previous error
   Offset_t start_offset, bias_offset;
-  if (!get_elf_offsets(filepath, start_offset, bias_offset)) {
+  if (!get_elf_offsets(fileInfoValue._fd, start_offset, bias_offset,
+                       filepath)) {
     fileInfoValue._errored = true;
     LG_WRN("Couldn't retrieve offsets from %s(%s)", module_name,
            fileInfoValue.get_path().c_str());
@@ -143,7 +138,8 @@ DDRes report_module(Dwfl *dwfl, ProcessAddress_t pc, const Dso &dso,
   Offset_t bias = dso._start - dso._pgoff - bias_offset;
 
   ddprof_mod._mod =
-      dwfl_report_elf(dwfl, module_name, filepath.c_str(), -1, start, false);
+      dwfl_report_elf(dwfl, module_name, filepath.c_str(), fileInfoValue._fd,
+                      start, false);
 
   if (!ddprof_mod._mod) {
     // Ideally we would differentiate pid errors from file errors.

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -81,7 +81,6 @@ DDRes worker_library_init(DDProfContext *ctx,
     // Make sure worker index is initialized correctly
     ctx->worker_ctx.i_current_pprof = 0;
     ctx->worker_ctx.exp_tid = {0};
-    LG_DBG("retrieved fd = %d", ctx->params.dd_profiling_fd);
     ctx->worker_ctx.us = new UnwindState(ctx->params.dd_profiling_fd);
 
     // register the existing persistent storage for the state
@@ -210,7 +209,6 @@ DDRes ddprof_pr_sample(DDProfContext *ctx, perf_event_sample *sample,
   us->output.pid = sample->pid;
   us->output.tid = sample->tid;
 
-  LG_DBG("process watch pos = %d  --", watcher_pos);
   // If this is a SW_TASK_CLOCK-type event, then aggregate the time
   if (ctx->watchers[watcher_pos].config == PERF_COUNT_SW_TASK_CLOCK)
     ddprof_stats_add(STATS_TARGET_CPU_USAGE, sample->period, NULL);

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -81,7 +81,7 @@ DDRes worker_library_init(DDProfContext *ctx,
     // Make sure worker index is initialized correctly
     ctx->worker_ctx.i_current_pprof = 0;
     ctx->worker_ctx.exp_tid = {0};
-
+    LG_DBG("retrieved fd = %d", ctx->params.fd_dd_profiling);
     ctx->worker_ctx.us = new UnwindState(ctx->params.fd_dd_profiling);
 
     // register the existing persistent storage for the state
@@ -210,6 +210,7 @@ DDRes ddprof_pr_sample(DDProfContext *ctx, perf_event_sample *sample,
   us->output.pid = sample->pid;
   us->output.tid = sample->tid;
 
+  LG_DBG("process watch pos = %d  --", watcher_pos);
   // If this is a SW_TASK_CLOCK-type event, then aggregate the time
   if (ctx->watchers[watcher_pos].config == PERF_COUNT_SW_TASK_CLOCK)
     ddprof_stats_add(STATS_TARGET_CPU_USAGE, sample->period, NULL);

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -82,7 +82,7 @@ DDRes worker_library_init(DDProfContext *ctx,
     ctx->worker_ctx.i_current_pprof = 0;
     ctx->worker_ctx.exp_tid = {0};
 
-    ctx->worker_ctx.us = new UnwindState();
+    ctx->worker_ctx.us = new UnwindState(ctx->params.fd_dd_profiling);
 
     // register the existing persistent storage for the state
     ctx->worker_ctx.persistent_worker_state = persistent_worker_state;

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -81,8 +81,8 @@ DDRes worker_library_init(DDProfContext *ctx,
     // Make sure worker index is initialized correctly
     ctx->worker_ctx.i_current_pprof = 0;
     ctx->worker_ctx.exp_tid = {0};
-    LG_DBG("retrieved fd = %d", ctx->params.fd_dd_profiling);
-    ctx->worker_ctx.us = new UnwindState(ctx->params.fd_dd_profiling);
+    LG_DBG("retrieved fd = %d", ctx->params.dd_profiling_fd);
+    ctx->worker_ctx.us = new UnwindState(ctx->params.dd_profiling_fd);
 
     // register the existing persistent storage for the state
     ctx->worker_ctx.persistent_worker_state = persistent_worker_state;

--- a/src/dso.cc
+++ b/src/dso.cc
@@ -5,6 +5,7 @@
 
 #include "dso.hpp"
 
+#include "constants.hpp"
 #include "ddprof_defs.hpp"
 #include "logger.hpp"
 #include "string_format.hpp"
@@ -27,7 +28,7 @@ static const std::string_view s_socket_str = "socket";
 // null elements
 static const std::string_view s_dev_zero_str = "/dev/zero";
 static const std::string_view s_dev_null_str = "/dev/null";
-static const std::string_view s_dd_profiling_str = "libdd_profiling";
+static const std::string_view s_dd_profiling_str = k_libdd_profiling_name;
 
 // invalid element
 Dso::Dso()

--- a/src/dso.cc
+++ b/src/dso.cc
@@ -27,6 +27,8 @@ static const std::string_view s_socket_str = "socket";
 // null elements
 static const std::string_view s_dev_zero_str = "/dev/zero";
 static const std::string_view s_dev_null_str = "/dev/null";
+static const std::string_view s_dd_profiling_str = "libdd_profiling";
+
 // invalid element
 Dso::Dso()
     : _pid(-1), _start(), _end(), _pgoff(), _filename(), _type(dso::kUndef),
@@ -61,6 +63,15 @@ Dso::Dso(pid_t pid, ElfAddress_t start, ElfAddress_t end, ElfAddress_t pgoff,
     _type = dso::kSocket;
   } else if (_filename[0] == '[') {
     _type = dso::kUndef;
+  }
+  else { // check if this standard dso matches our internal dd_profiling lib
+    std::size_t pos = _filename.rfind('/');
+    if (pos != std::string::npos) {
+      if (_filename.substr(pos + 1, s_dd_profiling_str.length()) == s_dd_profiling_str) {
+        _type = dso::kDDProfiling;
+      }
+    }
+
   }
 }
 

--- a/src/dso.cc
+++ b/src/dso.cc
@@ -63,15 +63,13 @@ Dso::Dso(pid_t pid, ElfAddress_t start, ElfAddress_t end, ElfAddress_t pgoff,
     _type = dso::kSocket;
   } else if (_filename[0] == '[') {
     _type = dso::kUndef;
-  }
-  else { // check if this standard dso matches our internal dd_profiling lib
+  } else { // check if this standard dso matches our internal dd_profiling lib
     std::size_t pos = _filename.rfind('/');
-    if (pos != std::string::npos) {
-      if (_filename.substr(pos + 1, s_dd_profiling_str.length()) == s_dd_profiling_str) {
-        _type = dso::kDDProfiling;
-      }
+    if (pos != std::string::npos &&
+        _filename.substr(pos + 1, s_dd_profiling_str.length()) ==
+            s_dd_profiling_str) {
+      _type = dso::kDDProfiling;
     }
-
   }
 }
 
@@ -82,7 +80,7 @@ std::string Dso::to_string() const {
 }
 
 std::string Dso::format_filename() const {
-  if (_type == dso::kStandard) {
+  if (dso::has_relevant_path(_type)) {
     return _filename;
   } else {
     return dso::dso_type_str(_type);

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -109,7 +109,7 @@ uint64_t DsoStats::sum_event_metric(DsoEventType dso_event) const {
 /**********/
 /* DsoHdr */
 /**********/
-DsoHdr::DsoHdr(int fd_dd_profiling) : _fd_dd_profiling(fd_dd_profiling) {
+DsoHdr::DsoHdr(int dd_profiling_fd) : _dd_profiling_fd(dd_profiling_fd) {
   // Test different places for existence of /proc
   // A given procfs can only work if its PID namespace is the same as mine.
   // Fortunately, `/proc/self` will return a symlink to my process ID in the
@@ -275,9 +275,9 @@ FileInfoId_t DsoHdr::update_id_and_path(const Dso &dso) {
   if (it == _file_info_inode_map.end()) {
     dso._id = _file_info_vector.size();
     _file_info_inode_map.emplace(std::move(key), dso._id);
-    if (dso._type == dso::DsoType::kDDProfiling && _fd_dd_profiling >= 0) {
+    if (dso._type == dso::DsoType::kDDProfiling && _dd_profiling_fd >= 0) {
       _file_info_vector.emplace_back(std::move(file_info), dso._id,
-                                     _fd_dd_profiling);
+                                     _dd_profiling_fd);
     } else {
       // open the file descriptor to this file
       _file_info_vector.emplace_back(std::move(file_info), dso._id);

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -262,14 +262,14 @@ FileInfoId_t DsoHdr::update_id_dd_profiling(const Dso &dso) {
     dso._id = _dd_profiling_file_info;
     return dso._id;
   }
-  
+
   if (_dd_profiling_fd != -1) {
     // Path is not valid, don't use the map
     // fd already exists --> lookup directly
     dso._id = _file_info_vector.size();
     _dd_profiling_file_info = dso._id;
-    _file_info_vector.emplace_back(std::move(FileInfo(dso._filename, 0, 0)), dso._id,
-                                    _dd_profiling_fd);
+    _file_info_vector.emplace_back(std::move(FileInfo(dso._filename, 0, 0)),
+                                   dso._id, _dd_profiling_fd);
     return _dd_profiling_file_info;
   }
   _dd_profiling_file_info = update_id_from_path(dso);

--- a/src/dso_symbol_lookup.cc
+++ b/src/dso_symbol_lookup.cc
@@ -52,7 +52,7 @@ SymbolIdx_t DsoSymbolLookup::get_or_insert(FileAddress_t normalized_addr,
                                            SymbolTable &symbol_table,
                                            std::string_view addr_type) {
   // Only add address information for relevant dso types
-  if (dso._type != dso::kStandard && dso._type != dso::kVdso &&
+  if (!dso::has_relevant_path(dso._type) && dso._type != dso::kVdso &&
       dso._type != dso::kVsysCall) {
     return get_or_insert_unhandled_type(dso, symbol_table);
   }

--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -183,9 +183,14 @@ static int start_profiler_internal(DDProfContext *ctx, bool &is_profiler) {
       if (socketpair(AF_UNIX, SOCK_DGRAM, 0, sockfds) == -1) {
         return -1;
       }
-      if (!IsDDResOK(get_library_path(dd_profiling_lib_path, ctx->params.fd_dd_profiling))) {
+      int fd = -1;
+      if (!IsDDResOK(get_library_path(dd_profiling_lib_path,
+                                      fd))) {
         return -1;
       }
+      LG_DBG("ctx->params.fd_dd_profiling = %d", ctx->params.fd_dd_profiling);
+      ctx->params.fd_dd_profiling = fd;
+
       ctx->params.sockfd = sockfds[kChildIdx];
       ctx->params.wait_on_socket = true;
     }

--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -184,12 +184,11 @@ static int start_profiler_internal(DDProfContext *ctx, bool &is_profiler) {
         return -1;
       }
       int fd = -1;
-      if (!IsDDResOK(get_library_path(dd_profiling_lib_path,
-                                      fd))) {
+      if (!IsDDResOK(get_library_path(dd_profiling_lib_path, fd))) {
         return -1;
       }
-      LG_DBG("ctx->params.fd_dd_profiling = %d", ctx->params.fd_dd_profiling);
-      ctx->params.fd_dd_profiling = fd;
+      LG_DBG("ctx->params.dd_profiling_fd = %d", ctx->params.dd_profiling_fd);
+      ctx->params.dd_profiling_fd = fd;
 
       ctx->params.sockfd = sockfds[kChildIdx];
       ctx->params.wait_on_socket = true;

--- a/src/lib/allocation_tracker.cc
+++ b/src/lib/allocation_tracker.cc
@@ -95,7 +95,6 @@ DDRes AllocationTracker::allocation_tracking_init(
 
   DDRES_CHECK_FWD(instance->init(allocation_profiling_rate,
                                  flags & kDeterministicSampling, ring_buffer));
-
   _instance = instance;
   state.track_allocations = true;
   state.track_deallocations = flags & kTrackDeallocations;

--- a/src/lib/malloc_wrapper.cc
+++ b/src/lib/malloc_wrapper.cc
@@ -87,6 +87,8 @@ void init() {
 } // namespace
 
 void *malloc(size_t size) {
+  printf("Going through %s", __FUNCTION__);
+
   void *ptr = s_malloc(size);
   ddprof::AllocationTracker::track_allocation(reinterpret_cast<uintptr_t>(ptr),
                                               size);

--- a/src/lib/malloc_wrapper.cc
+++ b/src/lib/malloc_wrapper.cc
@@ -87,8 +87,6 @@ void init() {
 } // namespace
 
 void *malloc(size_t size) {
-  printf("Going through %s", __FUNCTION__);
-
   void *ptr = s_malloc(size);
   ddprof::AllocationTracker::track_allocation(reinterpret_cast<uintptr_t>(ptr),
                                               size);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -375,6 +375,12 @@ add_unit_test(
     ../src/perf.cc
 )
 
+add_unit_test(
+    ddprof_file_info-ut
+    ddprof_file_info-ut.cc
+    ../src/ddprof_file_info.cc
+)
+
 add_benchmark(savecontext-bench savecontext-bench.cc ../src/savecontext.cc ../src/saveregisters.cc)
 add_benchmark(timer-bench timer-bench.cc ../src/timer.cc ../src/perf.cc)
 

--- a/test/ddprof_file_info-ut.cc
+++ b/test/ddprof_file_info-ut.cc
@@ -1,0 +1,23 @@
+#include "ddprof_file_info.hpp"
+
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include "loghandle.hpp"
+
+namespace ddprof {
+TEST(FileInfo, move) {
+  LogHandle handle;
+  std::string file_path = UNIT_TEST_DATA "/test_int_value.txt";
+  int fd = open(file_path.c_str(), O_RDONLY);
+  FileInfo file_info(file_path, 24, 25);
+  FileInfoValue value(std::move(file_info), 1, fd);
+  int dup_fd = value._fd;
+  {
+    auto new_val = std::move(value);
+    EXPECT_EQ(new_val._fd, dup_fd);
+  }
+  EXPECT_EQ(value._fd, -1);
+}
+} // namespace ddprof

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -210,10 +210,12 @@ static const char *s_inode_line = "7ffcd6c89000-7ffcd6c92000 rw-p 00000000 00:00
 
 static const char *s_jsa_line = "0x800000000-0x800001fff rw-p 00000000 00:00 0                          /usr/local/openjdk-11/lib/server/classes.jsa";
 
+static const char *s_dd_profiling = "0x800000000-0x800001fff rw-p 00000000 00:00 0                          /tmp/libdd_profiling.so.1234";
+
 // clang-format on
 
 TEST(DSOTest, dso_from_procline) {
-  // todo make dso_from_procline const
+  LogHandle handle;
   Dso no_exec =
       DsoHdr::dso_from_procline(10, const_cast<char *>(s_line_noexec));
   EXPECT_EQ(no_exec._type, dso::kStandard);
@@ -270,6 +272,11 @@ TEST(DSOTest, dso_from_procline) {
     DsoFindRes findres =
         dso_hdr.insert_erase_overlap(std::move(standard_dso_4));
     EXPECT_EQ(findres.first->second._end, end_4);
+  }
+  {
+    Dso dd_profiling_dso =
+        DsoHdr::dso_from_procline(10, const_cast<char *>(s_dd_profiling));
+    EXPECT_EQ(dd_profiling_dso._type, dso::kDDProfiling);
   }
 }
 

--- a/test/dwfl_module-ut.cc
+++ b/test/dwfl_module-ut.cc
@@ -37,7 +37,7 @@ TEST(DwflModule, inconsistency_test) {
 
   for (auto it = dso_map.begin(); it != dso_map.end(); ++it) {
     Dso &dso = it->second;
-    if (dso._type != dso::kStandard || !dso._executable) {
+    if (!dso::has_relevant_path(dso._type) || !dso._executable) {
       continue; // skip non exec / non standard (anon/vdso...)
     }
 

--- a/tools/get_libc_version.sh
+++ b/tools/get_libc_version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -z "${1=""}" ]; then
+  echo "specify the type of libc"
+  exit 1
+fi
+
+# slightly hacky way to check the libc version
+if [ ${1} == "musl" ]; then
+  ldd --version 2>&1 | grep Version | awk '{print $NF}'
+elif [ ${1} == "gnu" ]; then
+  ldd --version | head -n 1 | awk '{print $NF}'
+else
+  echo "LIBC NOT HANDLED"
+  exit 1
+fi


### PR DESCRIPTION
# What does this PR do?

- Store the file descriptor to the matching binaries to limit number of file opens on the same binary
- Store the file descriptor to the dd_profiling library when relevant
- Give libdwfl API a file descriptor instead of a path

# Motivation

As we were storing the library in a temporary file (getting deleted), we were not able to re-open the elf file when profiling the allocations. This was breaking allocation profiling.

# Additional Notes

This fixes allocation profiling when the library is not available

# How to test the change?

Allocation profiling (while deleting the dd_profiling library)
