### PR TITLE
Store requested sample stack size in Watcher

### DIFF
--- a/include/perf_watcher.hpp
+++ b/include/perf_watcher.hpp
@@ -34,6 +34,8 @@ typedef struct PerfWatcher {
     uint64_t sample_frequency;
   };
   int sample_type_id; // index into the sample types defined in this header
+  uint16_t sample_stack_size; // size of the stack to capture
+
   // perf_event_open configs
   struct PerfWatcherOptions options;
   // tracepoint configuration

--- a/include/unwind_output.hpp
+++ b/include/unwind_output.hpp
@@ -23,6 +23,7 @@ typedef struct UnwindOutput {
   uint64_t nb_locs;
   int pid;
   int tid;
+  bool is_incomplete;
 } UnwindOutput;
 
 void uw_output_clear(UnwindOutput *);

--- a/src/perf.cc
+++ b/src/perf.cc
@@ -42,7 +42,6 @@ struct perf_event_attr g_dd_native_attr = {
     .mmap_data = 0, // keep track of other mappings
     .sample_id_all = 1,
     .sample_regs_user = PERF_REGS_MASK,
-    .sample_stack_user = PERF_SAMPLE_STACK_SIZE, // Is this an insane default?
 };
 
 long get_page_size(void) {
@@ -88,6 +87,8 @@ perf_event_attr perf_config_from_watcher(const PerfWatcher *watcher,
   attr.sample_period = watcher->sample_period; // Equivalently, freq
   attr.freq = watcher->options.is_freq;
   attr.sample_type = watcher->sample_type;
+  attr.sample_stack_user = watcher->sample_stack_size;
+
   // If is_kernel is requested false --> exclude_kernel == true
   attr.exclude_kernel = (watcher->options.is_kernel == kPerfWatcher_Off);
 

--- a/src/perf_watcher.cc
+++ b/src/perf_watcher.cc
@@ -5,6 +5,8 @@
 
 #include "perf_watcher.hpp"
 
+#include "perf.hpp"
+
 #include <stddef.h>
 #include <string.h>
 
@@ -49,7 +51,7 @@ bool watcher_has_countable_sample_type(const PerfWatcher *watcher) {
 }
 
 #define X_EVENTS(a, b, c, d, e, f, g)                                          \
-  {DDPROF_PWE_##a, b, BASE_STYPES, c, d, {e}, f, g},
+  {DDPROF_PWE_##a, b, BASE_STYPES, c, d, {e}, f, PERF_SAMPLE_STACK_SIZE, g},
 const PerfWatcher events_templates[] = {EVENT_CONFIG_TABLE(X_EVENTS)};
 const PerfWatcher tracepoint_templates[] = {{
     .ddprof_event_type = DDPROF_PWE_TRACEPOINT,

--- a/src/unwind.cc
+++ b/src/unwind.cc
@@ -86,7 +86,10 @@ DDRes unwindstate__unwind(UnwindState *us) {
   }
 
   if (!is_stack_complete(us)) {
+    us->output.is_incomplete = true;
     ddprof_stats_add(STATS_UNWIND_INCOMPLETE_STACK, 1, nullptr);
+  } else {
+    us->output.is_incomplete = false;
   }
   ddprof_stats_add(STATS_UNWIND_AVG_STACK_DEPTH, us->output.nb_locs, nullptr);
 

--- a/src/unwind_output.cc
+++ b/src/unwind_output.cc
@@ -15,4 +15,5 @@ static void FunLoc_clear(FunLoc *locs) {
 void uw_output_clear(UnwindOutput *output) {
   FunLoc_clear(output->locs);
   output->nb_locs = 0;
+  output->is_incomplete = true;
 }


### PR DESCRIPTION
# What does this PR do?

Requested sample stack size is already present in perf_event_sample,
but in the future AllocationTracker will probably send only the
captured part of the stack to reduce perf_event_sample size, and
therefore `size_stack` will not correspond anymore to requested
stack size.

