### PR TITLE
proposal:  streamline std::pair()

### DIFF
--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -121,12 +121,12 @@ public:
   static Dso dso_from_procline(int pid, char *line);
 
   static DsoFindRes find_res_not_found(const DsoMap &map) {
-    return std::pair<DsoMapConstIt, bool>(map.end(), false);
+    return std::pair(map.end(), false);
   }
 
   DsoFindRes find_res_not_found(int pid) {
     // not const as it can create an element if the map does not exist for pid
-    return std::pair<DsoMapConstIt, bool>(_map[pid].end(), false);
+    return std::pair(_map[pid].end(), false);
   }
 
   // Access file and retrieve absolute path and ID

--- a/src/base_frame_symbol_lookup.cc
+++ b/src/base_frame_symbol_lookup.cc
@@ -29,14 +29,14 @@ BaseFrameSymbolLookup::insert_bin_symbol(pid_t pid, SymbolTable &symbol_table,
     // todo : how to tie lifetime of DSO to this ?
     symbol_idx =
         dso_symbol_lookup.get_or_insert(find_res.first->second, symbol_table);
-    _bin_map.insert(std::pair<pid_t, SymbolIdx_t>(pid, symbol_idx));
+    _bin_map.insert(std::pair(pid, symbol_idx));
   } else {
     std::string exe_name;
     bool exe_found = dso_hdr.find_exe_name(pid, exe_name);
     if (exe_found) {
       symbol_idx = symbol_table.size();
       symbol_table.emplace_back(Symbol({}, {}, 0, exe_name));
-      _bin_map.insert(std::pair<pid_t, SymbolIdx_t>(pid, symbol_idx));
+      _bin_map.insert(std::pair(pid, symbol_idx));
     }
   }
   return symbol_idx;

--- a/src/common_mapinfo_lookup.cc
+++ b/src/common_mapinfo_lookup.cc
@@ -27,8 +27,7 @@ MapInfoIdx_t CommonMapInfoLookup::get_or_insert(
   } else { // insert things
     res = mapinfo_table.size();
     mapinfo_table.push_back(mapinfo_from_common(lookup_case));
-    _map.insert(std::pair<CommonMapInfoLookup::MappingErrors, MapInfoIdx_t>(
-        lookup_case, res));
+    _map.insert(std::pair(lookup_case, res));
   }
   return res;
 }

