### PR TITLE
Live allocation - unique stacks

### DIFF
--- a/include/live_allocation.hpp
+++ b/include/live_allocation.hpp
@@ -9,6 +9,8 @@
 #include "unlikely.hpp"
 #include "unwind_output_hash.hpp"
 
+#include <sys/types.h>
+#include <cstddef>
 #include <unordered_map>
 
 namespace ddprof {
@@ -33,6 +35,7 @@ public:
 
   using PprofStacks =
       std::unordered_map<UnwindOutput, ValueAndCount, UnwindOutputHash>;
+
   struct ValuePerAddress {
     int64_t _value = 0;
     PprofStacks::value_type *_unique_stack = nullptr;

--- a/include/unwind_output.hpp
+++ b/include/unwind_output.hpp
@@ -11,12 +11,13 @@
 #include <vector>
 
 #include "ddprof_defs.hpp"
-#include "string_view.hpp"
 
 typedef struct FunLoc {
   uint64_t ip; // Relative to file, not VMA
   SymbolIdx_t _symbol_idx;
   MapInfoIdx_t _map_info_idx;
+
+  auto operator<=>(const FunLoc &) const = default;
 } FunLoc;
 
 struct UnwindOutput {
@@ -28,4 +29,6 @@ struct UnwindOutput {
   int pid;
   int tid;
   bool is_incomplete;
+
+  auto operator<=>(const UnwindOutput &) const = default;
 };

--- a/include/unwind_output_hash.hpp
+++ b/include/unwind_output_hash.hpp
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include "unwind_output.hpp"
+
+namespace ddprof {
+
+template <class T> inline void hash_combine(std::size_t &seed, const T &v) {
+  std::hash<T> hasher;
+  seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+struct UnwindOutputHash {
+  std::size_t operator()(const UnwindOutput &uo) const noexcept {
+    std::size_t seed = 0;
+    hash_combine(seed, uo.pid);
+    hash_combine(seed, uo.tid);
+    for (const auto &fl : uo.locs) {
+      hash_combine(seed, fl.ip);
+      hash_combine(seed, fl._symbol_idx);
+      hash_combine(seed, fl._map_info_idx);
+    }
+    return seed;
+  }
+};
+
+} // namespace ddprof

--- a/src/live_allocation.cc
+++ b/src/live_allocation.cc
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include "live_allocation.hpp"
+
+#include "logger.hpp"
+
+namespace ddprof {
+
+void LiveAllocation::register_deallocation(uintptr_t address,
+                                           PprofStacks &stacks,
+                                           AddressMap &address_map) {
+  // Find the ValuePerAddress object corresponding to the address
+  auto map_iter = address_map.find(address);
+  if (map_iter == address_map.end()) {
+    // No element found, nothing to do
+    // This means we lost previous events, leading to de-sync between
+    // the state of the profiler and the state of the library.
+    LG_DBG("Unmatched de-allocation at %lx", address);
+    return;
+  }
+  ValuePerAddress &v = map_iter->second;
+
+  // Decrement count and value of the corresponding PprofStacks::value_type
+  // object
+  if (v._unique_stack) {
+    v._unique_stack->second._value -= v._value;
+    if (v._unique_stack->second._count) {
+      --(v._unique_stack->second._count);
+    }
+    if (!v._unique_stack->second._count) {
+      // If count reaches 0, remove the UnwindOutput from stacks
+      stacks.erase(v._unique_stack->first);
+    }
+  }
+
+  // Remove the element from the address map
+  address_map.erase(map_iter);
+}
+
+void LiveAllocation::register_allocation(const UnwindOutput &uo,
+                                         uintptr_t address, int64_t value,
+                                         PprofStacks &stacks,
+                                         AddressMap &address_map) {
+  if (!uo.locs.size()) {
+    // avoid sending empty stacks
+    LG_DBG("(LIVE_ALLOC) Avoid registering empty stack");
+    return;
+  }
+  // Find or create the PprofStacks::value_type object corresponding to the
+  // UnwindOutput
+  auto iter = stacks.find(uo);
+  if (iter == stacks.end()) {
+    iter = stacks.emplace(uo, ValueAndCount{}).first;
+  }
+  PprofStacks::value_type &unique_stack = *iter;
+
+  // Add the value to the address map
+  ValuePerAddress &v = address_map[address];
+  if (v._value) {
+    // unexpected, we already have an allocation here
+    // This means we missed a previous free
+    LG_DBG("Existing allocation: %lx (cleaning up)", address);
+    if (v._unique_stack) {
+      // we should decrement count / value
+      v._unique_stack->second._value -= v._value;
+      if (v._unique_stack->second._count) {
+        --(v._unique_stack->second._count);
+      }
+      // Should we erase the element here ?
+      // only if we are sure it is not the same as the one we are inserting.
+    }
+  }
+
+  v._unique_stack = &unique_stack;
+  v._unique_stack->second._value += value;
+  ++(v._unique_stack->second._count);
+}
+
+} // namespace ddprof

--- a/src/live_allocation.cc
+++ b/src/live_allocation.cc
@@ -71,9 +71,14 @@ void LiveAllocation::register_allocation(const UnwindOutput &uo,
       }
       // Should we erase the element here ?
       // only if we are sure it is not the same as the one we are inserting.
+      if (v._unique_stack != &unique_stack &&
+          !v._unique_stack->second._count) {
+        stacks.erase(v._unique_stack->first);
+      }
     }
   }
 
+  v._value = value;
   v._unique_stack = &unique_stack;
   v._unique_stack->second._value += value;
   ++(v._unique_stack->second._count);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -326,6 +326,8 @@ add_unit_test(jitdump-ut jitdump-ut.cc ../src/jit/jitdump.cc)
 
 add_unit_test(tracepoint_config-ut tracepoint_config-ut.cc ../src/tracepoint_config.cc)
 
+add_unit_test(live_allocation-ut live_allocation-ut.cc ../src/live_allocation.cc)
+
 add_benchmark(savecontext-bench savecontext-bench.cc ../src/lib/savecontext.cc
               ../src/lib/saveregisters.cc)
 

--- a/test/live_allocation-ut.cc
+++ b/test/live_allocation-ut.cc
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include "live_allocation.hpp"
+#include "loghandle.hpp"
+
+#include <gtest/gtest.h>
+
+namespace ddprof {
+
+TEST(LiveAllocationTest, simple) {
+  LogHandle handle;
+  UnwindOutput uo;
+  uo.pid = 123;
+  uo.tid = 456;
+  uo.is_incomplete = false;
+  uo.locs.push_back({0x1234, 0x5678, 0x9abc});
+  uo.locs.push_back({0x4321, 0x8765, 0xcba9});
+
+  LiveAllocation live_alloc;
+  int watcher_pos = 0;
+  pid_t pid = 12;
+  int64_t value = 10;
+  int64_t nb_registered_allocs = 10;
+  { // allocate 10
+    uintptr_t addr = 0x10;
+    for (int i=0; i<nb_registered_allocs; ++i) {
+      live_alloc.register_allocation(uo, addr, value, watcher_pos, pid);
+      addr+=0x10;
+    }
+  }
+  // Check that the hash values are equal
+  //  EXPECT_EQ(hash_value, expected_hash_value);
+  auto &pid_map = live_alloc._watcher_vector[0];
+  EXPECT_EQ(pid_map.size(), 1);
+  auto &pid_stacks = pid_map[pid];
+  // all allocations are registerd
+  EXPECT_EQ(pid_stacks._address_map.size(), nb_registered_allocs);
+  // though the stack is the same
+  ASSERT_EQ(pid_stacks._unique_stacks.size(), 1);
+  const auto &el = pid_stacks._unique_stacks[uo];
+  EXPECT_EQ(el._value, 100);
+
+  { // allocate 10
+    uintptr_t addr = 0x10;
+    for (int i = 0; i < nb_registered_allocs; ++i) {
+      live_alloc.register_deallocation(addr, watcher_pos, pid);
+      addr += 0x10;
+    }
+  }
+  // all allocations are de-registerd
+  EXPECT_EQ(pid_stacks._address_map.size(), 0);
+  // though the stack is the same
+  EXPECT_EQ(pid_stacks._unique_stacks.size(), 0);
+}
+
+TEST(LiveAllocationTest, invalid_inputs) {
+  LiveAllocation live_alloc;
+  int watcher_pos = 0;
+  pid_t pid = 12;
+  int64_t value = 10;
+  UnwindOutput uo;
+
+  // Register allocation with empty UnwindOutput
+  uintptr_t addr = 0x10;
+  EXPECT_NO_THROW(live_alloc.register_allocation(uo, addr, value, watcher_pos, pid));
+  auto &pid_map = live_alloc._watcher_vector[0];
+  auto &pid_stacks = pid_map[pid];
+  // for now we don't consider them
+  EXPECT_EQ(pid_stacks._address_map.size(), 0);
+  EXPECT_EQ(pid_stacks._unique_stacks.size(), 0);
+
+  // Register allocation with negative value
+  uo.pid = 123;
+  uo.tid = 456;
+  uo.is_incomplete = false;
+  uo.locs.push_back({0x1234, 0x5678, 0x9abc});
+  // We will register them (though probably cause a UI bug...)
+  EXPECT_NO_THROW(live_alloc.register_allocation(uo, addr, -1, watcher_pos, pid));
+  // Register deallocation with invalid address
+  EXPECT_NO_THROW(live_alloc.register_deallocation(0, watcher_pos, pid));
+}
+}
+
+// Other cases to consider
+// -- same address registered
+//


### PR DESCRIPTION
# What does this PR do?

Unify the stacks when aggregating live allocations.
