### PR TITLE
Live Heap - Pid cleanup

### DIFF
--- a/include/live_allocation.hpp
+++ b/include/live_allocation.hpp
@@ -8,42 +8,60 @@
 #include "ddprof_defs.hpp"
 #include "logger.hpp"
 #include "unwind_output.hpp"
+#include "unlikely.hpp"
 
 #include <unordered_map>
 
 namespace ddprof {
 
+template <typename T>
+T& access_resize(std::vector<T>& v, size_t index, const T& default_value = T()) {
+  if (unlikely(index >= v.size())) {
+    v.resize(index + 1, default_value);
+  }
+  return v[index];
+}
+
+
 class LiveAllocation {
 public:
   void register_allocation(const UnwindOutput &stack, uintptr_t addr,
                            size_t size, int watcher_pos, pid_t pid) {
-    StackMap &stack_map = _pid_map[pid];
+    PidMap &pid_map = access_resize(_watcher_vector, watcher_pos);
+    StackMap &stack_map = pid_map[pid];
     stack_map[addr] = AllocationInfo{
         ._stack = stack, ._size = size, ._watcher_pos = watcher_pos};
   }
 
-  void register_deallocation(uintptr_t addr, pid_t pid) {
-    StackMap &stack_map = _pid_map[pid];
+  void register_deallocation(uintptr_t addr, int watcher_pos, pid_t pid) {
+    PidMap &pid_map = access_resize(_watcher_vector, watcher_pos);
+    StackMap &stack_map = pid_map[pid];
     if (!stack_map.erase(addr)) {
       LG_DBG("Unmatched deallocation at %lx of PID%d", addr, pid);
     }
   }
 
-  void clear(pid_t pid) { _pid_map[pid].clear(); }
+  void clear_pid_for_watcher(int watcher_pos, pid_t pid) {
+    PidMap &pid_map = access_resize(_watcher_vector, watcher_pos);
+    pid_map[pid].clear();
+  }
+
+  void clear_pid(pid_t pid) {
+    for (auto &pid_map : _watcher_vector) {
+      pid_map[pid].clear();
+    }
+  }
 
   struct AllocationInfo {
     UnwindOutput _stack;
     size_t _size;
-    // Should the watcher be part of the key ?
-    // In theory we could watch allocations with different rules (per watcher)
-    // for now I'll leave it here
     int _watcher_pos;
   };
 
   using StackMap = std::unordered_map<uintptr_t, AllocationInfo>;
   using PidMap = std::unordered_map<pid_t, StackMap>;
-
-  PidMap _pid_map;
+  using WatcherVector = std::vector<PidMap>;
+  WatcherVector _watcher_vector;
 };
 
 } // namespace ddprof

--- a/include/live_sysallocations.hpp
+++ b/include/live_sysallocations.hpp
@@ -85,23 +85,7 @@ public:
     add_allocs(stack, addr1, size1, pid);
   }
 
-  void do_exit(pid_t pid) {
-    StackMap &stack_map = _pid_map[pid];
-    stack_map.clear();
-    _visited_recently.erase(pid);
-  }
-
-  void sanitize_pids() {
-    for (auto &stack_map : _pid_map) {
-      if (!_visited_recently.contains(stack_map.first)) {
-        // This PID wasn't visited recently.  Is it still around?
-        if (kill(stack_map.first, 0)) {
-          _pid_map[stack_map.first].clear();
-        }
-      }
-    }
-    _visited_recently.clear();
-  }
+  void clear_pid(pid_t pid) { _pid_map.erase(pid); }
 
   using StackMap = std::unordered_map<uintptr_t, UnwindOutput>;
   using PidMap = std::unordered_map<pid_t, StackMap>;

