### PR TITLE
Ensure that temporary process exits normally

### DIFF
--- a/include/daemonize.hpp
+++ b/include/daemonize.hpp
@@ -5,12 +5,13 @@
 
 #pragma once
 
-#include <functional>
 #include <sys/types.h>
 
 namespace ddprof {
 
 struct DaemonizeResult {
+  enum State { Error, InitialProcess, IntermediateProcess, DaemonProcess };
+  State state; // Only InitialProcess can return in a Failure state
   pid_t
       temp_pid; // -1 on failure, 0 for initial process, > 0 for daemon process
   pid_t parent_pid; // pid of process initiating daemonize
@@ -18,7 +19,6 @@ struct DaemonizeResult {
 };
 
 // Daemonization function
-// cleanup_function is a callable invoked in the context of the intermediate,
 // short-lived process that will be killed by daemon process.
-DaemonizeResult daemonize(std::function<void()> cleanup_function = {});
+DaemonizeResult daemonize();
 } // namespace ddprof

--- a/src/lib/dd_profiling.cc
+++ b/src/lib/dd_profiling.cc
@@ -219,11 +219,15 @@ int ddprof_start_profiling_internal() {
         make_defer([&sockfds]() { close(sockfds[kParentIdx]); });
 
     auto daemonize_res = ddprof::daemonize();
-    if (daemonize_res.temp_pid == -1) {
+    if (daemonize_res.state == ddprof::DaemonizeResult::Error) {
       return -1;
     }
 
-    if (daemonize_res.temp_pid) {
+    if (daemonize_res.state == ddprof::DaemonizeResult::IntermediateProcess) {
+      _exit(0);
+    }
+
+    if (daemonize_res.state == ddprof::DaemonizeResult::DaemonProcess) {
       // executed by daemonized process
 
       // close parent socket end


### PR DESCRIPTION
Killing the temporary intermediate process generates false memory leak reports in valgrind because some resources are not cleaned up (eg. local strings on the stack).
The fix is to install a sigterm handler in temp pid, and upon receiving SIGTERM, make temp pid exits normally through main.
