### PR TITLE
Clarify parser behavior

### DIFF
--- a/test/ddprofcmdline-ut.cc
+++ b/test/ddprofcmdline-ut.cc
@@ -58,6 +58,18 @@ TEST(CmdLineTst, ParserKeyPatterns) {
 
   // Simple events without qualification are valid event names
   ASSERT_TRUE(watcher_from_str("hCPU", &watcher));
+  ASSERT_TRUE(watcher_from_str("e=hCPU", &watcher));
+  ASSERT_TRUE(watcher_from_str("e=hCPU ", &watcher));
+  ASSERT_TRUE(watcher_from_str("e=hCPU  ", &watcher));
+  ASSERT_TRUE(watcher_from_str("e=hCPU   ", &watcher));
+
+  // Trailing whitespace is fine, but can't split on =
+  ASSERT_FALSE(watcher_from_str("e= hCPU", &watcher));
+  ASSERT_FALSE(watcher_from_str("e=  hCPU", &watcher));
+  ASSERT_FALSE(watcher_from_str("e=   hCPU", &watcher));
+  ASSERT_FALSE(watcher_from_str("e= hCPU ", &watcher));
+  ASSERT_FALSE(watcher_from_str("e= hCPU  ", &watcher));
+  ASSERT_FALSE(watcher_from_str("e= hCPU   ", &watcher));
 
   // Events should be tolerant of padding whitespace
   // Three checks on each side to ensure fully recursive (base, 1, 2) stripping


### PR DESCRIPTION
Parser was unterminated when multiple confs were given; fix by terminating.  This also left a few ambiguities open around whitespace handling in options, so make those explicit as well.  This also could have been fixed by allowing for an empty opt, but I didn't want to think about such an abomination.

# What does this PR do?

Changes the behavior of the parser and adds a small number of clarifying tests.

# Motivation

We had a warning during build.  This also makes the behavior more strict.

# Additional Notes

No additional notes

# How to test the change?

Tests included