### PR TITLE
Mask API key when printing parameters

### DIFF
--- a/include/ddprof_defs.hpp
+++ b/include/ddprof_defs.hpp
@@ -13,6 +13,8 @@
 // Maximum depth for a single stack
 #define DD_MAX_STACK_DEPTH 512
 
+constexpr int k_size_api_key = 32;
+
 // Linux Inode type
 typedef uint64_t inode_t;
 

--- a/src/ddprof_input.cc
+++ b/src/ddprof_input.cc
@@ -57,7 +57,7 @@
   "  -" #c ", --" #b ", (envvar: " #a ")",
 
 namespace {
-std::string mask_value(const std::string_view value) {
+std::string api_key_to_dbg_string(const std::string_view value) {
   if (value.size() != k_size_api_key) {
     return "invalid";
   }
@@ -66,7 +66,7 @@ std::string mask_value(const std::string_view value) {
   masked.replace(len - 4, 4, value.substr(len - 4));
   return masked;
 }
-}
+} // namespace
 
 #define X_PRNT(a, b, c, d, e, f, g, h, i)                                      \
   {                                                                            \
@@ -74,7 +74,7 @@ std::string mask_value(const std::string_view value) {
       if (strcmp(#b, "api_key") != 0) {                                        \
         PRINT_NFO("  " #b ": %s", (f)->i b);                                   \
       } else {                                                                 \
-        std::string masked_value = mask_value((f)->i b);                       \
+        std::string masked_value = api_key_to_dbg_string((f)->i b);            \
         PRINT_NFO("  " #b ": %s", masked_value.c_str());                       \
       }                                                                        \
     }                                                                          \

--- a/src/ddprof_input.cc
+++ b/src/ddprof_input.cc
@@ -56,11 +56,27 @@
 #define X_HLPK(a, b, c, d, e, f, g, h, i)                                      \
   "  -" #c ", --" #b ", (envvar: " #a ")",
 
-// Helpers for expanding the OPT_TABLE here
+namespace {
+std::string mask_value(const std::string_view value) {
+  if (value.size() != k_size_api_key) {
+    return "invalid";
+  }
+  size_t len = value.length();
+  std::string masked(len, '*');
+  masked.replace(len - 4, 4, value.substr(len - 4));
+  return masked;
+}
+}
+
 #define X_PRNT(a, b, c, d, e, f, g, h, i)                                      \
   {                                                                            \
     if ((f)->i b) {                                                            \
-      PRINT_NFO("  " #b ": %s", (f)->i b);                                     \
+      if (strcmp(#b, "api_key") != 0) {                                        \
+        PRINT_NFO("  " #b ": %s", (f)->i b);                                   \
+      } else {                                                                 \
+        std::string masked_value = mask_value((f)->i b);                       \
+        PRINT_NFO("  " #b ": %s", masked_value.c_str());                       \
+      }                                                                        \
     }                                                                          \
   }
 

--- a/src/exporter/ddprof_exporter.cc
+++ b/src/exporter/ddprof_exporter.cc
@@ -24,7 +24,6 @@
 #include <vector>
 
 static const int k_timeout_ms = 10000;
-static const int k_size_api_key = 32;
 
 static char *alloc_url_agent(const char *protocol, const char *host,
                              const char *port) {


### PR DESCRIPTION
# What does this PR do?

When printing parameters in agentless mode, we are printing the API key.

# Motivation

Avoid possibly leaking a key in the logs.
