### PR TITLE
Add virtual [lost] frame for lost events

### DIFF
--- a/include/common_symbol_errors.hpp
+++ b/include/common_symbol_errors.hpp
@@ -12,6 +12,7 @@ enum SymbolErrors {
   unknown_dso,
   dwfl_frame,
   incomplete_stack,
+  lost_event,
 };
 
 }

--- a/include/ddprof_worker_context.hpp
+++ b/include/ddprof_worker_context.hpp
@@ -8,6 +8,7 @@
 #include "pevent.hpp"
 #include "proc_status.hpp"
 
+#include <array>
 #include <chrono>
 
 typedef struct DDProfExporter DDProfExporter;
@@ -35,4 +36,5 @@ struct DDProfWorkerContext {
       cycle_start_time;  // time at which current export cycle was started
   int64_t send_nanos;    // Last time an export was sent
   uint32_t count_worker; // exports since last cache clear
+  std::array<uint64_t, MAX_TYPE_WATCHER> lost_events_per_watcher;
 };

--- a/include/pprof/ddprof_pprof.hpp
+++ b/include/pprof/ddprof_pprof.hpp
@@ -34,7 +34,8 @@ DDRes pprof_create_profile(DDProfPProf *pprof, DDProfContext *ctx);
  */
 DDRes pprof_aggregate(const UnwindOutput *uw_output,
                       const SymbolHdr *symbol_hdr, uint64_t value,
-                      const PerfWatcher *watcher, DDProfPProf *pprof);
+                      uint64_t count, const PerfWatcher *watcher,
+                      DDProfPProf *pprof);
 
 DDRes pprof_reset(DDProfPProf *pprof);
 

--- a/src/common_symbol_lookup.cc
+++ b/src/common_symbol_lookup.cc
@@ -18,6 +18,8 @@ Symbol symbol_from_common(SymbolErrors lookup_case) {
     return Symbol(std::string(), std::string("[dwfl_frame]"), 0, std::string());
   case SymbolErrors::incomplete_stack:
     return Symbol(std::string(), std::string("[incomplete]"), 0, std::string());
+  case SymbolErrors::lost_event:
+    return Symbol(std::string(), std::string("[lost]"), 0, std::string());
   default:
     break;
   }

--- a/src/pprof/ddprof_pprof.cc
+++ b/src/pprof/ddprof_pprof.cc
@@ -171,16 +171,18 @@ static void write_line(const ddprof::Symbol &symbol, ddog_Line *ffi_line) {
 // Assumption of API is that sample is valid in a single type
 DDRes pprof_aggregate(const UnwindOutput *uw_output,
                       const SymbolHdr *symbol_hdr, uint64_t value,
-                      const PerfWatcher *watcher, DDProfPProf *pprof) {
+                      uint64_t count, const PerfWatcher *watcher,
+                      DDProfPProf *pprof) {
 
   const ddprof::SymbolTable &symbol_table = symbol_hdr->_symbol_table;
   const ddprof::MapInfoTable &mapinfo_table = symbol_hdr->_mapinfo_table;
   ddog_Profile *profile = pprof->_profile;
 
-  int64_t values[DDPROF_PWT_LENGTH] = {0};
-  values[watcher->pprof_sample_idx] = value;
-  if (watcher_has_countable_sample_type(watcher))
-    values[watcher->pprof_count_sample_idx] = 1;
+  int64_t values[DDPROF_PWT_LENGTH] = {};
+  values[watcher->pprof_sample_idx] = value * count;
+  if (watcher_has_countable_sample_type(watcher)) {
+    values[watcher->pprof_count_sample_idx] = count;
+  }
 
   ddog_Location locations_buff[DD_MAX_STACK_DEPTH];
   // assumption of single line per loc for now

--- a/test/ddprof_exporter-ut.cc
+++ b/test/ddprof_exporter-ut.cc
@@ -154,7 +154,7 @@ TEST(DDProfExporter, simple) {
 
     res = pprof_create_profile(&pprofs, &ctx);
     EXPECT_TRUE(IsDDResOK(res));
-    res = pprof_aggregate(&mock_output, &symbol_hdr, 1000, &ctx.watchers[0],
+    res = pprof_aggregate(&mock_output, &symbol_hdr, 1000, 1, &ctx.watchers[0],
                           &pprofs);
     EXPECT_TRUE(IsDDResOK(res));
   }

--- a/test/ddprof_pprof-ut.cc
+++ b/test/ddprof_pprof-ut.cc
@@ -74,7 +74,7 @@ TEST(DDProfPProf, aggregate) {
   ctx.num_watchers = 1;
   DDRes res = pprof_create_profile(&pprof, &ctx);
   EXPECT_TRUE(IsDDResOK(res));
-  res = pprof_aggregate(&mock_output, &symbol_hdr, 1000, &ctx.watchers[0],
+  res = pprof_aggregate(&mock_output, &symbol_hdr, 1000, 1, &ctx.watchers[0],
                         &pprof);
 
   EXPECT_TRUE(IsDDResOK(res));


### PR DESCRIPTION
# What does this PR do?

* Count lost events per watcher
* Add a count argument to pprof_aggregate to be able to report multiple
  identical samples at once
* Before profile upload, for each watcher with lost events, report a sample
  with watcher's sample_period and count of lost events
