### PR TITLE
Leak analysis - aggregate info before cleanup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ trigger_internal_build:
     DDPROF_SHORT_COMMIT_SHA: ${CI_COMMIT_SHORT_SHA}
     DDPROF_COMMIT_TAG: ${CI_COMMIT_TAG}
     # Reliability environment downstream branch
-    DDPROF_RELENV_BRANCH: master
+    DDPROF_RELENV_BRANCH: ${DDPROF_RELENV_BRANCH-"master"}
   trigger:
     project: DataDog/ddprof-build
     strategy: depend

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,7 +309,6 @@ add_custom_command(
 add_library(ddprof_exe_object OBJECT IMPORTED GLOBAL)
 set_target_properties(ddprof_exe_object PROPERTIES IMPORTED_OBJECTS "${DDPROF_EXE_OBJECT}")
 
-# \fixme{nsavoire} Need to make this wotrk with loader + GOT override
 add_library(dd_profiling-static STATIC ${DD_PROFILING_SOURCES} $<TARGET_OBJECTS:ddprof_exe_object>)
 set_target_properties(dd_profiling-static PROPERTIES OUTPUT_NAME dd_profiling)
 target_compile_definitions(dd_profiling-static PRIVATE DDPROF_EMBEDDED_EXE_DATA)
@@ -385,7 +384,7 @@ option(BUILD_NATIVE_LIB "Build a library out of the native profiler" ON)
 if(${BUILD_NATIVE_LIB})
 
   # Define all sources
-  set(DDPROF_LIB_SRC ${COMMON_SRC} src/lib/ddprof_output.cc)
+  set(DDPROF_LIB_SRC ${COMMON_SRC} src/lib/ddprof_output.cc include/pid_header.hpp)
 
   # Libs to link
   set(NATIVE_LIB_LIBRARY_LIST DDProf::Parser llvm-demangle ${ELFUTILS_LIBRARIES} Threads::Threads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,7 +384,7 @@ option(BUILD_NATIVE_LIB "Build a library out of the native profiler" ON)
 if(${BUILD_NATIVE_LIB})
 
   # Define all sources
-  set(DDPROF_LIB_SRC ${COMMON_SRC} src/lib/ddprof_output.cc include/pid_header.hpp)
+  set(DDPROF_LIB_SRC ${COMMON_SRC} src/lib/ddprof_output.cc)
 
   # Libs to link
   set(NATIVE_LIB_LIBRARY_LIST DDProf::Parser llvm-demangle ${ELFUTILS_LIBRARIES} Threads::Threads)

--- a/include/ddprof_worker_context.hpp
+++ b/include/ddprof_worker_context.hpp
@@ -8,7 +8,6 @@
 #include "live_allocation.hpp"
 #include "live_sysallocations.hpp"
 #include "pevent.hpp"
-#include "pid_header.hpp"
 #include "proc_status.hpp"
 
 #include <array>

--- a/include/ddprof_worker_context.hpp
+++ b/include/ddprof_worker_context.hpp
@@ -8,6 +8,7 @@
 #include "live_allocation.hpp"
 #include "live_sysallocations.hpp"
 #include "pevent.hpp"
+#include "pid_header.hpp"
 #include "proc_status.hpp"
 
 #include <array>

--- a/include/dwfl_hdr.hpp
+++ b/include/dwfl_hdr.hpp
@@ -65,7 +65,7 @@ class DwflHdr {
 public:
   DwflWrapper &get_or_insert(pid_t pid);
   std::vector<pid_t> get_unvisited() const;
-  std::vector<pid_t> reset_unvisited();
+  void reset_unvisited();
   void clear_pid(pid_t pid);
 
   // get number of accessed modules
@@ -74,6 +74,7 @@ public:
 
 private:
   std::unordered_map<pid_t, DwflWrapper> _dwfl_map;
+  // \fixme{r1viollet} this belongs in a higher level structure
   std::unordered_set<pid_t> _visited_pid;
 };
 

--- a/include/live_allocation.hpp
+++ b/include/live_allocation.hpp
@@ -25,9 +25,7 @@ public:
     }
   }
 
-  void clear_pid(pid_t pid) {
-    _pid_map.erase(pid);
-  }
+  void clear_pid(pid_t pid) { _pid_map.erase(pid); }
 
   struct AllocationInfo {
     UnwindOutput _stack;

--- a/include/live_allocation.hpp
+++ b/include/live_allocation.hpp
@@ -25,6 +25,10 @@ public:
     }
   }
 
+  void clear_pid(pid_t pid) {
+    _pid_map.erase(pid);
+  }
+
   struct AllocationInfo {
     UnwindOutput _stack;
     size_t _size;

--- a/include/live_sysallocations.hpp
+++ b/include/live_sysallocations.hpp
@@ -85,9 +85,7 @@ public:
     add_allocs(stack, addr1, size1, pid);
   }
 
