### PR TITLE
Fix crash when using custom stack

### DIFF
--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -24,6 +24,7 @@ struct TrackerThreadLocalState {
   int64_t remaining_bytes; // remaining allocation bytes until next sample
   bool remaining_bytes_initialized; // false if remaining_bytes is not
                                     // initialized
+  const std::byte *stack_start;     // thread stack bounds
   const std::byte *stack_end;
   pid_t tid; // cache of tid
 

--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -8,6 +8,7 @@
 #include "ddprof_base.hpp"
 #include "ddres_def.hpp"
 #include "pevent.hpp"
+#include "span.hpp"
 #include "unlikely.hpp"
 
 #include <atomic>
@@ -24,8 +25,7 @@ struct TrackerThreadLocalState {
   int64_t remaining_bytes; // remaining allocation bytes until next sample
   bool remaining_bytes_initialized; // false if remaining_bytes is not
                                     // initialized
-  const std::byte *stack_start;     // thread stack bounds
-  const std::byte *stack_end;
+  ddprof::span<const byte> stack_bounds;
   pid_t tid; // cache of tid
 
   bool reentry_guard; // prevent reentry in AllocationTracker (eg. when

--- a/include/lib/savecontext.hpp
+++ b/include/lib/savecontext.hpp
@@ -13,12 +13,10 @@
 #include "span.hpp"
 
 /** Cache stack end from current thread in TLS for future use */
-DDPROF_NOIPO int retrieve_stack_bounds(const std::byte *&start,
-                                       const std::byte *&end);
+DDPROF_NOINLINE ddprof::span<const std::byte> retrieve_stack_bounds();
 
 /** Save registers and stack for remote unwinding
  * Return saved stack size */
-DDPROF_NOIPO size_t save_context(const std::byte *stack_start,
-                                 const std::byte *stack_end,
+DDPROF_NOIPO size_t save_context(ddprof::span<const std::byte>,
                                  ddprof::span<uint64_t, PERF_REGS_COUNT> regs,
                                  ddprof::span<std::byte> buffer);

--- a/include/lib/savecontext.hpp
+++ b/include/lib/savecontext.hpp
@@ -18,7 +18,7 @@ DDPROF_NOIPO int retrieve_stack_bounds(const std::byte *&start,
 
 /** Save registers and stack for remote unwinding
  * Return saved stack size */
-DDPROF_NOIPO size_t save_context(const std::byte *start,
+DDPROF_NOIPO size_t save_context(const std::byte *stack_start,
                                  const std::byte *stack_end,
                                  ddprof::span<uint64_t, PERF_REGS_COUNT> regs,
                                  ddprof::span<std::byte> buffer);

--- a/include/lib/savecontext.hpp
+++ b/include/lib/savecontext.hpp
@@ -13,7 +13,7 @@
 #include "span.hpp"
 
 /** Cache stack end from current thread in TLS for future use */
-DDPROF_NOINLINE ddprof::span<const std::byte> retrieve_stack_bounds();
+DDPROF_NOIPO ddprof::span<const std::byte> retrieve_stack_bounds();
 
 /** Save registers and stack for remote unwinding
  * Return saved stack size */

--- a/include/lib/savecontext.hpp
+++ b/include/lib/savecontext.hpp
@@ -13,10 +13,12 @@
 #include "span.hpp"
 
 /** Cache stack end from current thread in TLS for future use */
-DDPROF_NOIPO const std::byte *retrieve_stack_end_address();
+DDPROF_NOIPO int retrieve_stack_bounds(const std::byte *&start,
+                                       const std::byte *&end);
 
 /** Save registers and stack for remote unwinding
  * Return saved stack size */
-DDPROF_NOIPO size_t save_context(const std::byte *stack_end,
+DDPROF_NOIPO size_t save_context(const std::byte *start,
+                                 const std::byte *stack_end,
                                  ddprof::span<uint64_t, PERF_REGS_COUNT> regs,
                                  ddprof::span<std::byte> buffer);

--- a/include/lib/savecontext.hpp
+++ b/include/lib/savecontext.hpp
@@ -12,7 +12,8 @@
 #include "perf_archmap.hpp"
 #include "span.hpp"
 
-/** Cache stack bounds from current thread in TLS for future use */
+/**Retrieve stack bounds from current thread.
+   Return an empty span in case of failure.*/
 DDPROF_NOIPO ddprof::span<const std::byte> retrieve_stack_bounds();
 
 /** Save registers and stack for remote unwinding

--- a/include/lib/savecontext.hpp
+++ b/include/lib/savecontext.hpp
@@ -12,11 +12,11 @@
 #include "perf_archmap.hpp"
 #include "span.hpp"
 
-/** Cache stack end from current thread in TLS for future use */
+/** Cache stack bounds from current thread in TLS for future use */
 DDPROF_NOIPO ddprof::span<const std::byte> retrieve_stack_bounds();
 
 /** Save registers and stack for remote unwinding
  * Return saved stack size */
-DDPROF_NOIPO size_t save_context(ddprof::span<const std::byte>,
+DDPROF_NOIPO size_t save_context(ddprof::span<const std::byte> stack_bounds,
                                  ddprof::span<uint64_t, PERF_REGS_COUNT> regs,
                                  ddprof::span<std::byte> buffer);

--- a/src/lib/allocation_tracker.cc
+++ b/src/lib/allocation_tracker.cc
@@ -278,8 +278,9 @@ DDRes AllocationTracker::push_sample(uint64_t allocated_size,
 
   event->dyn_size = save_context(tl_state.stack_bounds, event->regs,
                                  ddprof::Buffer{event->data, event->size});
-  // discard if dyn_size == 0, this way, we will skip over it
-  if (writer.commit(buffer, (event->dyn_size == 0)) || notify_consumer) {
+  // Even if dyn_size == 0, we keep the sample
+  // This way, the overall accounting is correct (even with empty stacks)
+  if (writer.commit(buffer) || notify_consumer) {
     uint64_t count = 1;
     if (write(_pevent.fd, &count, sizeof(count)) != sizeof(count)) {
       DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFRB,

--- a/src/lib/allocation_tracker.cc
+++ b/src/lib/allocation_tracker.cc
@@ -263,10 +263,10 @@ DDRes AllocationTracker::push_sample(uint64_t allocated_size,
     tl_state.tid = ddprof::gettid();
   }
 
-  if (tl_state.stack_bounds.size() == 0) {
+  if (tl_state.stack_bounds.empty()) {
     // This call should only occur on main thread
     tl_state.stack_bounds = retrieve_stack_bounds();
-    if (tl_state.stack_bounds.size() == 0) {
+    if (tl_state.stack_bounds.empty()) {
       DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFRB, "Unable to get thread bounds");
     }
   }

--- a/src/lib/savecontext.cc
+++ b/src/lib/savecontext.cc
@@ -40,7 +40,7 @@ static DDPROF_NO_SANITIZER_ADDRESS size_t
 save_stack(ddprof::span<const std::byte> stack_bounds,
            const std::byte *stack_ptr, ddprof::span<std::byte> buffer) {
   // Safety check to ensure we are not in a fiber using a different stack
-  if (stack_ptr <= stack_bounds.begin() && stack_ptr >= stack_bounds.end()) {
+  if (!(stack_ptr > stack_bounds.begin() && stack_ptr < stack_bounds.end())) {
     return 0;
   }
   // take the min of current stack size and requested stack sample size~

--- a/src/lib/savecontext.cc
+++ b/src/lib/savecontext.cc
@@ -61,7 +61,7 @@ size_t save_context(ddprof::span<const std::byte> stack_bounds,
                     ddprof::span<std::byte> buffer) {
   save_registers(regs);
   // save the stack just after saving registers, stack part above saved SP
-  // must no be changed between call to save_registers and call to save_stack
+  // must not be changed between call to save_registers and call to save_stack
   return save_stack(stack_bounds,
                     reinterpret_cast<const std::byte *>(regs[REGNAME(SP)]),
                     buffer);

--- a/src/lib/savecontext.cc
+++ b/src/lib/savecontext.cc
@@ -14,7 +14,7 @@
 #include <cstring>
 #include <pthread.h>
 
-// Returns -1 in case of failure
+// Returns an empty span in case of failure
 // Fills start (low address, so closer to SP) and end (stack end address is the
 // start of the stack since stack grows down)
 DDPROF_NOINLINE ddprof::span<const std::byte> retrieve_stack_bounds() {
@@ -40,7 +40,7 @@ static DDPROF_NO_SANITIZER_ADDRESS size_t
 save_stack(ddprof::span<const std::byte> stack_bounds,
            const std::byte *stack_ptr, ddprof::span<std::byte> buffer) {
   // Safety check to ensure we are not in a fiber using a different stack
-  if (!(stack_ptr > stack_bounds.begin() && stack_ptr < stack_bounds.end())) {
+  if (!(stack_ptr >= stack_bounds.begin() && stack_ptr < stack_bounds.end())) {
     return 0;
   }
   // take the min of current stack size and requested stack sample size~

--- a/src/lib/saveregisters.cc
+++ b/src/lib/saveregisters.cc
@@ -46,11 +46,11 @@ void save_registers(ddprof::span<uint64_t, PERF_REGS_COUNT>) {
       "movq %%r14, %c[iR14]*8(%%rdi)\n"
       "movq %%r15, %c[iR15]*8(%%rdi)\n"
       // Bump the stack by 8 bytes to remove the return address,
-      // that way we will have the value of RSP after funtion return
+      // that way we will have the value of RSP after function return
       "leaq 8(%%rsp), %%rax\n"
       "movq %%rax, %c[iRSP]*8(%%rdi)\n"
       // 0(%rsp) contains the return address, this is the value of RIP after
-      // funtion return
+      // function return
       "movq 0(%%rsp), %%rax\n"
       "movq %%rax, %c[iRIP]*8(%%rdi)\n"
       "ret\n"

--- a/src/pprof/ddprof_pprof.cc
+++ b/src/pprof/ddprof_pprof.cc
@@ -192,6 +192,12 @@ DDRes pprof_aggregate(const UnwindOutput *uw_output,
 
   if (watcher->options.nb_frames_to_skip < locs.size()) {
     locs = locs.subspan(watcher->options.nb_frames_to_skip);
+  } else {
+    // Keep the last two frames. In the case of stacks that we could not unwind
+    // We will have the following stack: binary_name; [incomplete]
+    if (locs.size() >= 3) {
+      locs = locs.subspan(locs.size() - 2);
+    }
   }
 
   unsigned cur_loc = 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -356,10 +356,6 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 
-add_exe(coroutine_fibo coroutine_fibo.cc)
-
-add_exe(deep_recursive deep_recursive.cc LIBRARIES Threads::Threads)
-
 add_test(
   NAME ddprof_help
   COMMAND ddprof -h

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -356,6 +356,10 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 
+add_exe(coroutine_fibo coroutine_fibo.cc)
+
+add_exe(deep_recursive deep_recursive.cc LIBRARIES Threads::Threads)
+
 add_test(
   NAME ddprof_help
   COMMAND ddprof -h

--- a/test/savecontext-bench.cc
+++ b/test/savecontext-bench.cc
@@ -36,13 +36,12 @@ DDPROF_NOINLINE static void *get_stack_start_tls() {
 static void BM_SaveContext(benchmark::State &state) {
   uint64_t regs[PERF_REGS_COUNT];
   std::byte stack[PERF_SAMPLE_STACK_SIZE];
-  const std::byte *stack_start, *stack_end = {};
-  int res = retrieve_stack_bounds(stack_start, stack_end);
-  if (res < 0) {
+  ddprof::span<const std::byte> stack_bounds = retrieve_stack_bounds();
+  if (stack_bounds.size() == 0) {
     exit(1);
   }
   for (auto _ : state) {
-    save_context(stack_start, stack_end, regs, stack);
+    save_context(stack_bounds, regs, stack);
   }
 }
 

--- a/test/savecontext-bench.cc
+++ b/test/savecontext-bench.cc
@@ -37,7 +37,7 @@ static void BM_SaveContext(benchmark::State &state) {
   uint64_t regs[PERF_REGS_COUNT];
   std::byte stack[PERF_SAMPLE_STACK_SIZE];
   ddprof::span<const std::byte> stack_bounds = retrieve_stack_bounds();
-  if (stack_bounds.size() == 0) {
+  if (stack_bounds.empty()) {
     exit(1);
   }
   for (auto _ : state) {

--- a/test/savecontext-bench.cc
+++ b/test/savecontext-bench.cc
@@ -36,10 +36,11 @@ DDPROF_NOINLINE static void *get_stack_start_tls() {
 static void BM_SaveContext(benchmark::State &state) {
   uint64_t regs[PERF_REGS_COUNT];
   std::byte stack[PERF_SAMPLE_STACK_SIZE];
-  auto *stack_end = retrieve_stack_end_address();
+  const std::byte *stack_start, *stack_end = {};
+  int res = retrieve_stack_bounds(stack_start, stack_end);
 
   for (auto _ : state) {
-    save_context(stack_end, regs, stack);
+    save_context(stack_start, stack_end, regs, stack);
   }
 }
 

--- a/test/savecontext-bench.cc
+++ b/test/savecontext-bench.cc
@@ -38,7 +38,9 @@ static void BM_SaveContext(benchmark::State &state) {
   std::byte stack[PERF_SAMPLE_STACK_SIZE];
   const std::byte *stack_start, *stack_end = {};
   int res = retrieve_stack_bounds(stack_start, stack_end);
-
+  if (res < 0) {
+    exit(1);
+  }
   for (auto _ : state) {
     save_context(stack_start, stack_end, regs, stack);
   }

--- a/test/savecontext-ut.cc
+++ b/test/savecontext-ut.cc
@@ -27,7 +27,9 @@ std::byte stack[PERF_SAMPLE_STACK_SIZE];
 void funcB() {
   UnwindState state;
   uint64_t regs[K_NB_REGS_UNWIND];
-  size_t stack_size = save_context(retrieve_stack_end_address(), regs, stack);
+  const std::byte *start, *end;
+  retrieve_stack_bounds(start, end);
+  size_t stack_size = save_context(start, end, regs, stack);
 
   ddprof::unwind_init_sample(&state, regs, getpid(), stack_size,
                              reinterpret_cast<char *>(stack));
@@ -65,7 +67,9 @@ static uint64_t regs[K_NB_REGS_UNWIND];
 static size_t stack_size;
 
 DDPROF_NO_SANITIZER_ADDRESS void handler(int sig) {
-  stack_size = save_context(retrieve_stack_end_address(), regs, stack);
+  const std::byte *start, *end;
+  retrieve_stack_bounds(start, end);
+  stack_size = save_context(start, end, regs, stack);
   stop = true;
 }
 

--- a/test/savecontext-ut.cc
+++ b/test/savecontext-ut.cc
@@ -27,8 +27,7 @@ std::byte stack[PERF_SAMPLE_STACK_SIZE];
 void funcB() {
   UnwindState state;
   uint64_t regs[K_NB_REGS_UNWIND];
-  ddprof::span<const std::byte> stack_bounds = retrieve_stack_bounds();
-  size_t stack_size = save_context(stack_bounds, regs, stack);
+  size_t stack_size = save_context(retrieve_stack_bounds(), regs, stack);
 
   ddprof::unwind_init_sample(&state, regs, getpid(), stack_size,
                              reinterpret_cast<char *>(stack));
@@ -66,8 +65,7 @@ static uint64_t regs[K_NB_REGS_UNWIND];
 static size_t stack_size;
 
 DDPROF_NO_SANITIZER_ADDRESS void handler(int sig) {
-  ddprof::span<const std::byte> stack_bounds = retrieve_stack_bounds();
-  stack_size = save_context(stack_bounds, regs, stack);
+  stack_size = save_context(retrieve_stack_bounds(), regs, stack);
   stop = true;
 }
 

--- a/test/savecontext-ut.cc
+++ b/test/savecontext-ut.cc
@@ -27,9 +27,8 @@ std::byte stack[PERF_SAMPLE_STACK_SIZE];
 void funcB() {
   UnwindState state;
   uint64_t regs[K_NB_REGS_UNWIND];
-  const std::byte *start, *end;
-  retrieve_stack_bounds(start, end);
-  size_t stack_size = save_context(start, end, regs, stack);
+  ddprof::span<const std::byte> stack_bounds = retrieve_stack_bounds();
+  size_t stack_size = save_context(stack_bounds, regs, stack);
 
   ddprof::unwind_init_sample(&state, regs, getpid(), stack_size,
                              reinterpret_cast<char *>(stack));
@@ -67,9 +66,8 @@ static uint64_t regs[K_NB_REGS_UNWIND];
 static size_t stack_size;
 
 DDPROF_NO_SANITIZER_ADDRESS void handler(int sig) {
-  const std::byte *start, *end;
-  retrieve_stack_bounds(start, end);
-  stack_size = save_context(start, end, regs, stack);
+  ddprof::span<const std::byte> stack_bounds = retrieve_stack_bounds();
+  stack_size = save_context(stack_bounds, regs, stack);
   stop = true;
 }
 


### PR DESCRIPTION
# What does this PR do?

    When the user is using a custom stack (different from the thread's stack)
    we would crash when copying the stack to the ring buffer.
    This adds a bound check (checking that the current SP is within the stack).
    If we are not within the thread's stack, we will push an empty sample. 
    We would need access to the runtime's API to understand the stack's structure.
    For now the user will see incomplete stack traces within the UI.

# Motivation

Avoid crashes when profiling runtimes with fibers (like Julia).
When making tests for [this](https://github.com/DataDog/ddprof/issues/212) issue, we encountered this crash when enabling allocation profiling.

# Additional Notes

    There is still a case where the stack could grow and we would not detect
    the growth of the stack, however we would not crash, we would simply not
    sample.

# How to test the change?

I will deliver a PR with Julia tests in prof-correctness repository.
