### PR TITLE
Disable part of test only for musl libc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.19)
 ### Global definitions   ###
 ############################
 
- project(DDProf
+project(DDProf
   LANGUAGES C CXX
   VERSION 0.9.3
   DESCRIPTION "Datadog's native profiler for Linux"
@@ -40,6 +40,12 @@ find_package(Threads REQUIRED)
 
 #helper functions (defines add_exe)
 include(Helperfunc)
+
+detect_libc(LIBC_TYPE)
+
+if (LIBC_TYPE STREQUAL "musl")
+   add_compile_definitions("MUSL_LIBC")
+endif()
 
 # path to external dependencies
 set(VENDOR_EXTENSION "" CACHE STRING "Extension to allow builds with different libc")

--- a/test/savecontext-ut.cc
+++ b/test/savecontext-ut.cc
@@ -114,7 +114,7 @@ TEST(getcontext, unwind_from_sighandler) {
   EXPECT_TRUE(get_symbol(0)._demangle_name.starts_with("save_context("));
   EXPECT_EQ(get_symbol(1)._demangle_name, "handler(int)");
   size_t next_idx = 3;
-#  ifdef ALPINE_BUG_IS_FIXED
+#  ifndef MUSL_LIBC
   while (next_idx < state.output.nb_locs - 1 &&
          get_symbol(next_idx)._demangle_name != "funcD()") {
     ++next_idx;


### PR DESCRIPTION
# What does this PR do?

* Detect libc type by compiling a snippet file with verbose output and parsing -dynamic-linker option.
* Define MUSL_LIBC when musl libc is detected
* Modify savecontext-ut depending if MUSL_LIBC is defined
