### PR TITLE
Fix small issues with event parser

### DIFF
--- a/include/ddprof_cmdline.hpp
+++ b/include/ddprof_cmdline.hpp
@@ -7,8 +7,9 @@
 
 #include <stddef.h> // size_t
 #include <stdint.h> // uint64_t
+#include <vector>
 
-typedef struct PerfWatcher PerfWatcher;
+struct PerfWatcher;
 
 /**************************** Cmdline Helpers *********************************/
 // Helper functions for processing commandline arguments.
@@ -27,4 +28,4 @@ bool arg_inset(const char *str, char const *const *set, int sz_set);
 
 bool arg_yesno(const char *str, int mode);
 
-bool watcher_from_str(const char *str, PerfWatcher *watcher);
+bool watchers_from_str(const char *str, std::vector<PerfWatcher> &watchers);

--- a/include/event_config.hpp
+++ b/include/event_config.hpp
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 #include <string>
+#include <vector>
 
 // Defines how a sample is aggregated when it is received
 enum class EventConfMode : uint32_t {
@@ -163,4 +164,6 @@ struct EventConf {
   void clear() { *this = EventConf{}; }
 };
 
-EventConf *EventConf_parse(const char *msg); // Provided by generated code
+int EventConf_parse(
+    const char *msg,
+    std::vector<EventConf> &event_configs); // Provided by generated code

--- a/include/presets.hpp
+++ b/include/presets.hpp
@@ -12,9 +12,8 @@
 namespace ddprof {
 
 struct Preset {
-  static constexpr size_t k_max_events = 10;
   const char *name;
-  const char *events[k_max_events];
+  const char *events;
 };
 
 DDRes add_preset(DDProfContext *ctx, const char *preset,

--- a/src/event_parser/event_parser.l
+++ b/src/event_parser/event_parser.l
@@ -73,7 +73,9 @@ z|raw_size|rawsz           DISPATCH(RawSize)
 	return EQ;
 }
 
-[ ,\t][ \t]*                {
+[ \t]* {}
+
+[ ,\t]                      {
 	BEGIN 0;
 	return OPTSEP;
 }

--- a/src/presets.cc
+++ b/src/presets.cc
@@ -19,11 +19,11 @@ DDRes add_preset(DDProfContext *ctx, const char *preset,
                  bool pid_or_global_mode) {
   using namespace std::literals;
   static Preset presets[] = {
-      {"default", {"sCPU", "sALLOC"}},
-      {"default-pid", {"sCPU"}},
-      {"cpu_only", {"sCPU"}},
-      {"alloc_only", {"sALLOC"}},
-      {"cpu_live_heap", {"sCPU", "sALLOC mode=l"}},
+      {"default", "sCPU;sALLOC"},
+      {"default-pid", "sCPU"},
+      {"cpu_only", "sCPU"},
+      {"alloc_only", "sALLOC"},
+      {"cpu_live_heap", "sCPU;sALLOC mode=l"},
   };
 
   if (preset == "default"sv && pid_or_global_mode) {
@@ -40,27 +40,29 @@ DDRes add_preset(DDProfContext *ctx, const char *preset,
                            preset);
   }
 
-  for (const char *event : it->events) {
-    if (event == nullptr) {
-      break;
-    }
-    if (ctx->num_watchers == MAX_TYPE_WATCHER) {
-      DDRES_RETURN_ERROR_LOG(DD_WHAT_INPUT_PROCESS, "Too many input events");
-    }
-    PerfWatcher *watcher = &ctx->watchers[ctx->num_watchers];
-    if (!watcher_from_str(event, watcher)) {
-      DDRES_RETURN_ERROR_LOG(DD_WHAT_INPUT_PROCESS,
-                             "Invalid event/tracepoint (%s)", event);
-    }
+  if (ctx->num_watchers == MAX_TYPE_WATCHER) {
+    DDRES_RETURN_ERROR_LOG(DD_WHAT_INPUT_PROCESS, "Too many input events");
+  }
+  std::vector<PerfWatcher> new_watchers;
+  if (!watchers_from_str(it->events, new_watchers)) {
+    DDRES_RETURN_ERROR_LOG(DD_WHAT_INPUT_PROCESS,
+                           "Invalid event/tracepoint (%s)", it->events);
+  }
+
+  for (auto &watcher : new_watchers) {
     ddprof::span watchers{ctx->watchers,
                           static_cast<size_t>(ctx->num_watchers)};
 
     // ignore event if it was already present in watchers
-    if (watcher->ddprof_event_type == DDPROF_PWE_TRACEPOINT ||
+    if (watcher.ddprof_event_type == DDPROF_PWE_TRACEPOINT ||
         std::find_if(watchers.begin(), watchers.end(), [&watcher](auto &w) {
-          return w.ddprof_event_type == watcher->ddprof_event_type;
+          return w.ddprof_event_type == watcher.ddprof_event_type;
         }) == watchers.end()) {
-      ++ctx->num_watchers;
+
+      if (ctx->num_watchers == MAX_TYPE_WATCHER) {
+        DDRES_RETURN_ERROR_LOG(DD_WHAT_INPUT_PROCESS, "Too many input events");
+      }
+      ctx->watchers[ctx->num_watchers++] = std::move(watcher);
     }
   }
 

--- a/test/ddprof_input-ut.cc
+++ b/test/ddprof_input-ut.cc
@@ -33,15 +33,6 @@ protected:
   LogHandle _handle;
 };
 
-TEST_F(InputTest, watcher_from_str) {
-  LogHandle handle;
-  const char *str_event = "sALLOC mode=l";
-  PerfWatcher watcher;
-  bool ret = watcher_from_str(str_event, &watcher);
-  ASSERT_TRUE(ret);
-  log_watcher(&watcher, 0);
-}
-
 TEST_F(InputTest, default_values) {
   DDProfInput input;
   DDRes res = ddprof_input_default(&input);


### PR DESCRIPTION
* Grammar was allowing multiple events separated by ';'
  but only the last one was taken into account.
  Now `watchers_from_str` return a vector of watchers.
* Make `mode` option less permissive
* Allow for empty configs: "; ; ;;;" is a valid event string
* Simplify stripping by skipping space/tabs in the lexer
* Convert presets to single string since multiple events
  can now be described by a string
* Remove warnings from lexer/bison
