### PR TITLE
Add pragmaonce to a header

### DIFF
--- a/include/sys_utils.hpp
+++ b/include/sys_utils.hpp
@@ -3,6 +3,8 @@
 // developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
 // Datadog, Inc.
 
+#pragma once
+
 #include "ddres_def.hpp"
 
 namespace ddprof {


### PR DESCRIPTION
We've been adding `#pragma once` to all headers, even those which are called by only a single source file, since it's annoying ti fix transitive issues downstream.  Noticed one header was missing the pragma, so here's the fix.