### PR TITLE
Fix: Remove incomplete frames

### DIFF
--- a/src/unwind.cc
+++ b/src/unwind.cc
@@ -53,8 +53,15 @@ static bool is_ld(const std::string &path) {
 }
 
 static bool is_stack_complete(UnwindState *us) {
-  static constexpr std::array s_expected_root_frames{"_start"sv, "__clone"sv,
-                                                     "_exit"sv};
+  static constexpr std::array s_expected_root_frames{
+      "__clone"sv,
+      "__clone3"sv,
+      "_exit"sv,
+      "main"sv,
+      "runtime.goexit.abi0"sv,
+      "runtime.systemstack.abi0"sv,
+      "_start"sv,
+      "start_thread"sv};
 
   if (us->output.locs.size() == 0) {
     return false;


### PR DESCRIPTION
# What does this PR do?

In case of incomplete stacks, we add an `[incomplete]` frame. We were adding this frame too often This PR adds new cases where we should consider the stack as complete.

# Motivation

Improve the look of frames by removing some of the `[incomplete]` qualifiers