-  void clear_pid(pid_t pid) {
-    _pid_map.erase(pid);
-  }
+  void clear_pid(pid_t pid) { _pid_map.erase(pid); }
 
   using StackMap = std::unordered_map<uintptr_t, UnwindOutput>;
   using PidMap = std::unordered_map<pid_t, StackMap>;

--- a/include/live_sysallocations.hpp
+++ b/include/live_sysallocations.hpp
@@ -85,22 +85,8 @@ public:
     add_allocs(stack, addr1, size1, pid);
   }
 
-  void do_exit(pid_t pid) {
-    StackMap &stack_map = _pid_map[pid];
-    stack_map.clear();
-    _visited_recently.erase(pid);
-  }
-
-  void sanitize_pids() {
-    for (auto &stack_map : _pid_map) {
-      if (!_visited_recently.contains(stack_map.first)) {
-        // This PID wasn't visited recently.  Is it still around?
-        if (kill(stack_map.first, 0)) {
-          _pid_map[stack_map.first].clear();
-        }
-      }
-    }
-    _visited_recently.clear();
+  void clear_pid(pid_t pid) {
+    _pid_map.erase(pid);
   }
 
   using StackMap = std::unordered_map<uintptr_t, UnwindOutput>;

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -55,7 +55,10 @@ CmakeWithOptions() {
   shift
   VENDOR_EXTENSION=$(GetDirectoryExtention ${BUILD_TYPE})
   # shellcheck disable=SC2086
-  cmake ${COMMON_OPT} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DVENDOR_EXTENSION=${VENDOR_EXTENSION} $@
+  cmd="cmake ${COMMON_OPT} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DVENDOR_EXTENSION=${VENDOR_EXTENSION} $@"
+  echo "Using ${cmd}"
+  echo"###################################"
+  eval ${cmd}
 }
 
 RelCMake() {

--- a/src/dwfl_hdr.cc
+++ b/src/dwfl_hdr.cc
@@ -92,7 +92,7 @@ std::vector<pid_t> DwflHdr::get_unvisited() const {
   return pids_remove;
 }
 
-std::vector<pid_t> DwflHdr::reset_unvisited() {
+void DwflHdr::reset_unvisited() {
   // clear the list of visited for next cycle
   _visited_pid.clear();
 }

--- a/src/dwfl_thread_callbacks.cc
+++ b/src/dwfl_thread_callbacks.cc
@@ -28,7 +28,7 @@ bool set_initial_registers(Dwfl_Thread *thread, void *arg) {
   struct UnwindState *us = reinterpret_cast<UnwindState *>(arg);
 
   unsigned int regs_num;
-  for (regs_num = 0; - 1u != dwarf_to_perf_regno(regs_num); ++regs_num) {
+  for (regs_num = 0; -1u != dwarf_to_perf_regno(regs_num); ++regs_num) {
     unsigned int regs_idx = dwarf_to_perf_regno(regs_num);
     regs[regs_num] = us->initial_regs.regs[regs_idx];
   }

--- a/src/unwind.cc
+++ b/src/unwind.cc
@@ -101,11 +101,6 @@ DDRes unwindstate__unwind(UnwindState *us) {
 
   // Add a frame that identifies executable to which these belong
   add_virtual_base_frame(us);
-  if (us->_dwfl_wrapper->_inconsistent) {
-    // error detected on this pid
-    LG_WRN("(Inconsistent DWFL/DSOs)%d - Free associated objects", us->pid);
-    unwind_pid_free(us, us->pid);
-  }
   return res;
 }
 

--- a/test/simple_malloc-ut.sh
+++ b/test/simple_malloc-ut.sh
@@ -96,8 +96,8 @@ check "./ddprof ./test/simple_malloc ${opts}" 1
 # Test wrapper mode with forks + threads
 check "./ddprof ./test/simple_malloc ${opts} --fork 2 --threads 2" 2 4
 
-# Test wrapper mode with forks + threads
-# check "./ddprof --live_allocations yes ./test/simple_malloc ${opts} --fork 2 --threads 2 --skip-free 100" 2 4
+# Test Live Allocation
+check "./ddprof --live_allocations yes ./test/simple_malloc ${opts} --fork 2 --threads 2 --skip-free 100" 2 4
 
 # Test slow profiler startup
 check "env DD_PROFILING_NATIVE_STARTUP_WAIT_MS=200 ./ddprof ./test/simple_malloc ${opts}" 1

--- a/tools/style-check.sh
+++ b/tools/style-check.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR/.."
 
 # Find most recent clang-format, defaulting to an unqualified default
-CLANG_FORMAT=$(command -v clang-format{-13,-12,-11,-10,-9,} | head -n1)
+CLANG_FORMAT=$(command -v clang-format{-15,-13,-12,-11,-10,-9,} | head -n1)
 if [ -z "${CLANG_FORMAT}" ]; then
   echo "No suitable clang-format found"
   exit 1


### PR DESCRIPTION
# What does this PR do?

Ensure we aggregate live allocation information before cleaning pid info

# Motivation

Ensure we don't loose information on short lived pids

# Additional Notes

This needs more work to ensure we have a global pid object.

# How to test the change?

ongoing