### PR TITLE
Fix Dockerfile ADD statements

### DIFF
--- a/app/base-env-alpine/Dockerfile
+++ b/app/base-env-alpine/Dockerfile
@@ -9,7 +9,8 @@ ENV CXX=g++
 # libjemalloc
 # libexecinfo-dev # No static lib
 RUN apk update \
-    && apk add --no-cache aws-cli \
+    && apk add --no-cache \
+       aws-cli \
        bash \
        binutils-dev \
        ca-certificates \

--- a/app/base-env-alpine/Dockerfile
+++ b/app/base-env-alpine/Dockerfile
@@ -100,6 +100,6 @@ RUN VERSION="1.6.1" \
 
 # Patch to fix compilation of elfutils
 RUN mkdir /patch
-ADD ./app/base-env-alpine/*.patch /patch/
-ADD ./app/base-env-alpine/error.h /patch/
-ADD ./app/base-env-alpine/libintl.h /patch/
+ADD *.patch /patch/
+ADD error.h /patch/
+ADD libintl.h /patch/

--- a/app/base-env-alpine/Dockerfile
+++ b/app/base-env-alpine/Dockerfile
@@ -10,42 +10,42 @@ ENV CXX=g++
 # libexecinfo-dev # No static lib
 RUN apk update \
     && apk add --no-cache aws-cli \
-	 bash \
-	 binutils-dev \
-	 ca-certificates \
-	 gcovr \
-	 git \
-	 subversion \
-	 patch \
-	 curl \
-	 wget \
-	 make \
-	 cmake \
-	 m4 \
-	 autoconf \
-	 automake \
-	 unzip \
-	 gcc \
-	 g++ \
-	 clang \
-   libcap-static \
-   libunwind-dev \
-	 py3-pkgconfig \
-	 gtest-dev \
-	 cppcheck \
-	 openssh \
-   zlib-dev \
-   zlib-static \
-   bzip2-dev \
-	 xz-dev \
-	 argp-standalone \
-	 fts-dev \
-	 musl-obstack-dev \
-	 musl-libintl \
-	 musl-legacy-error \
-	 libcap-dev \
-	 netcat-openbsd \
-   util-linux
+       bash \
+       binutils-dev \
+       ca-certificates \
+       gcovr \
+       git \
+       subversion \
+       patch \
+       curl \
+       wget \
+       make \
+       cmake \
+       m4 \
+       autoconf \
+       automake \
+       unzip \
+       gcc \
+       g++ \
+       clang \
+       libcap-static \
+       libunwind-dev \
+       py3-pkgconfig \
+       gtest-dev \
+       cppcheck \
+       openssh \
+       zlib-dev \
+       zlib-static \
+       bzip2-dev \
+       xz-dev \
+       argp-standalone \
+       fts-dev \
+       musl-obstack-dev \
+       musl-libintl \
+       musl-legacy-error \
+       libcap-dev \
+       netcat-openbsd \
+       util-linux
 
 # Tell docker to use bash as the default
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
# What does this PR do?
Dockerfile `ADD` statements have their relative paths expanded based on the position of the Dockerfile, not based on the current working directory when `docker build` is invoked.  This patch fixes the ADD statements in the Alpine Dockerfile, which had an over-qualified relative path fragment.

# Motivation
The Alpine Dockerfile is really useful; it's easy to build this image and then launch a local dev environment based on it.  I'd like to keep it for musl testing.