### PR TITLE
Minor refactoring - Extract presets

### DIFF
--- a/include/ddprof_context_lib.hpp
+++ b/include/ddprof_context_lib.hpp
@@ -10,8 +10,10 @@ typedef struct DDProfInput DDProfInput;
 typedef struct DDProfContext DDProfContext;
 typedef struct PerfWatcher PerfWatcher;
 
+namespace ddprof {
 /***************************** Context Management *****************************/
-DDRes ddprof_context_set(DDProfInput *input, DDProfContext *);
-void ddprof_context_free(DDProfContext *);
+DDRes context_set(DDProfInput *input, DDProfContext *);
+void context_free(DDProfContext *);
 
-int ddprof_context_allocation_profiling_watcher_idx(const DDProfContext *ctx);
+int context_allocation_profiling_watcher_idx(const DDProfContext *ctx);
+} // namespace ddprof

--- a/include/perf_mainloop.hpp
+++ b/include/perf_mainloop.hpp
@@ -8,6 +8,7 @@
 #include "ddprof_context.hpp"
 #include "worker_attr.hpp"
 
+namespace ddprof {
 /**
  * Continuously poll for new events and process them accordingly
  *
@@ -23,3 +24,4 @@ DDRes main_loop(const WorkerAttr *, DDProfContext *);
 
 // Same as main loop without any forks
 void main_loop_lib(const WorkerAttr *attr, DDProfContext *ctx);
+} // namespace ddprof

--- a/include/presets.hpp
+++ b/include/presets.hpp
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#pragma once
+
+#include "ddprof_context.hpp"
+#include "ddres_def.hpp"
+#include <cstddef>
+
+namespace ddprof {
+
+struct Preset {
+  static constexpr size_t k_max_events = 10;
+  const char *name;
+  const char *events[k_max_events];
+};
+
+DDRes add_preset(DDProfContext *ctx, const char *preset,
+                 bool pid_or_global_mode);
+
+} // namespace ddprof

--- a/src/ddprof.cc
+++ b/src/ddprof.cc
@@ -133,5 +133,5 @@ DDRes ddprof_start_profiler(DDProfContext *ctx) {
 
   // Enter the main loop -- this will not return unless there is an error.
   LG_NFO("Entering main loop");
-  return main_loop(&perf_funs, ctx);
+  return ddprof::main_loop(&perf_funs, ctx);
 }

--- a/src/perf_mainloop.cc
+++ b/src/perf_mainloop.cc
@@ -30,6 +30,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+namespace ddprof {
 static pid_t g_child_pid = 0;
 static bool g_termination_requested = false;
 
@@ -321,7 +322,7 @@ DDRes main_loop(const WorkerAttr *attr, DDProfContext *ctx) {
     // Ensure worker does not return,
     // because we don't want to free resources (perf_event fds,...) that are
     // shared between processes. Only free the context.
-    ddprof_context_free(ctx);
+    context_free(ctx);
     exit(0);
   }
   return {};
@@ -335,3 +336,5 @@ void main_loop_lib(const WorkerAttr *attr, DDProfContext *ctx) {
     LG_NFO("Request to exit");
   }
 }
+
+} // namespace ddprof

--- a/src/presets.cc
+++ b/src/presets.cc
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include "presets.hpp"
+
+#include "ddres.hpp"
+
+#include "ddprof_cmdline.hpp"
+#include "span.hpp"
+
+#include <algorithm>
+#include <string_view>
+
+namespace ddprof {
+
+DDRes add_preset(DDProfContext *ctx, const char *preset,
+                 bool pid_or_global_mode) {
+  using namespace std::literals;
+  static Preset presets[] = {
+      {"default", {"sCPU", "sALLOC"}},
+      {"default-pid", {"sCPU"}},
+      {"cpu_only", {"sCPU"}},
+      {"alloc_only", {"sALLOC"}},
+      {"cpu_live_heap", {"sCPU", "sALLOC mode=l"}},
+  };
+
+  if (preset == "default"sv && pid_or_global_mode) {
+    preset = "default-pid";
+  }
+
+  ddprof::span presets_span{presets};
+  std::string_view preset_sv{preset};
+
+  auto it = std::find_if(presets_span.begin(), presets_span.end(),
+                         [&preset_sv](auto &e) { return e.name == preset_sv; });
+  if (it == presets_span.end()) {
+    DDRES_RETURN_ERROR_LOG(DD_WHAT_INPUT_PROCESS, "Unknown preset (%s)",
+                           preset);
+  }
+
+  for (const char *event : it->events) {
+    if (event == nullptr) {
+      break;
+    }
+    if (ctx->num_watchers == MAX_TYPE_WATCHER) {
+      DDRES_RETURN_ERROR_LOG(DD_WHAT_INPUT_PROCESS, "Too many input events");
+    }
+    PerfWatcher *watcher = &ctx->watchers[ctx->num_watchers];
+    if (!watcher_from_str(event, watcher)) {
+      DDRES_RETURN_ERROR_LOG(DD_WHAT_INPUT_PROCESS,
+                             "Invalid event/tracepoint (%s)", event);
+    }
+    ddprof::span watchers{ctx->watchers,
+                          static_cast<size_t>(ctx->num_watchers)};
+
+    // ignore event if it was already present in watchers
+    if (watcher->ddprof_event_type == DDPROF_PWE_TRACEPOINT ||
+        std::find_if(watchers.begin(), watchers.end(), [&watcher](auto &w) {
+          return w.ddprof_event_type == watcher->ddprof_event_type;
+        }) == watchers.end()) {
+      ++ctx->num_watchers;
+    }
+  }
+
+  return {};
+}
+} // namespace ddprof

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -133,7 +133,6 @@ add_unit_test(
   ../src/perf_watcher.cc
   ../src/presets.cc
   ../src/tracepoint_config.cc
-  ../src/version.cc
   ddprof_input-ut.cc
   LIBRARIES DDProf::Parser
   DEFINITIONS MYNAME="ddprof_input-ut")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -131,7 +131,9 @@ add_unit_test(
   ../src/ddprof_cpumask.cc
   ../src/logger_setup.cc
   ../src/perf_watcher.cc
+  ../src/presets.cc
   ../src/tracepoint_config.cc
+  ../src/version.cc
   ddprof_input-ut.cc
   LIBRARIES DDProf::Parser
   DEFINITIONS MYNAME="ddprof_input-ut")

--- a/test/ddprof_input-ut.cc
+++ b/test/ddprof_input-ut.cc
@@ -20,6 +20,11 @@
 
 using namespace std::literals;
 
+// mocks
+bool s_version_called = false;
+void print_version() { s_version_called = true; }
+string_view str_version() { return STRING_VIEW_LITERAL("1.2.3"); }
+
 namespace ddprof {
 class InputTest : public ::testing::Test {
 protected:
@@ -27,10 +32,6 @@ protected:
 
   LogHandle _handle;
 };
-
-bool s_version_called = false;
-void print_version() { s_version_called = true; }
-string_view str_version() { return STRING_VIEW_LITERAL("1.2.3"); }
 
 TEST_F(InputTest, watcher_from_str) {
   LogHandle handle;

--- a/test/ddprof_input-ut.cc
+++ b/test/ddprof_input-ut.cc
@@ -20,6 +20,7 @@
 
 using namespace std::literals;
 
+namespace ddprof {
 class InputTest : public ::testing::Test {
 protected:
   void SetUp() override {}
@@ -211,11 +212,11 @@ TEST_F(InputTest, duplicate_events) {
     EXPECT_TRUE(contine_exec);
 
     DDProfContext ctx;
-    res = ddprof_context_set(&input, &ctx);
+    res = context_set(&input, &ctx);
     EXPECT_FALSE(IsDDResOK(res));
 
     ddprof_input_free(&input);
-    ddprof_context_free(&ctx);
+    context_free(&ctx);
   }
   {
     // Duplicate events (except tracepoints) are disallowed
@@ -230,11 +231,11 @@ TEST_F(InputTest, duplicate_events) {
     EXPECT_TRUE(contine_exec);
 
     DDProfContext ctx;
-    res = ddprof_context_set(&input, &ctx);
+    res = context_set(&input, &ctx);
     EXPECT_FALSE(IsDDResOK(res));
 
     ddprof_input_free(&input);
-    ddprof_context_free(&ctx);
+    context_free(&ctx);
   }
 }
 
@@ -252,7 +253,7 @@ TEST_F(InputTest, presets) {
     EXPECT_TRUE(contine_exec);
 
     DDProfContext ctx;
-    res = ddprof_context_set(&input, &ctx);
+    res = context_set(&input, &ctx);
     EXPECT_TRUE(IsDDResOK(res));
 
     ddprof::span watchers{ctx.watchers, static_cast<size_t>(ctx.num_watchers)};
@@ -271,7 +272,7 @@ TEST_F(InputTest, presets) {
               watchers.end());
 
     ddprof_input_free(&input);
-    ddprof_context_free(&ctx);
+    context_free(&ctx);
   }
 
   {
@@ -286,14 +287,14 @@ TEST_F(InputTest, presets) {
     EXPECT_TRUE(contine_exec);
 
     DDProfContext ctx;
-    res = ddprof_context_set(&input, &ctx);
+    res = context_set(&input, &ctx);
     EXPECT_TRUE(IsDDResOK(res));
 
     EXPECT_EQ(ctx.num_watchers, 1);
     EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
 
     ddprof_input_free(&input);
-    ddprof_context_free(&ctx);
+    context_free(&ctx);
   }
   {
     // Check cpu_only preset
@@ -307,7 +308,7 @@ TEST_F(InputTest, presets) {
     EXPECT_TRUE(contine_exec);
 
     DDProfContext ctx;
-    res = ddprof_context_set(&input, &ctx);
+    res = context_set(&input, &ctx);
     EXPECT_TRUE(IsDDResOK(res));
 
     ddprof::span watchers{ctx.watchers, static_cast<size_t>(ctx.num_watchers)};
@@ -316,7 +317,7 @@ TEST_F(InputTest, presets) {
     EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
 
     ddprof_input_free(&input);
-    ddprof_context_free(&ctx);
+    context_free(&ctx);
   }
   {
     // Check alloc_only preset
@@ -331,7 +332,7 @@ TEST_F(InputTest, presets) {
     EXPECT_TRUE(contine_exec);
 
     DDProfContext ctx;
-    res = ddprof_context_set(&input, &ctx);
+    res = context_set(&input, &ctx);
     EXPECT_TRUE(IsDDResOK(res));
 
     EXPECT_EQ(ctx.num_watchers, 2);
@@ -339,7 +340,7 @@ TEST_F(InputTest, presets) {
     EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sDUM);
 
     ddprof_input_free(&input);
-    ddprof_context_free(&ctx);
+    context_free(&ctx);
   }
   {
     // Check manual setting of live allocation
@@ -353,7 +354,7 @@ TEST_F(InputTest, presets) {
     EXPECT_TRUE(contine_exec);
 
     DDProfContext ctx;
-    res = ddprof_context_set(&input, &ctx);
+    res = context_set(&input, &ctx);
     EXPECT_TRUE(IsDDResOK(res));
 
     EXPECT_EQ(ctx.num_watchers, 2);
@@ -363,7 +364,7 @@ TEST_F(InputTest, presets) {
     log_watcher(&ctx.watchers[1], 1);
 
     ddprof_input_free(&input);
-    ddprof_context_free(&ctx);
+    context_free(&ctx);
   }
   {
     // Check cpu_live_heap preset
@@ -378,7 +379,7 @@ TEST_F(InputTest, presets) {
     EXPECT_TRUE(contine_exec);
 
     DDProfContext ctx;
-    res = ddprof_context_set(&input, &ctx);
+    res = context_set(&input, &ctx);
     EXPECT_TRUE(IsDDResOK(res));
 
     EXPECT_EQ(ctx.num_watchers, 2);
@@ -388,7 +389,7 @@ TEST_F(InputTest, presets) {
     EXPECT_EQ(ctx.watchers[0].output_mode, EventConfMode::kCallgraph);
 
     ddprof_input_free(&input);
-    ddprof_context_free(&ctx);
+    context_free(&ctx);
   }
   {
     // Default preset should not be loaded if an event is given in input
@@ -402,14 +403,14 @@ TEST_F(InputTest, presets) {
     EXPECT_TRUE(contine_exec);
 
     DDProfContext ctx;
-    res = ddprof_context_set(&input, &ctx);
+    res = context_set(&input, &ctx);
     EXPECT_TRUE(IsDDResOK(res));
 
     EXPECT_EQ(ctx.num_watchers, 1);
     EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
 
     ddprof_input_free(&input);
-    ddprof_context_free(&ctx);
+    context_free(&ctx);
   }
   {
     // If preset is explicit given in input, then another event with the same
@@ -425,7 +426,7 @@ TEST_F(InputTest, presets) {
     EXPECT_TRUE(contine_exec);
 
     DDProfContext ctx;
-    res = ddprof_context_set(&input, &ctx);
+    res = context_set(&input, &ctx);
     EXPECT_TRUE(IsDDResOK(res));
 
     EXPECT_EQ(ctx.num_watchers, 2);
@@ -434,6 +435,7 @@ TEST_F(InputTest, presets) {
     EXPECT_EQ(ctx.watchers[1].ddprof_event_type, DDPROF_PWE_sALLOC);
 
     ddprof_input_free(&input);
-    ddprof_context_free(&ctx);
+    context_free(&ctx);
   }
 }
+} // namespace ddprof


### PR DESCRIPTION
# What does this PR do?

- As the preset logics grows, I wanted to extract it from the ddprof_context init
- Minor renaming / namespacing refactoring