--- a/src/common_symbol_lookup.cc
+++ b/src/common_symbol_lookup.cc
@@ -35,7 +35,7 @@ SymbolIdx_t CommonSymbolLookup::get_or_insert(SymbolErrors lookup_case,
   } else { // insert things
     symbol_idx = symbol_table.size();
     symbol_table.push_back(symbol_from_common(lookup_case));
-    _map.insert(std::pair<SymbolErrors, SymbolIdx_t>(lookup_case, symbol_idx));
+    _map.insert(std::pair(lookup_case, symbol_idx));
   }
   return symbol_idx;
 }

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -154,7 +154,7 @@ DsoFindRes DsoHdr::dso_find_first_std_executable(pid_t pid) {
   if (it == map.end()) {
     return find_res_not_found(map);
   }
-  return std::pair<DsoMapConstIt, bool>(it, true);
+  return std::pair(it, true);
 }
 
 DsoFindRes DsoHdr::dso_find_closest(const DsoMap &map, pid_t pid,
@@ -165,7 +165,7 @@ DsoFindRes DsoHdr::dso_find_closest(const DsoMap &map, pid_t pid,
   if (it != map.end()) {
     is_within = it->second.is_within(pid, addr);
     if (is_within) { // exact match
-      return std::pair<DsoMapConstIt, bool>(it, is_within);
+      return std::pair(it, is_within);
     }
   }
   // previous element is more likely to contain our addr
@@ -175,7 +175,7 @@ DsoFindRes DsoHdr::dso_find_closest(const DsoMap &map, pid_t pid,
     return find_res_not_found(map);
   }
   is_within = it->second.is_within(pid, addr);
-  return std::pair<DsoMapConstIt, bool>(it, is_within);
+  return std::pair(it, is_within);
 }
 
 // Find the closest and indicate if we found a dso matching this address
@@ -185,7 +185,7 @@ DsoFindRes DsoHdr::dso_find_closest(pid_t pid, ElfAddress_t addr) {
 
 DsoRange DsoHdr::get_intersection(DsoMap &map, const Dso &dso) {
   if (map.empty()) {
-    return std::pair<DsoMapIt, DsoMapIt>(map.end(), map.end());
+    return std::pair(map.end(), map.end());
   }
   // Get element after (with a start addr over the current)
   DsoMapIt first_el = map.lower_bound(dso._start);
@@ -224,7 +224,7 @@ DsoRange DsoHdr::get_intersection(DsoMap &map, const Dso &dso) {
   if (end != map.end()) {
     ++end;
   }
-  return std::pair<DsoMapIt, DsoMapIt>(start, end);
+  return std::pair(start, end);
 }
 
 // erase range of elements
@@ -242,8 +242,7 @@ DsoFindRes DsoHdr::dso_find_adjust_same(DsoMap &map, const Dso &dso) {
     // if it is the same or smaller, we keep the current dso
     found_same = it->second.adjust_same(dso);
   }
-  return std::pair<DsoFindRes::first_type, DsoFindRes::second_type>(it,
-                                                                    found_same);
+  return std::pair(it, found_same);
 }
 
 FileInfoId_t DsoHdr::get_or_insert_file_info(const Dso &dso) {
@@ -344,8 +343,7 @@ DsoFindRes DsoHdr::insert_erase_overlap(DsoMap &map, Dso &&dso) {
   _stats.incr_metric(DsoStats::kNewDso, dso._type);
   LG_DBG("[DSO] : Insert %s", dso.to_string().c_str());
   // warning rvalue : do not use dso after this line
-  return map.insert(std::make_pair<ProcessAddress_t, Dso>(
-      ProcessAddress_t(dso._start), std::move(dso)));
+  return map.insert(std::pair(ProcessAddress_t(dso._start), std::move(dso)));
 }
 
 DsoFindRes DsoHdr::insert_erase_overlap(Dso &&dso) {

--- a/src/dso_symbol_lookup.cc
+++ b/src/dso_symbol_lookup.cc
@@ -41,8 +41,7 @@ DsoSymbolLookup::get_or_insert_unhandled_type(const Dso &dso,
   } else {
     symbol_idx = symbol_table.size();
     symbol_table.push_back(symbol_from_unhandled_dso(dso));
-    _map_unhandled_dso.insert(
-        std::pair<dso::DsoType, SymbolIdx_t>(dso._type, symbol_idx));
+    _map_unhandled_dso.insert(std::pair(dso._type, symbol_idx));
   }
   return symbol_idx;
 }
@@ -65,8 +64,7 @@ SymbolIdx_t DsoSymbolLookup::get_or_insert(FileAddress_t normalized_addr,
   } else { // insert things
     symbol_idx = symbol_table.size();
     symbol_table.push_back(symbol_from_dso(normalized_addr, dso, addr_type));
-    addr_lookup.insert(
-        std::pair<FileAddress_t, SymbolIdx_t>(normalized_addr, symbol_idx));
+    addr_lookup.insert(std::pair(normalized_addr, symbol_idx));
   }
   return symbol_idx;
 }

--- a/src/symbol_map.cc
+++ b/src/symbol_map.cc
@@ -24,7 +24,7 @@ SymbolMap::FindRes SymbolMap::find_closest(Offset_t norm_pc) {
   SymbolMap::It it = lower_bound(norm_pc);
   if (it != end()) { // map is empty
     if (SymbolMap::is_within(norm_pc, *it)) {
-      return std::pair<SymbolMap::It, bool>(it, true);
+      return std::pair(it, true);
     }
   }
 
@@ -32,10 +32,10 @@ SymbolMap::FindRes SymbolMap::find_closest(Offset_t norm_pc) {
   if (it != begin()) {
     --it;
   } else { // map is empty
-    return std::make_pair<SymbolMap::It, bool>(end(), false);
+    return std::pair(end(), false);
   }
   // element can not be end (as we reversed or exit)
-  return std::pair<SymbolMap::It, bool>(it, SymbolMap::is_within(norm_pc, *it));
+  return std::pair(it, SymbolMap::is_within(norm_pc, *it));
 }
 
 } // namespace ddprof

--- a/test/ddprof_exporter-ut.cc
+++ b/test/ddprof_exporter-ut.cc
@@ -53,8 +53,7 @@ get_host_port_from_full_addr(const char *full_url) {
   std::string host =
       full_str.substr(found_host + 1, found_port - (found_host + 1));
 
-  return std::make_pair<std::string, std::string>(std::move(host),
-                                                  std::move(port));
+  return std::pair(std::move(host), std::move(port));
 }
 
 // returns host and port from env var HTTP_RECEPTOR_URL
@@ -63,7 +62,7 @@ std::pair<std::string, std::string> get_receptor_host_port() {
   if (full_addr) {
     return get_host_port_from_full_addr(full_addr);
   } else {
-    return std::make_pair<std::string, std::string>("localhost", "8126");
+    return std::pair("localhost", "8126");
   }
 }
 
@@ -94,8 +93,7 @@ void fill_mock_exporter_input(ExporterInput &exporter_input,
 
 TEST(DDProfExporter, url) {
   LogHandle handle;
-  std::pair<std::string, std::string> url =
-      std::make_pair("25.04.1988.0", "1234");
+  std::pair<std::string, std::string> url{"25.04.1988.0", "1234"};
   ExporterInput exporter_input;
   // Test the site / host / port / API logic
   // If API key --> use site


### PR DESCRIPTION
# What does this PR do?

Removes template parameters to `std::pair()` which are unneeded in C++17

# Motivation

Brevity.

# Additional Notes

This is stacked on #169, if I'm not around @r1viollet please feel free to merge this PR if #169 is otherwise ready and this one is agreeable.