### PR TITLE
Do not trigger build on non-release tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,13 @@ variables:
     value: "main"
     description: "Run the build CI on this branch"
 
+workflow:
+  rules:
+    # If triggered by tag, run only for release tags and not rc
+    - if: '$CI_COMMIT_TAG != null && ($CI_COMMIT_TAG =~ /^v.*-rc$/ || $DDPROF_COMMIT_TAG !~ /^v/)'
+      when: never
+    - when: always
+
 # Triggers a build within the Datadog infrastructure in the ddprof-build repository
 trigger_internal_build:
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ variables:
 workflow:
   rules:
     # If triggered by tag, run only for release tags and not rc
-    - if: '$CI_COMMIT_TAG != null && ($CI_COMMIT_TAG =~ /^v.*-rc$/ || $DDPROF_COMMIT_TAG !~ /^v/)'
+    - if: '$CI_COMMIT_TAG != null && ($CI_COMMIT_TAG =~ /^v.*-rc$/ || $CI_COMMIT_TAG !~ /^v/)'
       when: never
     - when: always
 


### PR DESCRIPTION
Do not trigger downstream build pipeline for tags that are not release tags.
This ensures that rc tags do not trigger a build.
Currently downstream pipeline is triggered but entirely skipped for non release tags and this somehow makes the upstream pipeline fail.