### PR TITLE
Add jq as a build time dependency

### DIFF
--- a/app/base-env/Dockerfile
+++ b/app/base-env/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update \
   flex \
   gcovr \
   git \
+  jq \
   lcov \
   libcap-dev \
   libjemalloc-dev \


### PR DESCRIPTION
# What does this PR do?

The scripts that push automatically to GitHub require the jq dependency
