### PR TITLE
Changes to setup_env.sh

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -7,10 +7,15 @@ export PATH=$PATH:${PWD}/tools:${PWD}/bench/runners
 # Helper command lines for cmake. Source this file, then you can just do :
 # SanCMake ../ 
 
+# Attempt to use the latest known working version of GCC as the default
+DDPROF_CC_DEFAULT=$(command -v gcc-{-11,-10,-9,} | head -n1)
+DDPROF_CXX_DEFAULT=$(command -v g++-{-11,-10,-9,} | head -n1)
+
+SCRIPTDIR="$(cd -- $( dirname -- "${BASH_SOURCE[0]}" ) && pwd)" # no "$0" when sourcing
 DDPROF_INSTALL_PREFIX="../deliverables"
 DDPROF_BUILD_BENCH="ON"
 NATIVE_LIB="ON"
-COMPILER_SETTING="-DCMAKE_CXX_COMPILER=${CXX:-"g++"} -DCMAKE_C_COMPILER=${CC:-"gcc"}"
+COMPILER_SETTING="-DCMAKE_CXX_COMPILER=${CXX:-"${DDPROF_CXX_DEFAULT}"} -DCMAKE_C_COMPILER=${CC:-"${DDPROF_CC_DEFAULT}"}"
 # Avoid having the vendors compiled in the same directory
 EXTENSION_CC=${CC:-"gcc"}
 # strip version number from compiler
@@ -18,10 +23,10 @@ EXTENSION_CC=${EXTENSION_CC%-*}
 
 LIBC_HAS_MUSL=$(ldd  --version 2>&1  | grep musl || true)
 if [ ! -z "${LIBC_HAS_MUSL}" ]; then
-  LIBC_VERSION=$(get_libc_version.sh musl)
+  LIBC_VERSION=$(${SCRIPTDIR}/tools/get_libc_version.sh musl)
   EXTENSION_OS="alpine-linux-${LIBC_VERSION}"
 else
-  LIBC_VERSION=$(get_libc_version.sh gnu)
+  LIBC_VERSION=$(${SCRIPTDIR}/tools/get_libc_version.sh gnu)
   EXTENSION_OS="unknown-linux-${LIBC_VERSION}"
 fi
 


### PR DESCRIPTION
* Make easier to source outside of root directory
* Automatically try to use newest compiler if not specified

# What does this PR do?

On Alpine, the setup script would break when sourced outside of the root directory for the project.  This isn't a problem in CI, but it is slightly annoying for humans.

Similarly, I'm proposing an update to our logic for getting the latest compiler version.  I admit this is fairly niche, but we perform a similar expansion in other helper scripts and it's a bit more convenient for people who build natively on VMs.

# Motivation

Make things work in more places with fewer steps.

# Additional Notes
Looks like it works.  In a fresh Alpine container:
```
bash-5.1# cd build/
bash-5.1# rm -rf *
bash-5.1# source ../setup_env.sh
bash-5.1# echo $CC
gcc
bash-5.1# echo $LIBC_VERSION
1.2.3
bash-5.1# echo $LIBC_HAS_MUSL
musl libc (x86_64) Usage: /lib/ld-musl-x86_64.so.1 [options] [--] pathname
```
