### PR TITLE
Handle statsd paths in different format

### DIFF
--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -8,3 +8,4 @@ add_custom_target(format-apply COMMAND ${CMAKE_SOURCE_DIR}/tools/style-check.sh 
 
 add_custom_target(help-generate COMMAND ${CMAKE_SOURCE_DIR}/tools/help_generate.sh -b
                                         ${CMAKE_BINARY_DIR})
+add_dependencies(help-generate ddprof)

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -76,7 +76,7 @@ Debug options:
                               log_level, One of stdout, stderr, syslog, or disabled.
   --show_config [0]           Display the configuration.
   -b,--internal_stats TEXT (Env:DD_PROFILING_INTERNAL_STATS)
-                              Enables statsd metrics for ddprof. Value should point to a statsd socket..
+                              Enables statsd metrics for ddprof. Value should point to a statsd socket.
                               Example: /var/run/datadog-agent/statsd.sock
   --show_samples              Display captured samples as logs.
                               

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -75,7 +75,8 @@ Debug options:
   -o,--log_mode TEXT [stdout]  (Env:DD_PROFILING_NATIVE_LOG_MODE)
                               log_level, One of stdout, stderr, syslog, or disabled.
   --show_config [0]           Display the configuration.
-  -b,--internal_stats TEXT    Enables statsd metrics for " MYNAME ". Value should point to a statsd socket..
+  -b,--internal_stats TEXT (Env:DD_PROFILING_INTERNAL_STATS)
+                              Enables statsd metrics for ddprof. Value should point to a statsd socket..
                               Example: /var/run/datadog-agent/statsd.sock
   --show_samples              Display captured samples as logs.
                               

--- a/include/statsd.hpp
+++ b/include/statsd.hpp
@@ -29,3 +29,5 @@ DDRes statsd_close(int);
 
 /* Private */
 DDRes statsd_listen(std::string_view path, int *fd);
+
+std::string_view adjust_uds_path(std::string_view path);

--- a/include/statsd.hpp
+++ b/include/statsd.hpp
@@ -29,5 +29,3 @@ DDRes statsd_close(int);
 
 /* Private */
 DDRes statsd_listen(std::string_view path, int *fd);
-
-std::string_view adjust_uds_path(std::string_view path);

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -242,7 +242,8 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
   extended_options.push_back(
       app.add_option("--debug_pprof_prefix", exporter_input.debug_pprof_prefix,
                      "Prefix path to capture pprof files locally")
-          ->group(""));
+          ->group("")
+          ->envname("DD_PROFILING_PPROF_PREFIX"));
   extended_options.push_back(
       app.add_option("--agentless", exporter_input.agentless,
                      "Allow sending profiles directly to Datadog intake")

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -190,8 +190,8 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
       ->group("Debug options");
   //
   app.add_option("--internal_stats,-b", internal_stats,
-                 "Enables statsd metrics for \" MYNAME \". Value should point "
-                 "to a statsd socket..\n"
+                 "Enables statsd metrics for " MYNAME ". Value should point "
+                 "to a statsd socket.\n"
                  "Example: /var/run/datadog-agent/statsd.sock")
       ->group("Debug options")
       ->envname("DD_PROFILING_INTERNAL_STATS");

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -193,7 +193,9 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
                  "Enables statsd metrics for \" MYNAME \". Value should point "
                  "to a statsd socket..\n"
                  "Example: /var/run/datadog-agent/statsd.sock")
-      ->group("Debug options");
+      ->group("Debug options")
+      ->envname("DD_PROFILING_INTERNAL_STATS");
+
   app.add_flag("--show_samples", show_samples,
                "Display captured samples as logs.\n")
       ->group("Debug options");

--- a/src/statsd.cc
+++ b/src/statsd.cc
@@ -15,10 +15,18 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+std::string_view adjust_uds_path(std::string_view path) {
+  // Check if the socket_path starts with unix://
+  if (path.substr(0, 7) == "unix://") {
+    path.remove_prefix(7);
+  }
+  return path;
+}
+
 DDRes statsd_listen(std::string_view path, int *fd) {
   struct sockaddr_un addr_bind = {.sun_family = AF_UNIX};
   int fd_sock = -1;
-
+  path = adjust_uds_path(path);
   // Open the socket
   if (path.size() >= sizeof(addr_bind.sun_path) - 1) {
     DDRES_RETURN_WARN_LOG(DD_WHAT_STATSD, "[STATSD] %.*s path is too long",
@@ -63,6 +71,7 @@ DDRes statsd_connect(std::string_view statsd_socket, int *fd) {
   struct sockaddr_un addr_peer = {.sun_family = AF_UNIX};
   int fd_sock = -1;
 
+  statsd_socket = adjust_uds_path(statsd_socket);
   if (statsd_socket.size() >= sizeof(addr_peer.sun_path) - 1) {
     DDRES_RETURN_WARN_LOG(DD_WHAT_STATSD, "[STATSD] %.*s path is too long",
                           static_cast<int>(statsd_socket.size()),

--- a/src/statsd.cc
+++ b/src/statsd.cc
@@ -15,10 +15,11 @@
 #include <sys/un.h>
 #include <unistd.h>
 
-std::string_view adjust_uds_path(std::string_view path) {
+static std::string_view adjust_uds_path(std::string_view path) {
   // Check if the socket_path starts with unix://
-  if (path.substr(0, 7) == "unix://") {
-    path.remove_prefix(7);
+  static constexpr std::string_view prefix{"unix://"};
+  if (path.starts_with(prefix)) {
+    path.remove_prefix(prefix.length());
   }
   return path;
 }

--- a/test/statsd-ut.cc
+++ b/test/statsd-ut.cc
@@ -56,7 +56,7 @@ TEST(StatsDTest, BadConnection) {
 TEST(StatsDTest, Format) {
   // Note that the result is hardcoded, based on what the spec says it should
   // be; we don't bring in any kind of statsd validation lib or compare types
-  const char path_listen[] = "/tmp/my_statsd_listener";
+  const char path_listen[] = "unix:///tmp/my_statsd_listener";
   const char answer[] = "foo:9999|g";
   unlink(path_listen); // Make sure the default listening path is available
 


### PR DESCRIPTION
# What does this PR do?

Add an environment variable to the internal stat field
Adjust the format if it contains `unix://`
Revert removal of env var for pprof_prefix

# Motivation

Make it easier to set the internal stats field.
Avoid breaking relenv
Fix prof-correctness tests