### PR TITLE
Symbol cache fix off by one error

### DIFF
--- a/include/dwfl_symbol_lookup.hpp
+++ b/include/dwfl_symbol_lookup.hpp
@@ -69,7 +69,7 @@ private:
   SymbolIdx_t insert(const DDProfMod &ddprof_mod, SymbolTable &table,
                      DsoSymbolLookup &dso_symbol_lookup,
                      ProcessAddress_t process_pc, const Dso &dso,
-                     SymbolMap &map);
+                     SymbolMap &map, SymbolMap::It &it);
 
   // Symbols are ordered by file.
   // The assumption is that the elf addresses are the same across processes


### PR DESCRIPTION
# What does this PR do?

- The symbol cache had a off by one error in some cases.
- When libdwfl did not git us the size of a symbol, we would use pc+1 (which was wrong)

# Motivation

Fix for flaky test
