### PR TITLE
Sanchda/use gcc 12

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -8,8 +8,8 @@ export PATH=$PATH:${PWD}/tools:${PWD}/bench/runners
 # SanCMake ../ 
 
 # Attempt to use the latest known working version of GCC as the default
-DDPROF_CC_DEFAULT=$(command -v gcc{-11,-10,-9,} | head -n1)
-DDPROF_CXX_DEFAULT=$(command -v g++{-11,-10,-9,} | head -n1)
+DDPROF_CC_DEFAULT=$(command -v gcc{-12,-11,-10,-9,} | head -n1)
+DDPROF_CXX_DEFAULT=$(command -v g++{-12,-11,-10,-9,} | head -n1)
 
 SCRIPTDIR="$(cd -- $( dirname -- "${BASH_SOURCE[0]}" ) && pwd)" # no "$0" when sourcing
 DDPROF_INSTALL_PREFIX="../deliverables"

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -8,8 +8,8 @@ export PATH=$PATH:${PWD}/tools:${PWD}/bench/runners
 # SanCMake ../ 
 
 # Attempt to use the latest known working version of GCC as the default
-DDPROF_CC_DEFAULT=$(command -v gcc{-12,-11,-10,-9,} | head -n1)
-DDPROF_CXX_DEFAULT=$(command -v g++{-12,-11,-10,-9,} | head -n1)
+DDPROF_CC_DEFAULT=$(command -v gcc{-11,-10,-9,} | head -n1)
+DDPROF_CXX_DEFAULT=$(command -v g++{-11,-10,-9,} | head -n1)
 
 SCRIPTDIR="$(cd -- $( dirname -- "${BASH_SOURCE[0]}" ) && pwd)" # no "$0" when sourcing
 DDPROF_INSTALL_PREFIX="../deliverables"

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -8,8 +8,8 @@ export PATH=$PATH:${PWD}/tools:${PWD}/bench/runners
 # SanCMake ../ 
 
 # Attempt to use the latest known working version of GCC as the default
-DDPROF_CC_DEFAULT=$(command -v gcc-{-11,-10,-9,} | head -n1)
-DDPROF_CXX_DEFAULT=$(command -v g++-{-11,-10,-9,} | head -n1)
+DDPROF_CC_DEFAULT=$(command -v gcc-{-12,-11,-10,-9,} | head -n1)
+DDPROF_CXX_DEFAULT=$(command -v g++-{-12,-11,-10,-9,} | head -n1)
 
 SCRIPTDIR="$(cd -- $( dirname -- "${BASH_SOURCE[0]}" ) && pwd)" # no "$0" when sourcing
 DDPROF_INSTALL_PREFIX="../deliverables"

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -8,8 +8,8 @@ export PATH=$PATH:${PWD}/tools:${PWD}/bench/runners
 # SanCMake ../ 
 
 # Attempt to use the latest known working version of GCC as the default
-DDPROF_CC_DEFAULT=$(command -v gcc-{-12,-11,-10,-9,} | head -n1)
-DDPROF_CXX_DEFAULT=$(command -v g++-{-12,-11,-10,-9,} | head -n1)
+DDPROF_CC_DEFAULT=$(command -v gcc{-12,-11,-10,-9,} | head -n1)
+DDPROF_CXX_DEFAULT=$(command -v g++{-12,-11,-10,-9,} | head -n1)
 
 SCRIPTDIR="$(cd -- $( dirname -- "${BASH_SOURCE[0]}" ) && pwd)" # no "$0" when sourcing
 DDPROF_INSTALL_PREFIX="../deliverables"

--- a/src/unwind.cc
+++ b/src/unwind.cc
@@ -17,6 +17,7 @@
 #include "unwind_metrics.hpp"
 #include "unwind_state.hpp"
 
+#include <algorithm>
 #include <array>
 #include <string_view.hpp>
 


### PR DESCRIPTION
# What does this PR do?

As per a previous PR comment from @nsavoire, it's not a bad idea to include gcc-12 support in the environment setup script.  However, gcc-12 (and clang-13) are less permissive around the `find()` invocation in `src/unwind.cc` which requires the inclusion of `<algorithm>`.

This PR
* Adds gcc-12 defaulting to the setup script
* Fixes a typo I introduced in a previous PR (oops)
* Adds `<algorithm>` to `src/unwind.cc`