### PR TITLE
Add a benchmark for the allocation tracker

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -349,6 +349,24 @@ add_benchmark(savecontext-bench savecontext-bench.cc ../src/lib/pthread_fixes.cc
 
 add_benchmark(timer-bench timer-bench.cc ../src/timer.cc ../src/perf.cc)
 
+add_benchmark(
+  allocation_tracker-bench
+  allocation_tracker-bench.cc
+  ../src/lib/allocation_tracker.cc
+  ../src/pevent_lib.cc
+  ../src/perf.cc
+  ../src/perf_ringbuffer.cc
+  ../src/perf_watcher.cc
+  ../src/ringbuffer_utils.cc
+  ../src/lib/pthread_fixes.cc
+  ../src/lib/savecontext.cc
+  ../src/lib/saveregisters.cc
+  ../src/procutils.cc
+  ../src/user_override.cc
+  ../src/sys_utils.cc
+  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle DDProf::Parser
+  DEFINITIONS ${DDPROF_DEFINITION_LIST} KMAX_TRACKED_ALLOCATIONS=10000)
+
 if(NOT CMAKE_BUILD_TYPE STREQUAL "SanitizedDebug")
   add_exe(
     simple_malloc-static simple_malloc.cc

--- a/test/allocation_tracker-bench.cc
+++ b/test/allocation_tracker-bench.cc
@@ -1,0 +1,94 @@
+#include <benchmark/benchmark.h>
+
+#include "allocation_tracker.hpp"
+#include "ringbuffer_holder.hpp"
+#include <thread>
+
+DDPROF_NOINLINE void my_malloc(size_t size, uintptr_t addr = 0xdeadbeef) {
+  ddprof::AllocationTracker::track_allocation(addr, size);
+  // prevent tail call optimization
+  getpid();
+}
+
+DDPROF_NOINLINE void my_free(uintptr_t addr) {
+  ddprof::AllocationTracker::track_deallocation(addr);
+  // prevent tail call optimization
+  getpid();
+}
+// Function to perform allocations and deallocations
+void perform_memory_operations(bool track_allocations,
+                               benchmark::State &state) {
+  const uint64_t rate = 1;
+  const size_t buf_size_order = 5;
+  ddprof::RingBufferHolder ring_buffer{buf_size_order,
+                                       RingBufferType::kMPSCRingBuffer};
+
+  if (track_allocations) {
+    ddprof::AllocationTracker::allocation_tracking_init(
+        rate,
+        ddprof::AllocationTracker::kDeterministicSampling |
+            ddprof::AllocationTracker::kTrackDeallocations,
+        ring_buffer.get_buffer_info());
+  }
+
+  int nb_threads = 4;
+  std::vector<std::thread> threads;
+  int num_allocations = 1000;
+  size_t page_size = 0x1000;
+  std::random_device rd;
+  std::mt19937 gen(rd());
+
+  for (auto _ : state) {
+    state.PauseTiming();
+
+    // Initialize threads and clear addresses
+    threads.clear();
+    std::vector<std::vector<uintptr_t>> thread_addresses(nb_threads);
+
+    for (int i = 0; i < nb_threads; ++i) {
+      threads.emplace_back([&, i] {
+        std::uniform_int_distribution<> dis(i * page_size,
+                                            (i + 1) * page_size - 1);
+
+        for (int j = 0; j < num_allocations; ++j) {
+          uintptr_t addr = dis(gen);
+          my_malloc(1024, addr);
+          thread_addresses[i].push_back(addr);
+        }
+      });
+    }
+
+    for (auto &t : threads) {
+      t.join();
+    }
+
+    state.ResumeTiming();
+
+    threads.clear();
+    for (int i = 0; i < nb_threads; ++i) {
+      threads.emplace_back([&, i] {
+        for (auto addr : thread_addresses[i]) {
+          my_free(addr);
+        }
+      });
+    }
+
+    for (auto &t : threads) {
+      t.join();
+    }
+  }
+  ddprof::AllocationTracker::allocation_tracking_free();
+}
+
+// Benchmark without allocation tracking
+static void BM_ThreadedAllocations_NoTracking(benchmark::State &state) {
+  perform_memory_operations(false, state);
+}
+
+// Benchmark with allocation tracking
+static void BM_ThreadedAllocations_Tracking(benchmark::State &state) {
+  perform_memory_operations(true, state);
+}
+
+BENCHMARK(BM_ThreadedAllocations_NoTracking);
+BENCHMARK(BM_ThreadedAllocations_Tracking);

--- a/test/allocation_tracker-ut.cc
+++ b/test/allocation_tracker-ut.cc
@@ -4,21 +4,17 @@
 // Datadog, Inc.
 #include "allocation_tracker.hpp"
 
-#include "ddprof_base.hpp"
 #include "ddprof_perf_event.hpp"
 #include "ipc.hpp"
 #include "live_allocation-c.hpp"
 #include "loghandle.hpp"
-#include "perf_watcher.hpp"
 #include "pevent_lib.hpp"
 #include "ringbuffer_holder.hpp"
-#include "ringbuffer_utils.hpp"
 #include "syscalls.hpp"
 #include "unwind.hpp"
 #include "unwind_state.hpp"
 
 #include <gtest/gtest.h>
-#include <sys/syscall.h>
 #include <unistd.h>
 
 DDPROF_NOINLINE void my_malloc(size_t size, uintptr_t addr = 0xdeadbeef) {


### PR DESCRIPTION
# What does this PR do?

Add a benchmark for allocation tracking

# Motivation

Preparing the work on reducing the overhead. We can see that the issue is the time spent in locks.

# Additional Notes

The numbers are bad for now! Let's work on it.

# How to test the change?

This is executed in CI.