--- a/include/pprof/ddprof_pprof.hpp
+++ b/include/pprof/ddprof_pprof.hpp
@@ -33,7 +33,7 @@ DDRes pprof_create_profile(DDProfPProf *pprof, DDProfContext *ctx);
  * @param pprof
  */
 DDRes pprof_aggregate(const UnwindOutput *uw_output,
-                      const SymbolHdr *symbol_hdr, uint64_t value,
+                      const SymbolHdr &symbol_hdr, uint64_t value,
                       uint64_t count, const PerfWatcher *watcher,
                       DDProfPProf *pprof);
 

--- a/src/lib/allocation_tracker.cc
+++ b/src/lib/allocation_tracker.cc
@@ -396,7 +396,6 @@ DDRes AllocationTracker::push_alloc_sample(uintptr_t addr,
   event->abi = PERF_SAMPLE_REGS_ABI_64;
   event->sample_id.time = 0;
   event->addr = addr;
-
   if (_state.pid == 0) {
     _state.pid = getpid();
   }

--- a/src/pprof/ddprof_pprof.cc
+++ b/src/pprof/ddprof_pprof.cc
@@ -169,12 +169,12 @@ static void write_line(const ddprof::Symbol &symbol, ddog_prof_Line *ffi_line) {
 
 // Assumption of API is that sample is valid in a single type
 DDRes pprof_aggregate(const UnwindOutput *uw_output,
-                      const SymbolHdr *symbol_hdr, uint64_t value,
+                      const SymbolHdr &symbol_hdr, uint64_t value,
                       uint64_t count, const PerfWatcher *watcher,
                       DDProfPProf *pprof) {
 
-  const ddprof::SymbolTable &symbol_table = symbol_hdr->_symbol_table;
-  const ddprof::MapInfoTable &mapinfo_table = symbol_hdr->_mapinfo_table;
+  const ddprof::SymbolTable &symbol_table = symbol_hdr._symbol_table;
+  const ddprof::MapInfoTable &mapinfo_table = symbol_hdr._mapinfo_table;
   ddog_prof_Profile *profile = pprof->_profile;
 
   int64_t values[DDPROF_PWT_LENGTH] = {};

--- a/src/unwind.cc
+++ b/src/unwind.cc
@@ -101,11 +101,6 @@ DDRes unwindstate__unwind(UnwindState *us) {
 
   // Add a frame that identifies executable to which these belong
   add_virtual_base_frame(us);
-  if (us->_dwfl_wrapper->_inconsistent) {
-    // error detected on this pid
-    LG_WRN("(Inconsistent DWFL/DSOs)%d - Free associated objects", us->pid);
-    unwind_pid_free(us, us->pid);
-  }
   return res;
 }
 

--- a/test/ddprof_exporter-ut.cc
+++ b/test/ddprof_exporter-ut.cc
@@ -160,7 +160,7 @@ TEST(DDProfExporter, simple) {
 
     res = pprof_create_profile(&pprofs, &ctx);
     EXPECT_TRUE(IsDDResOK(res));
-    res = pprof_aggregate(&mock_output, &symbol_hdr, 1000, 1, &ctx.watchers[0],
+    res = pprof_aggregate(&mock_output, symbol_hdr, 1000, 1, &ctx.watchers[0],
                           &pprofs);
     EXPECT_TRUE(IsDDResOK(res));
   }

--- a/test/ddprof_pprof-ut.cc
+++ b/test/ddprof_pprof-ut.cc
@@ -74,7 +74,7 @@ TEST(DDProfPProf, aggregate) {
   ctx.num_watchers = 1;
   DDRes res = pprof_create_profile(&pprof, &ctx);
   EXPECT_TRUE(IsDDResOK(res));
-  res = pprof_aggregate(&mock_output, &symbol_hdr, 1000, 1, &ctx.watchers[0],
+  res = pprof_aggregate(&mock_output, symbol_hdr, 1000, 1, &ctx.watchers[0],
                         &pprof);
 
   EXPECT_TRUE(IsDDResOK(res));


### PR DESCRIPTION
- Clear aggregated live information when we remove a PID.
- Re-introduce the watcher dimension in the aggregation of allocations.