### PR TITLE
Move the CI downstream repository to apm-reliability

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,6 @@ trigger_internal_build:
     # Reliability environment downstream branch
     DDPROF_RELENV_BRANCH: ${DDPROF_RELENV_BRANCH-"master"}
   trigger:
-    project: DataDog/ddprof-build
+    project: DataDog/apm-reliability/ddprof-build
     strategy: depend
     branch: $DOWNSTREAM_BUILD_BRANCH


### PR DESCRIPTION
# What does this PR do?

Move the CI downstream repository to apm-reliability

# Motivation

Fix CI
Allow benchmarks :rocket: 

