### PR TITLE
Fix kernel frames configuration

### DIFF
--- a/src/perf.cc
+++ b/src/perf.cc
@@ -90,9 +90,9 @@ perf_event_attr perf_config_from_watcher(const PerfWatcher *watcher,
   attr.sample_type = watcher->sample_type;
   attr.sample_stack_user = watcher->sample_stack_size;
 
-  // If use_kernel is requested false --> exclude_kernel == true
-  if (watcher->options.use_kernel != PerfWatcherUseKernel::kOff)
-    attr.exclude_kernel = false;
+  // If use_kernel==off means we exclude_kernel
+  attr.exclude_kernel =
+      (watcher->options.use_kernel == PerfWatcherUseKernel::kOff);
 
   // Extras (metadata for tracking process state)
   if (extras) {

--- a/src/perf.cc
+++ b/src/perf.cc
@@ -91,8 +91,8 @@ perf_event_attr perf_config_from_watcher(const PerfWatcher *watcher,
   attr.sample_stack_user = watcher->sample_stack_size;
 
   // If use_kernel is requested false --> exclude_kernel == true
-  if (watcher->options.use_kernel == PerfWatcherUseKernel::kTry)
-    attr.exclude_kernel = true;
+  if (watcher->options.use_kernel != PerfWatcherUseKernel::kOff)
+    attr.exclude_kernel = false;
 
   // Extras (metadata for tracking process state)
   if (extras) {


### PR DESCRIPTION
# What does this PR do?

Kernel frames were removed by default

# Motivation

Kernel frames were not showing up by default.

# How to test the change?

To be defined
The logic is confusing as it is a negation. Testing the generation of the configuration seems valuable.