### PR TITLE
Increase the size of the ring buffer for custom events

### DIFF
--- a/include/perf.hpp
+++ b/include/perf.hpp
@@ -16,6 +16,8 @@
 
 // defaut ring buffer size expressed as a power-of-two in number of pages
 #define DEFAULT_BUFF_SIZE_SHIFT 6
+// this does not count as pinned memory, use a larger size
+#define MPSC_BUFF_SIZE_SHIFT 8
 
 #define PSAMPLE_DEFAULT_WAKEUP_MS 100 // sample frequency check
 

--- a/src/pevent_lib.cc
+++ b/src/pevent_lib.cc
@@ -139,7 +139,7 @@ DDRes pevent_open(DDProfContext *ctx, pid_t pid, int num_cpu,
       size_t pevent_idx = 0;
       DDRES_CHECK_FWD(pevent_create(pevent_hdr, watcher_idx, &pevent_idx));
       DDRES_CHECK_FWD(ddprof::ring_buffer_create(
-          DEFAULT_BUFF_SIZE_SHIFT, RingBufferType::kMPSCRingBuffer, true,
+          MPSC_BUFF_SIZE_SHIFT, RingBufferType::kMPSCRingBuffer, true,
           &pevent_hdr->pes[pevent_idx]));
     }
   }


### PR DESCRIPTION
# What does this PR do?

Increase the size of the ring buffer for allocation profiling

# Motivation

This will reduce the amount of lost events for allocations

# Additional Notes

I'll have to redeploy on staging to check if lost events are fixed on prof-probe.

# How to test the change?

Tested in relenv / staging