### PR TITLE
Switch user if failing to read /proc/<pid>/maps

### DIFF
--- a/include/user_override.hpp
+++ b/include/user_override.hpp
@@ -8,11 +8,17 @@
 #include "ddres.hpp"
 #include <sys/types.h>
 
-typedef struct UIDInfo {
-  bool override;
-  uid_t previous_user;
-} UIDInfo;
+struct UIDInfo {
+  uid_t uid = -1;
+  gid_t gid = -1;
+};
 
-DDRes user_override(UIDInfo *user_override);
+// Change real and effective user and group ids
+DDRes user_override_to_nobody_if_root(UIDInfo *old_uids = nullptr);
+DDRes user_override(const char *user, UIDInfo *old_uids = nullptr);
+DDRes user_override(uid_t uid, gid_t gid, UIDInfo *old_uids = nullptr);
 
-DDRes revert_override(UIDInfo *user_override);
+bool is_root();
+
+// Irreversibly switch to user `user`
+DDRes become_user(const char *user);

--- a/src/ddprof.cc
+++ b/src/ddprof.cc
@@ -78,8 +78,9 @@ DDRes ddprof_setup(DDProfContext *ctx) {
 
     display_system_info();
 
-    // Do not mmap events yet because mmap'ings from perf fds are lost after
-    // fork
+    // Open perf events and mmap events right now to start receiving events
+    // mmaps from perf fds will be lost after fork, that why we mmap them again
+    // in worker (but kernel only accounts for the pinned memory once).
     DDRES_CHECK_FWD(
         pevent_setup(ctx, ctx->params.pid, ctx->params.num_cpu, pevent_hdr));
 

--- a/src/pevent_lib.cc
+++ b/src/pevent_lib.cc
@@ -166,16 +166,20 @@ DDRes pevent_mmap_event(PEvent *event) {
 
 DDRes pevent_mmap(PEventHdr *pevent_hdr, bool use_override) {
   // Switch user if needed (when root switch to nobody user)
-  // pinned memory accounting in root user does not always work
-  // hence we use a different user
+  // Pinned memory is accounted by the kernel by (real) uid across containers
+  // (uid 1000 in the host and in containers will share the same count).
+  // Sometimes root allowance (when no CAP_IPC_LOCK/CAP_SYS_ADMIN in a
+  // container) is already exhausted, hence we switch to a different user.
   UIDInfo info;
   if (use_override) {
-    DDRES_CHECK_FWD(user_override(&info));
+    /* perf_event_mlock_kb is accounted per real user id */
+    DDRES_CHECK_FWD(user_override_to_nobody_if_root(&info));
   }
 
   defer {
-    if (use_override)
-      revert_override(&info);
+    if (use_override) {
+      user_override(info.uid, info.gid);
+    }
   };
 
   auto defer_munmap = make_defer([&] { pevent_munmap(pevent_hdr); });
@@ -193,7 +197,10 @@ DDRes pevent_mmap(PEventHdr *pevent_hdr, bool use_override) {
 DDRes pevent_setup(DDProfContext *ctx, pid_t pid, int num_cpu,
                    PEventHdr *pevent_hdr) {
   DDRES_CHECK_FWD(pevent_open(ctx, pid, num_cpu, pevent_hdr));
-  DDRES_CHECK_FWD(pevent_mmap(pevent_hdr, true));
+  if (!IsDDResOK(pevent_mmap(pevent_hdr, true))) {
+    LG_NTC("Retrying attachment without user override");
+    DDRES_CHECK_FWD(pevent_mmap(pevent_hdr, false));
+  }
   return ddres_init();
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -173,6 +173,7 @@ add_unit_test(
   ../src/ddprof_file_info.cc
   ../src/procutils.cc
   ../src/signal_helper.cc
+  ../src/user_override.cc
   dso-ut.cc
   DEFINITIONS MYNAME="dso-ut")
 target_include_directories(dso-ut PRIVATE ${LIBCAP_INCLUDE_DIR})
@@ -197,6 +198,7 @@ add_unit_test(
   ../src/failed_assumption.cc
   ../src/procutils.cc
   ../src/signal_helper.cc
+  ../src/user_override.cc
   LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle
   DEFINITIONS MYNAME="dwfl_symbol-ut")
 add_compile_definitions("DWFL_TEST_DATA=\"${CMAKE_CURRENT_SOURCE_DIR}/data\"")
@@ -232,6 +234,7 @@ add_unit_test(
   ../src/unwind_helpers.cc
   ../src/unwind_metrics.cc
   ../src/unwind_output.cc
+  ../src/user_override.cc
   LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle
   DEFINITIONS MYNAME="savecontext-ut")
 

--- a/test/user_id-ut.cc
+++ b/test/user_id-ut.cc
@@ -53,16 +53,19 @@ TEST(UserIDTest, api) {
   UIDInfo info;
   uid_t old_user = getuid();
 
-  DDRes res = user_override(&info);
+  DDRes res = user_override_to_nobody_if_root(&info);
   EXPECT_TRUE(IsDDResOK(res));
 
   uid_t new_user = getuid();
   printf("New user = %d \n", new_user);
   if (old_user == 0) { // root
     EXPECT_TRUE(new_user != 0);
-    EXPECT_TRUE(info.override);
+    EXPECT_EQ(info.uid, old_user);
+  } else {
+    EXPECT_EQ(info.uid, -1);
+    EXPECT_EQ(new_user, old_user);
   }
-  res = revert_override(&info);
+  res = user_override(info.uid, info.gid);
   EXPECT_TRUE(IsDDResOK(res));
   EXPECT_EQ(old_user, getuid());
 }


### PR DESCRIPTION
# Description

If open of `/proc/<pid>/maps` fails, then try to switch to same user as `/proc/<pid>/maps` for opening the file.
