### PR TITLE
Configure stack size

### DIFF
--- a/include/ddprof_cli.hpp
+++ b/include/ddprof_cli.hpp
@@ -56,12 +56,12 @@ public:
 
   // extended
   std::string cpu_affinity;
+  uint32_t default_sample_stack_user{k_default_perf_sample_stack_user};
   bool show_samples{false};
   bool fault_info{true};
   bool help_extended{false};
   int socket{-1};
-  // valid state to continue ?
-  bool continue_exec = {false};
+  bool continue_exec{false};
 
   // args
   std::vector<std::string> command_line;

--- a/include/ddprof_cli.hpp
+++ b/include/ddprof_cli.hpp
@@ -56,7 +56,7 @@ public:
 
   // extended
   std::string cpu_affinity;
-  uint32_t default_sample_stack_user{k_default_perf_sample_stack_user};
+  uint32_t default_stack_sample_size{k_default_perf_stack_sample_size};
   bool show_samples{false};
   bool fault_info{true};
   bool help_extended{false};

--- a/include/ddprof_cmdline.hpp
+++ b/include/ddprof_cmdline.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "ddprof_defs.hpp"
+
 #include <stddef.h> // size_t
 #include <stdint.h> // uint64_t
 #include <vector>
@@ -31,4 +32,4 @@ bool arg_yesno(const char *str, int mode);
 
 bool watchers_from_str(
     const char *str, std::vector<PerfWatcher> &watchers,
-    uint32_t sample_stack_user = k_default_perf_sample_stack_user);
+    uint32_t stack_sample_size = k_default_perf_stack_sample_size);

--- a/include/ddprof_cmdline.hpp
+++ b/include/ddprof_cmdline.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "ddprof_defs.hpp"
 #include <stddef.h> // size_t
 #include <stdint.h> // uint64_t
 #include <vector>
@@ -28,4 +29,6 @@ bool arg_inset(const char *str, char const *const *set, int sz_set);
 
 bool arg_yesno(const char *str, int mode);
 
-bool watchers_from_str(const char *str, std::vector<PerfWatcher> &watchers);
+bool watchers_from_str(
+    const char *str, std::vector<PerfWatcher> &watchers,
+    uint32_t sample_stack_user = k_default_perf_sample_stack_user);

--- a/include/ddprof_defs.hpp
+++ b/include/ddprof_defs.hpp
@@ -24,7 +24,7 @@ constexpr uint32_t k_default_perf_stack_sample_size = (4096UL * 8);
 // considering sample size, we adjust the size of ring buffers.
 // Following is considered as a minimum number of samples to be fit in the
 // ring buffer.
-constexpr auto k_min_number_samples_per_ring_buffer = 8;
+constexpr auto k_min_number_samples_per_ring_buffer = 7;
 
 constexpr int k_size_api_key = 32;
 

--- a/include/ddprof_defs.hpp
+++ b/include/ddprof_defs.hpp
@@ -19,12 +19,12 @@
 // as `size_stack` might be smaller then the requested size
 // The type is uint32 to be consistent with the perf_event interface
 // Check linux sources for a reference to the sample size check
-constexpr uint32_t k_default_perf_stack_sample_size = (4096UL * 8);
+constexpr uint32_t k_default_perf_stack_sample_size = 32000;
 
 // considering sample size, we adjust the size of ring buffers.
 // Following is considered as a minimum number of samples to be fit in the
 // ring buffer.
-constexpr auto k_min_number_samples_per_ring_buffer = 7;
+constexpr auto k_min_number_samples_per_ring_buffer = 8;
 
 constexpr int k_size_api_key = 32;
 

--- a/include/ddprof_defs.hpp
+++ b/include/ddprof_defs.hpp
@@ -13,6 +13,9 @@
 // Maximum depth for a single stack
 #define DD_MAX_STACK_DEPTH 512
 
+// default stack size for perf_event_open
+constexpr unsigned long k_default_perf_sample_stack_user = (4096UL * 8);
+
 constexpr int k_size_api_key = 32;
 
 // Linux Inode type

--- a/include/ddprof_defs.hpp
+++ b/include/ddprof_defs.hpp
@@ -14,9 +14,17 @@
 #define DD_MAX_STACK_DEPTH 512
 
 // Sample stack size must a multiple of 8 and strictly inferior to 2^16
+// Note that since maximum perf_event_hdr size is 2^16-1 and there are other
+// data/headers in perf_event struct, actual maximum stack sample size returned
+// as `size_stack` might be smaller then the requested size
 // The type is uint32 to be consistent with the perf_event interface
-// Check linux sources for a reference to this check
-constexpr uint32_t k_default_perf_sample_stack_user = (4096UL * 8);
+// Check linux sources for a reference to the sample size check
+constexpr uint32_t k_default_perf_stack_sample_size = (4096UL * 8);
+
+// considering sample size, we adjust the size of ring buffers.
+// Following is considered as a minimum number of samples to be fit in the
+// ring buffer.
+constexpr auto k_min_number_samples_per_ring_buffer = 8;
 
 constexpr int k_size_api_key = 32;
 

--- a/include/ddprof_defs.hpp
+++ b/include/ddprof_defs.hpp
@@ -13,8 +13,10 @@
 // Maximum depth for a single stack
 #define DD_MAX_STACK_DEPTH 512
 
-// default stack size for perf_event_open
-constexpr unsigned long k_default_perf_sample_stack_user = (4096UL * 8);
+// Sample stack size must a multiple of 8 and strictly inferior to 2^16
+// The type is uint32 to be consistent with the perf_event interface
+// Check linux sources for a reference to this check
+constexpr uint32_t k_default_perf_sample_stack_user = (4096UL * 8);
 
 constexpr int k_size_api_key = 32;
 

--- a/include/event_config.hpp
+++ b/include/event_config.hpp
@@ -143,11 +143,11 @@ enum class EventConfField {
    *  The `perf_event` register number to use for sample normalization.  In a
    *  future patch, the user will be able to use register names.
    */
-  kSampleStackUser,
+  kStackSampleSize,
   /*
-   *  The `perf_event` sample stack user. Defines the size of samples that are
-   *  copied from the user application. This also relates to how far we can
-   *  unwind.
+   *  The `perf_event` setting on stack size. Defines the size of samples that
+   * are copied from the user application. This will define how far we can
+   * unwind.
    */
 };
 
@@ -164,7 +164,7 @@ struct EventConf {
   uint8_t register_num{};
   uint8_t raw_size{};
   uint64_t raw_offset{};
-  uint32_t sample_stack_user{k_default_perf_sample_stack_user};
+  uint32_t stack_sample_size{k_default_perf_stack_sample_size};
   double value_scale{};
 
   EventConfCadenceType cad_type{};
@@ -173,6 +173,5 @@ struct EventConf {
   void clear() { *this = EventConf{}; }
 };
 
-int EventConf_parse(
-    const char *msg,
-    std::vector<EventConf> &event_configs); // Provided by generated code
+int EventConf_parse(const char *msg, const EventConf &template_conf,
+                    std::vector<EventConf> &event_configs);

--- a/include/event_config.hpp
+++ b/include/event_config.hpp
@@ -145,8 +145,9 @@ enum class EventConfField {
    */
   kSampleStackUser,
   /*
-   *  The `perf_event` sample stack user, which can define if unwinding
-   *  will be truncated (bsased on size of the stacks).
+   *  The `perf_event` sample stack user. Defines the size of samples that are
+   *  copied from the user application. This also relates to how far we can
+   *  unwind.
    */
 };
 

--- a/include/event_config.hpp
+++ b/include/event_config.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "ddprof_defs.hpp"
+
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -141,25 +143,31 @@ enum class EventConfField {
    *  The `perf_event` register number to use for sample normalization.  In a
    *  future patch, the user will be able to use register names.
    */
+  kSampleStackUser,
+  /*
+   *  The `perf_event` sample stack user, which can define if unwinding
+   *  will be truncated (bsased on size of the stacks).
+   */
 };
 
 struct EventConf {
-  EventConfMode mode;
+  EventConfMode mode{};
 
-  int64_t id;
+  int64_t id{};
 
-  std::string eventname;
-  std::string groupname;
-  std::string label;
+  std::string eventname{};
+  std::string groupname{};
+  std::string label{};
 
-  EventConfValueSource value_source;
-  uint8_t register_num;
-  uint8_t raw_size;
-  uint64_t raw_offset;
-  double value_scale;
+  EventConfValueSource value_source{};
+  uint8_t register_num{};
+  uint8_t raw_size{};
+  uint64_t raw_offset{};
+  uint32_t sample_stack_user{k_default_perf_sample_stack_user};
+  double value_scale{};
 
-  EventConfCadenceType cad_type;
-  int64_t cadence;
+  EventConfCadenceType cad_type{};
+  int64_t cadence{};
 
   void clear() { *this = EventConf{}; }
 };

--- a/include/event_config.hpp
+++ b/include/event_config.hpp
@@ -169,8 +169,6 @@ struct EventConf {
 
   EventConfCadenceType cad_type{};
   int64_t cadence{};
-
-  void clear() { *this = EventConf{}; }
 };
 
 int EventConf_parse(const char *msg, const EventConf &template_conf,

--- a/include/ipc.hpp
+++ b/include/ipc.hpp
@@ -104,7 +104,7 @@ struct ReplyMessage {
   // cppcheck-suppress unusedStructMember
   RingBufferInfo ring_buffer;
   int32_t allocation_flags = 0;
-  uint32_t sample_stack_user = 0;
+  uint32_t stack_sample_size = 0;
 };
 
 class Client {

--- a/include/ipc.hpp
+++ b/include/ipc.hpp
@@ -104,6 +104,7 @@ struct ReplyMessage {
   // cppcheck-suppress unusedStructMember
   RingBufferInfo ring_buffer;
   int32_t allocation_flags = 0;
+  uint32_t sample_stack_user = 0;
 };
 
 class Client {

--- a/include/lib/allocation_event.hpp
+++ b/include/lib/allocation_event.hpp
@@ -13,7 +13,6 @@ namespace ddprof {
 // This represent a sampled allocation.
 // We Keep the same layout as a perf event to unify the code paths.
 struct AllocationEvent {
-  static constexpr unsigned k_data_fake_size = 8; // 8 to keep aligned struct
   perf_event_header hdr;
   struct sample_id sample_id;
   uint64_t addr; /* if PERF_SAMPLE_ADDR */
@@ -27,7 +26,7 @@ struct AllocationEvent {
 // An extra field is added after the end to communicate the dyn_size
 //  uint64_t dyn_size_stack;
 
-static inline size_t SizeOfAllocationEvent(uint32_t stack_sample_user) {
+inline size_t sizeof_allocation_event(uint32_t stack_sample_user) {
   // stack_sample_user is 8 byte aligned
   // (Size of the event) + (stack size - 1) + sizeof(dyn_size field)
   return sizeof(AllocationEvent) + stack_sample_user + sizeof(uint64_t);

--- a/include/lib/allocation_event.hpp
+++ b/include/lib/allocation_event.hpp
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
+// Datadog, Inc.
+
+#pragma once
+
+#include <linux/perf_event.h>
+
+namespace ddprof {
+
+struct AllocationEvent {
+  perf_event_header hdr;
+  struct sample_id sample_id;
+  uint64_t addr; /* if PERF_SAMPLE_ADDR */
+  uint64_t period;
+  uint64_t abi;                   /* if PERF_SAMPLE_REGS_USER */
+  uint64_t regs[PERF_REGS_COUNT]; /* if PERF_SAMPLE_REGS_USER */
+  uint64_t size;                  /* if PERF_SAMPLE_STACK_USER */
+  std::byte data[1]; /* if PERF_SAMPLE_STACK_USER, the actual size will be
+                                     determined at runtime */
+  uint64_t dyn_size; /* if PERF_SAMPLE_STACK_USER && size != 0 */
+};
+} // namespace ddprof

--- a/include/lib/allocation_event.hpp
+++ b/include/lib/allocation_event.hpp
@@ -18,18 +18,18 @@ struct AllocationEvent {
   struct sample_id sample_id;
   uint64_t addr; /* if PERF_SAMPLE_ADDR */
   uint64_t period;
-  uint64_t abi;                   /* if PERF_SAMPLE_REGS_USER */
-  uint64_t regs[PERF_REGS_COUNT]; /* if PERF_SAMPLE_REGS_USER */
-  uint64_t size_stack;                  /* if PERF_SAMPLE_STACK_USER */
-  std::byte data[k_data_fake_size]; /* requires PERF_SAMPLE_STACK_USER, dyn size will contain the actual size */
+  uint64_t abi;                     /* if PERF_SAMPLE_REGS_USER */
+  uint64_t regs[PERF_REGS_COUNT];   /* if PERF_SAMPLE_REGS_USER */
+  uint64_t size_stack;              /* if PERF_SAMPLE_STACK_USER */
+  std::byte data[k_data_fake_size]; /* requires PERF_SAMPLE_STACK_USER, dyn size
+                                       will contain the actual size */
 };
 //  uint64_t dyn_size_stack;  /* added after the buffer */
 
 static inline size_t SizeOfAllocationEvent(uint32_t stack_sample_user) {
   // stack_sample_user is 8 byte aligned
   // (Size of the event) + (stack size - 1) + sizeof(dyn_size field)
-  return sizeof(AllocationEvent) + stack_sample_user
-      - AllocationEvent::k_data_fake_size
-      + sizeof(uint64_t);
+  return sizeof(AllocationEvent) + stack_sample_user -
+      AllocationEvent::k_data_fake_size + sizeof(uint64_t);
 }
 } // namespace ddprof

--- a/include/lib/allocation_event.hpp
+++ b/include/lib/allocation_event.hpp
@@ -18,18 +18,18 @@ struct AllocationEvent {
   struct sample_id sample_id;
   uint64_t addr; /* if PERF_SAMPLE_ADDR */
   uint64_t period;
-  uint64_t abi;                     /* if PERF_SAMPLE_REGS_USER */
-  uint64_t regs[PERF_REGS_COUNT];   /* if PERF_SAMPLE_REGS_USER */
-  uint64_t size_stack;              /* if PERF_SAMPLE_STACK_USER */
-  std::byte data[k_data_fake_size]; /* requires PERF_SAMPLE_STACK_USER, dyn size
-                                       will contain the actual size */
+  uint64_t abi;                   /* if PERF_SAMPLE_REGS_USER */
+  uint64_t regs[PERF_REGS_COUNT]; /* if PERF_SAMPLE_REGS_USER */
+  uint64_t size_stack;            /* if PERF_SAMPLE_STACK_USER */
+  std::byte data[];               /* requires PERF_SAMPLE_STACK_USER, dyn size
+                                      will contain the actual size */
 };
-//  uint64_t dyn_size_stack;  /* added after the buffer */
+// An extra field is added after the end to communicate the dyn_size
+//  uint64_t dyn_size_stack;
 
 static inline size_t SizeOfAllocationEvent(uint32_t stack_sample_user) {
   // stack_sample_user is 8 byte aligned
   // (Size of the event) + (stack size - 1) + sizeof(dyn_size field)
-  return sizeof(AllocationEvent) + stack_sample_user -
-      AllocationEvent::k_data_fake_size + sizeof(uint64_t);
+  return sizeof(AllocationEvent) + stack_sample_user + sizeof(uint64_t);
 }
 } // namespace ddprof

--- a/include/lib/allocation_event.hpp
+++ b/include/lib/allocation_event.hpp
@@ -27,8 +27,7 @@ struct AllocationEvent {
 //  uint64_t dyn_size_stack;
 
 inline size_t sizeof_allocation_event(uint32_t stack_sample_user) {
-  // stack_sample_user is 8 byte aligned
-  // (Size of the event) + (stack size - 1) + sizeof(dyn_size field)
+  // (Size of the event) + + sizeof(dyn_size field)
   return sizeof(AllocationEvent) + stack_sample_user + sizeof(uint64_t);
 }
 } // namespace ddprof

--- a/include/lib/allocation_event.hpp
+++ b/include/lib/allocation_event.hpp
@@ -9,16 +9,27 @@
 
 namespace ddprof {
 
+// AllocationEvent
+// This represent a sampled allocation.
+// We Keep the same layout as a perf event to unify the code paths.
 struct AllocationEvent {
+  static constexpr unsigned k_data_fake_size = 8; // 8 to keep aligned struct
   perf_event_header hdr;
   struct sample_id sample_id;
   uint64_t addr; /* if PERF_SAMPLE_ADDR */
   uint64_t period;
   uint64_t abi;                   /* if PERF_SAMPLE_REGS_USER */
   uint64_t regs[PERF_REGS_COUNT]; /* if PERF_SAMPLE_REGS_USER */
-  uint64_t size;                  /* if PERF_SAMPLE_STACK_USER */
-  std::byte data[1]; /* if PERF_SAMPLE_STACK_USER, the actual size will be
-                                     determined at runtime */
-  uint64_t dyn_size; /* if PERF_SAMPLE_STACK_USER && size != 0 */
+  uint64_t size_stack;                  /* if PERF_SAMPLE_STACK_USER */
+  std::byte data[k_data_fake_size]; /* requires PERF_SAMPLE_STACK_USER, dyn size will contain the actual size */
 };
+//  uint64_t dyn_size_stack;  /* added after the buffer */
+
+static inline size_t SizeOfAllocationEvent(uint32_t stack_sample_user) {
+  // stack_sample_user is 8 byte aligned
+  // (Size of the event) + (stack size - 1) + sizeof(dyn_size field)
+  return sizeof(AllocationEvent) + stack_sample_user
+      - AllocationEvent::k_data_fake_size
+      + sizeof(uint64_t);
+}
 } // namespace ddprof

--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -53,6 +53,7 @@ public:
 
   static DDRes allocation_tracking_init(uint64_t allocation_profiling_rate,
                                         uint32_t flags,
+                                        uint32_t sample_stack_user,
                                         const RingBufferInfo &ring_buffer);
   static void allocation_tracking_free();
 
@@ -85,7 +86,7 @@ private:
   uint64_t next_sample_interval();
 
   DDRes init(uint64_t mem_profile_interval, bool deterministic_sampling,
-             const RingBufferInfo &ring_buffer);
+             uint32_t sample_stack_user, const RingBufferInfo &ring_buffer);
   void free();
 
   static AllocationTracker *create_instance();
@@ -108,6 +109,7 @@ private:
 
   TrackerState _state;
   uint64_t _sampling_interval;
+  uint32_t _sample_stack_user;
   std::mt19937 _gen;
   PEvent _pevent;
   bool _deterministic_sampling;

--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -53,7 +53,7 @@ public:
 
   static DDRes allocation_tracking_init(uint64_t allocation_profiling_rate,
                                         uint32_t flags,
-                                        uint32_t sample_stack_user,
+                                        uint32_t stack_sample_size,
                                         const RingBufferInfo &ring_buffer);
   static void allocation_tracking_free();
 
@@ -86,7 +86,7 @@ private:
   uint64_t next_sample_interval();
 
   DDRes init(uint64_t mem_profile_interval, bool deterministic_sampling,
-             uint32_t sample_stack_user, const RingBufferInfo &ring_buffer);
+             uint32_t stack_sample_size, const RingBufferInfo &ring_buffer);
   void free();
 
   static AllocationTracker *create_instance();
@@ -109,7 +109,7 @@ private:
 
   TrackerState _state;
   uint64_t _sampling_interval;
-  uint32_t _sample_stack_user;
+  uint32_t _stack_sample_size;
   std::mt19937 _gen;
   PEvent _pevent;
   bool _deterministic_sampling;

--- a/include/perf.hpp
+++ b/include/perf.hpp
@@ -15,7 +15,7 @@
 #include <vector>
 
 // defaut ring buffer size expressed as a power-of-two in number of pages
-#define DEFAULT_BUFF_SIZE_SHIFT 6
+#define DEFAULT_BUFF_SIZE_SHIFT 7
 // this does not count as pinned memory, use a larger size
 #define MPSC_BUFF_SIZE_SHIFT 8
 

--- a/include/perf.hpp
+++ b/include/perf.hpp
@@ -21,9 +21,6 @@
 
 #define PSAMPLE_DEFAULT_WAKEUP_MS 100 // sample frequency check
 
-// Sample stack size must a multiple of 8 and strictly inferior to 2^32
-// #define PERF_SAMPLE_STACK_SIZE (4096U * 8)
-
 struct read_format {
   uint64_t value;        // The value of the event
   uint64_t time_enabled; // if PERF_FORMAT_TOTAL_TIME_ENABLED

--- a/include/perf.hpp
+++ b/include/perf.hpp
@@ -15,7 +15,7 @@
 #include <vector>
 
 // defaut ring buffer size expressed as a power-of-two in number of pages
-#define DEFAULT_BUFF_SIZE_SHIFT 7
+#define DEFAULT_BUFF_SIZE_SHIFT 6
 // this does not count as pinned memory, use a larger size
 #define MPSC_BUFF_SIZE_SHIFT 8
 

--- a/include/perf.hpp
+++ b/include/perf.hpp
@@ -21,11 +21,8 @@
 
 #define PSAMPLE_DEFAULT_WAKEUP_MS 100 // sample frequency check
 
-// Sample stack size must a multiple of 8 and strictly inferior to 2^16
-// Note that since maximum perf_event_hdr size is 2^16-1 and there are other
-// data/headers in perf_event struct, actual maximum stack sample size returned
-// as `size_stack` might be smaller then the requested size
-#define PERF_SAMPLE_STACK_SIZE (4096UL * 8)
+// Sample stack size must a multiple of 8 and strictly inferior to 2^32
+// #define PERF_SAMPLE_STACK_SIZE (4096U * 8)
 
 struct read_format {
   uint64_t value;        // The value of the event

--- a/include/perf_watcher.hpp
+++ b/include/perf_watcher.hpp
@@ -24,8 +24,8 @@ struct PerfWatcherOptions {
   uint8_t nb_frames_to_skip; // number of bottom frames to skip in stack trace
                              // (useful for allocation profiling to remove
                              // frames belonging to lib_ddprofiling.so)
-  uint32_t sample_stack_user{
-      k_default_perf_sample_stack_user}; // size of the user stack to capture
+  uint32_t stack_sample_size{
+      k_default_perf_stack_sample_size}; // size of the user stack to capture
 };
 
 struct PerfWatcher {

--- a/include/perf_watcher.hpp
+++ b/include/perf_watcher.hpp
@@ -5,8 +5,8 @@
 
 #pragma once
 
+#include "ddprof_defs.hpp"
 #include "event_config.hpp"
-
 #include <string>
 
 #include <linux/perf_event.h>
@@ -24,6 +24,8 @@ struct PerfWatcherOptions {
   uint8_t nb_frames_to_skip; // number of bottom frames to skip in stack trace
                              // (useful for allocation profiling to remove
                              // frames belonging to lib_ddprofiling.so)
+  uint32_t sample_stack_user{
+      k_default_perf_sample_stack_user}; // size of the user stack to capture
 };
 
 struct PerfWatcher {
@@ -38,7 +40,6 @@ struct PerfWatcher {
     uint64_t sample_frequency;
   };
   int sample_type_id; // index into the sample types defined in this header
-  uint16_t sample_stack_size; // size of the stack to capture
 
   // perf_event_open configs
   struct PerfWatcherOptions options;

--- a/include/pevent_lib.hpp
+++ b/include/pevent_lib.hpp
@@ -19,6 +19,11 @@ DDRes pevent_open(DDProfContext *ctx, pid_t pid, int num_cpu,
 /// Setup mmap buffers according to content of peventhdr
 DDRes pevent_mmap(PEventHdr *pevent_hdr, bool use_override);
 
+/// Compute minimum size for a given ring buffer
+/// This is adjusted using the number of samples we can fit in a buffer
+int pevent_compute_min_mmap_order(int min_buffer_size_order,
+                                  uint32_t sample_stack_user);
+
 /// Setup watchers = setup mmap + setup perfevent
 DDRes pevent_setup(DDProfContext &ctx, pid_t pid, int num_cpu,
                    PEventHdr *pevent_hdr);

--- a/include/pevent_lib.hpp
+++ b/include/pevent_lib.hpp
@@ -22,7 +22,8 @@ DDRes pevent_mmap(PEventHdr *pevent_hdr, bool use_override);
 /// Compute minimum size for a given ring buffer
 /// This is adjusted using the number of samples we can fit in a buffer
 int pevent_compute_min_mmap_order(int min_buffer_size_order,
-                                  uint32_t sample_stack_user);
+                                  uint32_t stack_sample_size,
+                                  unsigned min_number_samples);
 
 /// Setup watchers = setup mmap + setup perfevent
 DDRes pevent_setup(DDProfContext &ctx, pid_t pid, int num_cpu,

--- a/include/presets.hpp
+++ b/include/presets.hpp
@@ -19,7 +19,7 @@ struct Preset {
 };
 
 DDRes add_preset(std::string_view preset, bool pid_or_global_mode,
-                 uint32_t default_sample_stack_user,
+                 uint32_t default_stack_sample_size,
                  std::vector<PerfWatcher> &watchers);
 
 } // namespace ddprof

--- a/include/presets.hpp
+++ b/include/presets.hpp
@@ -19,6 +19,7 @@ struct Preset {
 };
 
 DDRes add_preset(std::string_view preset, bool pid_or_global_mode,
+                 uint32_t default_sample_stack_user,
                  std::vector<PerfWatcher> &watchers);
 
 } // namespace ddprof

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -67,8 +67,9 @@ struct SampleStackSizeValidator : public Validator {
     func_ = [](const std::string &str) {
       int value = std::stoi(str);
       if (value >= USHRT_MAX || value % 8 != 0) {
-        return std::string("Invalid sample_stack_user value. Value should be "
-                           "less than USHRT_MAX and a multiple of 8.");
+        return std::string("Invalid stack_sample_size value. Value should be "
+                           "less than " +
+                           std::to_string(USHRT_MAX) + " and a multiple of 8.");
       } else {
         return std::string();
       }
@@ -277,11 +278,11 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
           ->envname("DD_PROFILING_NATIVE_SOCKET")
           ->group(""));
   extended_options.push_back(
-      app.add_option("--sample_stack_user", default_sample_stack_user,
+      app.add_option("--stack_sample_size", default_stack_sample_size,
                      "Sample size for the user's stack."
                      "This setting can help with truncated stack traces."
                      "Maximum value is 65528 (<USHORT_MAX and 8Bytes aligned).")
-          ->default_val(k_default_perf_sample_stack_user)
+          ->default_val(k_default_perf_stack_sample_size)
           ->envname("DD_PROFILING_SAMPLE_STACK_USER")
           ->group("")
           ->check(SampleStackSizeValidator()));
@@ -329,7 +330,7 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
 DDRes DDProfCLI::add_watchers_from_events(
     std::vector<PerfWatcher> &watchers) const {
   for (const auto &el : events) {
-    if (!watchers_from_str(el.c_str(), watchers, default_sample_stack_user)) {
+    if (!watchers_from_str(el.c_str(), watchers, default_stack_sample_size)) {
       DDRES_RETURN_ERROR_LOG(DD_WHAT_INPUT_PROCESS,
                              "Invalid event/tracepoint (%s)", el.c_str());
     }
@@ -413,9 +414,9 @@ void DDProfCLI::print() const {
   }
   PRINT_NFO("  - fault_info: %s", fault_info ? "true" : "false");
 
-  if (default_sample_stack_user != k_default_perf_sample_stack_user) {
+  if (default_stack_sample_size != k_default_perf_stack_sample_size) {
     PRINT_NFO("Extended:");
-    PRINT_NFO("  - sample_stack_user: %u", default_sample_stack_user);
+    PRINT_NFO("  - stack_sample_size: %u", default_stack_sample_size);
   }
 }
 

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -59,6 +59,22 @@ void write_config_file(const CLI::App &app, const std::string &file_path) {
   out_file << app.config_to_str();
   out_file.close();
 }
+
+using Validator = CLI::Validator;
+struct SampleStackSizeValidator : public Validator {
+  SampleStackSizeValidator() {
+    name_ = "SAMPLE_STACK_SIZE";
+    func_ = [](const std::string &str) {
+      int value = std::stoi(str);
+      if (value >= USHRT_MAX || value % 8 != 0) {
+        return std::string("Invalid sample_stack_user value. Value should be "
+                           "less than USHRT_MAX and a multiple of 8.");
+      } else {
+        return std::string();
+      }
+    };
+  }
+};
 } // namespace
 
 int DDProfCLI::parse(int argc, const char *argv[]) {
@@ -267,7 +283,8 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
                      "Maximum value is 65528 (<USHORT_MAX and 8Bytes aligned).")
           ->default_val(k_default_perf_sample_stack_user)
           ->envname("DD_PROFILING_SAMPLE_STACK_USER")
-          ->group(""));
+          ->group("")
+          ->check(SampleStackSizeValidator()));
 
   // Parse
   CLI11_PARSE(app, argc, argv);

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -262,8 +262,9 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
           ->group(""));
   extended_options.push_back(
       app.add_option("--sample_stack_user", default_sample_stack_user,
-                     "Default sample size for the user's stack."
-                     "This setting can help with truncated stack traces.")
+                     "Sample size for the user's stack."
+                     "This setting can help with truncated stack traces."
+                     "Maximum value is 65528 (<USHORT_MAX and 8Bytes aligned).")
           ->default_val(k_default_perf_sample_stack_user)
           ->envname("DD_PROFILING_SAMPLE_STACK_USER")
           ->group(""));

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -260,6 +260,13 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
                      "Profiler's IPC socket, as a file descriptor")
           ->envname("DD_PROFILING_NATIVE_SOCKET")
           ->group(""));
+  extended_options.push_back(
+      app.add_option("--sample_stack_user", default_sample_stack_user,
+                     "Default sample size for the user's stack."
+                     "This setting can help with truncated stack traces.")
+          ->default_val(k_default_perf_sample_stack_user)
+          ->envname("DD_PROFILING_SAMPLE_STACK_USER")
+          ->group(""));
 
   // Parse
   CLI11_PARSE(app, argc, argv);
@@ -304,7 +311,7 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
 DDRes DDProfCLI::add_watchers_from_events(
     std::vector<PerfWatcher> &watchers) const {
   for (const auto &el : events) {
-    if (!watchers_from_str(el.c_str(), watchers)) {
+    if (!watchers_from_str(el.c_str(), watchers, default_sample_stack_user)) {
       DDRES_RETURN_ERROR_LOG(DD_WHAT_INPUT_PROCESS,
                              "Invalid event/tracepoint (%s)", el.c_str());
     }
@@ -387,6 +394,11 @@ void DDProfCLI::print() const {
     PRINT_NFO("  - show_samples: %s", show_samples ? "true" : "false");
   }
   PRINT_NFO("  - fault_info: %s", fault_info ? "true" : "false");
+
+  if (default_sample_stack_user != k_default_perf_sample_stack_user) {
+    PRINT_NFO("Extended:");
+    PRINT_NFO("  - sample_stack_user: %u", default_sample_stack_user);
+  }
 }
 
 CommandLineWrapper DDProfCLI::get_user_command_line() const {

--- a/src/ddprof_context_lib.cc
+++ b/src/ddprof_context_lib.cc
@@ -101,7 +101,7 @@ DDRes context_add_watchers(const DDProfCLI &ddprof_cli, DDProfContext &ctx) {
     bool pid_or_global_mode =
         (ddprof_cli.global || ddprof_cli.pid) && ctx.params.sockfd == -1;
     DDRES_CHECK_FWD(add_preset(preset, pid_or_global_mode,
-                               ddprof_cli.default_sample_stack_user, watchers));
+                               ddprof_cli.default_stack_sample_size, watchers));
   }
 
   // Add a dummy watcher if needed

--- a/src/ddprof_context_lib.cc
+++ b/src/ddprof_context_lib.cc
@@ -100,7 +100,8 @@ DDRes context_add_watchers(const DDProfCLI &ddprof_cli, DDProfContext &ctx) {
   if (!preset.empty()) {
     bool pid_or_global_mode =
         (ddprof_cli.global || ddprof_cli.pid) && ctx.params.sockfd == -1;
-    DDRES_CHECK_FWD(add_preset(preset, pid_or_global_mode, watchers));
+    DDRES_CHECK_FWD(add_preset(preset, pid_or_global_mode,
+                               ddprof_cli.default_sample_stack_user, watchers));
   }
 
   // Add a dummy watcher if needed

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -269,7 +269,8 @@ static DDRes ddprof_unwind_sample(DDProfContext &ctx, perf_event_sample *sample,
    * That's why we consider the stack as truncated in input only if it is also
    * detected as incomplete during unwinding.
    */
-  if (sample->size_stack == ctx.watchers[watcher_pos].sample_stack_size &&
+  if (sample->size_stack ==
+          ctx.watchers[watcher_pos].options.sample_stack_user &&
       us->output.is_incomplete) {
     ddprof_stats_add(STATS_UNWIND_TRUNCATED_INPUT, 1, nullptr);
   }

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -270,7 +270,7 @@ static DDRes ddprof_unwind_sample(DDProfContext &ctx, perf_event_sample *sample,
    * detected as incomplete during unwinding.
    */
   if (sample->size_stack ==
-          ctx.watchers[watcher_pos].options.sample_stack_user &&
+          ctx.watchers[watcher_pos].options.stack_sample_size &&
       us->output.is_incomplete) {
     ddprof_stats_add(STATS_UNWIND_TRUNCATED_INPUT, 1, nullptr);
   }

--- a/src/event_parser/event_parser.l
+++ b/src/event_parser/event_parser.l
@@ -55,18 +55,19 @@
 }
 }
 
-s|value_scale|scale        DISPATCH(ValueScale)
-f|frequency|freq           DISPATCH(Frequency)
-e|event|eventname|ev       DISPATCH(Event)
-g|group|groupname|gr       DISPATCH(Group)
-i|id                       DISPATCH(Id)
-l|label                    DISPATCH(Label)
-m|mode                     DISPATCH(Mode)
-n|arg_num|argno            DISPATCH(Parameter)
-o|raw_offset|rawoff        DISPATCH(RawOffset)
-p|period|per               DISPATCH(Period)
-r|register|regno           DISPATCH(Register)
-z|raw_size|rawsz           DISPATCH(RawSize)
+s|value_scale|scale         DISPATCH(ValueScale)
+f|frequency|freq            DISPATCH(Frequency)
+e|event|eventname|ev        DISPATCH(Event)
+g|group|groupname|gr        DISPATCH(Group)
+i|id                        DISPATCH(Id)
+l|label                     DISPATCH(Label)
+m|mode                      DISPATCH(Mode)
+n|arg_num|argno             DISPATCH(Parameter)
+o|raw_offset|rawoff         DISPATCH(RawOffset)
+p|period|per                DISPATCH(Period)
+s|sample_stack_user|stckusr DISPATCH(SampleStackUser)
+r|register|regno            DISPATCH(Register)
+z|raw_size|rawsz            DISPATCH(RawSize)
 
 =                           {
 	BEGIN VALUE;

--- a/src/event_parser/event_parser.l
+++ b/src/event_parser/event_parser.l
@@ -65,7 +65,7 @@ m|mode                      DISPATCH(Mode)
 n|arg_num|argno             DISPATCH(Parameter)
 o|raw_offset|rawoff         DISPATCH(RawOffset)
 p|period|per                DISPATCH(Period)
-s|sample_stack_user|stckusr DISPATCH(SampleStackUser)
+st|stack_sample_size|stcksz DISPATCH(StackSampleSize)
 r|register|regno            DISPATCH(Register)
 z|raw_size|rawsz            DISPATCH(RawSize)
 

--- a/src/event_parser/event_parser.y
+++ b/src/event_parser/event_parser.y
@@ -109,7 +109,7 @@ void conf_print(const EventConf *tp) {
     printf("  location: register (%d)\n", tp->register_num);
   else if (tp->value_source == EventConfValueSource::kRaw)
     printf("  location: raw event (%lu with size %d bytes)\n", tp->raw_offset, tp->raw_size);
-
+  printf("  stack_sample_size: %u\n", tp->stack_sample_size);
   if (tp->value_scale != 0)
     printf("  scaling factor: %f\n", tp->value_scale);
 
@@ -132,8 +132,8 @@ void yyerror(yyscan_t scanner, const char *str) {
    YYABORT;  \
  } while(0)
 
- int EventConf_parse(const char *msg, std::vector<EventConf>& event_configs) {
-  g_accum_event_conf.clear();
+ int EventConf_parse(const char *msg, const EventConf &template_conf, std::vector<EventConf>& event_configs) {
+  g_accum_event_conf = template_conf;
   g_event_configs = &event_configs;
   int ret = -1;
   yyscan_t scanner = NULL;
@@ -300,8 +300,9 @@ opt:
              g_accum_event_conf.raw_offset = $3;
            }
            break;
-         case EventConfField::kSampleStackUser:
-            g_accum_event_conf.sample_stack_user = $3;
+         case EventConfField::kStackSampleSize:
+            g_accum_event_conf.stack_sample_size = $3;
+            printf("set value to %u \n", g_accum_event_conf.stack_sample_size);
             break;
          case EventConfField::kPeriod:
          case EventConfField::kFrequency:

--- a/src/event_parser/event_parser.y
+++ b/src/event_parser/event_parser.y
@@ -36,6 +36,11 @@ extern int yylex_destroy(yyscan_t scanner);
 extern YY_BUFFER_STATE yy_scan_string(const char * str, yyscan_t scanner);
 extern void yy_delete_buffer(YY_BUFFER_STATE buffer, yyscan_t scanner);
 
+
+EventConf g_accum_event_conf = {};
+EventConf g_template_event_conf = {};
+std::vector<EventConf>* g_event_configs;
+
 std::optional<EventConfMode> mode_from_str(const std::string &str) {
   EventConfMode mode = EventConfMode::kDisabled;
   if (str.empty())
@@ -83,7 +88,7 @@ void conf_finalize(EventConf * conf, std::vector<EventConf> * configs) {
   }
 
   configs->push_back(*conf);
-  conf->clear();
+  g_accum_event_conf = g_template_event_conf;
 }
 
 void conf_print(const EventConf *tp) {
@@ -117,9 +122,6 @@ void conf_print(const EventConf *tp) {
 
 }
 
-EventConf g_accum_event_conf = {};
-std::vector<EventConf>* g_event_configs;
-
 void yyerror(yyscan_t scanner, const char *str) {
 #ifdef EVENT_PARSER_MAIN
   fprintf(stderr, "err: %s\n", str);
@@ -133,7 +135,8 @@ void yyerror(yyscan_t scanner, const char *str) {
  } while(0)
 
  int EventConf_parse(const char *msg, const EventConf &template_conf, std::vector<EventConf>& event_configs) {
-  g_accum_event_conf = template_conf;
+  g_template_event_conf = template_conf;
+  g_accum_event_conf = g_template_event_conf;
   g_event_configs = &event_configs;
   int ret = -1;
   yyscan_t scanner = NULL;

--- a/src/event_parser/event_parser.y
+++ b/src/event_parser/event_parser.y
@@ -305,7 +305,6 @@ opt:
            break;
          case EventConfField::kStackSampleSize:
             g_accum_event_conf.stack_sample_size = $3;
-            printf("set value to %u \n", g_accum_event_conf.stack_sample_size);
             break;
          case EventConfField::kPeriod:
          case EventConfField::kFrequency:

--- a/src/event_parser/event_parser.y
+++ b/src/event_parser/event_parser.y
@@ -300,7 +300,9 @@ opt:
              g_accum_event_conf.raw_offset = $3;
            }
            break;
-
+         case EventConfField::kSampleStackUser:
+            g_accum_event_conf.sample_stack_user = $3;
+            break;
          case EventConfField::kPeriod:
          case EventConfField::kFrequency:
            // If the cadence has already been set, it's an error
@@ -315,7 +317,6 @@ opt:
            if ($$ == EventConfField::kFrequency)
              g_accum_event_conf.cad_type = EventConfCadenceType::kFrequency;
            break;
-
          default: VAL_ERROR(); break;
        }
      }

--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -328,6 +328,8 @@ static int start_profiler_internal(DDProfContext *ctx, bool &is_profiler) {
             static_cast<int>(event_it->ring_buffer_type);
         reply.allocation_profiling_rate =
             ctx->watchers[alloc_watcher_idx].sample_period;
+        reply.sample_stack_user =
+            ctx->watchers[alloc_watcher_idx].options.sample_stack_user;
 
         if (ctx->watchers[alloc_watcher_idx].output_mode ==
             EventConfMode::kLiveCallgraph) {

--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -328,8 +328,8 @@ static int start_profiler_internal(DDProfContext *ctx, bool &is_profiler) {
             static_cast<int>(event_it->ring_buffer_type);
         reply.allocation_profiling_rate =
             ctx->watchers[alloc_watcher_idx].sample_period;
-        reply.sample_stack_user =
-            ctx->watchers[alloc_watcher_idx].options.sample_stack_user;
+        reply.stack_sample_size =
+            ctx->watchers[alloc_watcher_idx].options.stack_sample_size;
 
         if (ctx->watchers[alloc_watcher_idx].output_mode ==
             EventConfMode::kLiveCallgraph) {

--- a/src/ipc.cc
+++ b/src/ipc.cc
@@ -23,6 +23,7 @@ struct InternalResponseMessage {
   int32_t pid;
   int64_t mem_size;
   int64_t allocation_profiling_rate;
+  uint32_t sample_stack_user;
   int32_t ring_buffer_type;
   int32_t allocation_flags;
 };
@@ -258,6 +259,7 @@ DDRes send(UnixSocket &socket, const ReplyMessage &msg) {
       .pid = msg.pid,
       .mem_size = msg.ring_buffer.mem_size,
       .allocation_profiling_rate = msg.allocation_profiling_rate,
+      .sample_stack_user = msg.sample_stack_user,
       .ring_buffer_type = msg.ring_buffer.ring_buffer_type,
       .allocation_flags = msg.allocation_flags};
   socket.send(to_byte_span(&data), fd_span, ec);
@@ -289,6 +291,7 @@ DDRes receive(UnixSocket &socket, ReplyMessage &msg) {
   msg.pid = data.pid;
   msg.request = data.request;
   msg.allocation_profiling_rate = data.allocation_profiling_rate;
+  msg.sample_stack_user = data.sample_stack_user;
   msg.ring_buffer.mem_size = data.mem_size;
   msg.ring_buffer.ring_buffer_type = data.ring_buffer_type;
   msg.ring_buffer.ring_fd = fds[0];

--- a/src/ipc.cc
+++ b/src/ipc.cc
@@ -23,7 +23,7 @@ struct InternalResponseMessage {
   int32_t pid;
   int64_t mem_size;
   int64_t allocation_profiling_rate;
-  uint32_t sample_stack_user;
+  uint32_t stack_sample_size;
   int32_t ring_buffer_type;
   int32_t allocation_flags;
 };
@@ -259,7 +259,7 @@ DDRes send(UnixSocket &socket, const ReplyMessage &msg) {
       .pid = msg.pid,
       .mem_size = msg.ring_buffer.mem_size,
       .allocation_profiling_rate = msg.allocation_profiling_rate,
-      .sample_stack_user = msg.sample_stack_user,
+      .stack_sample_size = msg.stack_sample_size,
       .ring_buffer_type = msg.ring_buffer.ring_buffer_type,
       .allocation_flags = msg.allocation_flags};
   socket.send(to_byte_span(&data), fd_span, ec);
@@ -291,7 +291,7 @@ DDRes receive(UnixSocket &socket, ReplyMessage &msg) {
   msg.pid = data.pid;
   msg.request = data.request;
   msg.allocation_profiling_rate = data.allocation_profiling_rate;
-  msg.sample_stack_user = data.sample_stack_user;
+  msg.stack_sample_size = data.stack_sample_size;
   msg.ring_buffer.mem_size = data.mem_size;
   msg.ring_buffer.ring_buffer_type = data.ring_buffer_type;
   msg.ring_buffer.ring_fd = fds[0];

--- a/src/lib/allocation_tracker.cc
+++ b/src/lib/allocation_tracker.cc
@@ -5,6 +5,7 @@
 
 #include "allocation_tracker.hpp"
 
+#include "allocation_event.hpp"
 #include "ddprof_perf_event.hpp"
 #include "ddres.hpp"
 #include "defer.hpp"
@@ -20,24 +21,10 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
-#include <linux/perf_event.h>
-#include <sys/types.h>
+
 #include <unistd.h>
 
 namespace ddprof {
-
-struct AllocationEvent {
-  perf_event_header hdr;
-  struct sample_id sample_id;
-  uint64_t addr; /* if PERF_SAMPLE_ADDR */
-  uint64_t period;
-  uint64_t abi;                   /* if PERF_SAMPLE_REGS_USER */
-  uint64_t regs[PERF_REGS_COUNT]; /* if PERF_SAMPLE_REGS_USER */
-  uint64_t size;                  /* if PERF_SAMPLE_STACK_USER */
-  std::byte data[1]; /* if PERF_SAMPLE_STACK_USER, the actual size will be
-                        determined at runtime */
-  uint64_t dyn_size; /* if PERF_SAMPLE_STACK_USER && size != 0 */
-};
 
 struct LostEvent {
   perf_event_header hdr;

--- a/src/lib/dd_profiling.cc
+++ b/src/lib/dd_profiling.cc
@@ -260,7 +260,8 @@ int ddprof_start_profiling_internal() {
       }
 
       if (IsDDResOK(ddprof::AllocationTracker::allocation_tracking_init(
-              info.allocation_profiling_rate, flags, info.ring_buffer))) {
+              info.allocation_profiling_rate, flags, info.sample_stack_user,
+              info.ring_buffer))) {
         // \fixme{nsavoire} pthread_create should probably be overridden
         // at load time since we need to capture stack end addresses of all
         // threads in case allocation profiling is started later on

--- a/src/lib/dd_profiling.cc
+++ b/src/lib/dd_profiling.cc
@@ -260,7 +260,7 @@ int ddprof_start_profiling_internal() {
       }
 
       if (IsDDResOK(ddprof::AllocationTracker::allocation_tracking_init(
-              info.allocation_profiling_rate, flags, info.sample_stack_user,
+              info.allocation_profiling_rate, flags, info.stack_sample_size,
               info.ring_buffer))) {
         // \fixme{nsavoire} pthread_create should probably be overridden
         // at load time since we need to capture stack end addresses of all

--- a/src/perf.cc
+++ b/src/perf.cc
@@ -88,7 +88,7 @@ perf_event_attr perf_config_from_watcher(const PerfWatcher *watcher,
   attr.sample_period = watcher->sample_period; // Equivalently, freq
   attr.freq = watcher->options.is_freq;
   attr.sample_type = watcher->sample_type;
-  attr.sample_stack_user = watcher->options.sample_stack_user;
+  attr.sample_stack_user = watcher->options.stack_sample_size;
 
   // If use_kernel==off means we exclude_kernel
   attr.exclude_kernel =

--- a/src/perf.cc
+++ b/src/perf.cc
@@ -88,7 +88,7 @@ perf_event_attr perf_config_from_watcher(const PerfWatcher *watcher,
   attr.sample_period = watcher->sample_period; // Equivalently, freq
   attr.freq = watcher->options.is_freq;
   attr.sample_type = watcher->sample_type;
-  attr.sample_stack_user = watcher->sample_stack_size;
+  attr.sample_stack_user = watcher->options.sample_stack_user;
 
   // If use_kernel==off means we exclude_kernel
   attr.exclude_kernel =

--- a/src/perf_ringbuffer.cc
+++ b/src/perf_ringbuffer.cc
@@ -237,7 +237,6 @@ perf_event_sample *hdr2samp(const perf_event_header *hdr, uint64_t mask) {
   }
   if (PERF_SAMPLE_STACK_USER & mask) {
     uint64_t size_stack = *buf++;
-
     // Empirically, it seems that the size of the static stack is either 0 or
     // the amount requested in the call to `perf_event_open()`.  We don't
     // check for that, since there isn't much we'd be able to do anyway.
@@ -252,7 +251,6 @@ perf_event_sample *hdr2samp(const perf_event_header *hdr, uint64_t mask) {
 
       // If the size was specified, we also have a dyn_size
       dynsz_stack = *buf++;
-
       // If the dyn_size is too big, zero out the stack size since it is
       // likely an error
       sample.size_stack = size_stack < dynsz_stack ? 0 : dynsz_stack;

--- a/src/perf_watcher.cc
+++ b/src/perf_watcher.cc
@@ -52,7 +52,7 @@ bool watcher_has_countable_sample_type(const PerfWatcher *watcher) {
 }
 
 #define X_EVENTS(a, b, c, d, e, f, g)                                          \
-  {DDPROF_PWE_##a, b, BASE_STYPES, c, d, {e}, f, PERF_SAMPLE_STACK_SIZE, g},
+  {DDPROF_PWE_##a, b, BASE_STYPES, c, d, {e}, f, g},
 
 #define X_STR(a, b, c, d, e, f, g) #a,
 const char *event_type_name_from_idx(int idx) {
@@ -95,7 +95,6 @@ const PerfWatcher *tracepoint_default_watcher() {
       .type = PERF_TYPE_TRACEPOINT,
       .sample_period = 1,
       .sample_type_id = DDPROF_PWT_TRACEPOINT,
-      .sample_stack_size = PERF_SAMPLE_STACK_SIZE,
       .options = {.use_kernel = PerfWatcherUseKernel::kRequired},
       .value_scale = 1.0,
   };
@@ -128,6 +127,7 @@ void log_watcher(const PerfWatcher *w, int idx) {
             sample_type_name_from_idx(w->sample_type_id),
             w->tracepoint_event.c_str(), w->tracepoint_group.c_str(),
             w->tracepoint_label.c_str());
+  PRINT_NFO("    Sample user Stack Size: %u", w->options.sample_stack_user);
 
   if (w->options.is_freq)
     PRINT_NFO("    Cadence: Freq, Freq: %lu", w->sample_frequency);

--- a/src/perf_watcher.cc
+++ b/src/perf_watcher.cc
@@ -127,7 +127,7 @@ void log_watcher(const PerfWatcher *w, int idx) {
             sample_type_name_from_idx(w->sample_type_id),
             w->tracepoint_event.c_str(), w->tracepoint_group.c_str(),
             w->tracepoint_label.c_str());
-  PRINT_NFO("    Sample user Stack Size: %u", w->options.sample_stack_user);
+  PRINT_NFO("    Sample user Stack Size: %u", w->options.stack_sample_size);
 
   if (w->options.is_freq)
     PRINT_NFO("    Cadence: Freq, Freq: %lu", w->sample_frequency);
@@ -178,6 +178,7 @@ std::string_view watcher_help_text() {
 "- `n|arg_num|argno`: Argument number to retrieve a value associated with this event.\n"
 "- `p|period|per`: Period of the event.\n"
 "- `r|register|regno`: Register to retrieve the value associated with this event.\n"
+"- `st|stack_sample_size|stcksz : Same as the stack_sample_size input option for this event."
 "- `o|raw_offset|rawoff`: Raw offset to retrieve the value associated with this event.\n"
 "- `z|raw_size|rawsz`: Raw size associated to raw offset.\n\n"
 "Disclaimer:\n"

--- a/src/pevent_lib.cc
+++ b/src/pevent_lib.cc
@@ -75,11 +75,16 @@ int pevent_compute_min_mmap_order(int min_buffer_size_order,
 // set info for a perf_event_open type of buffer
 static void pevent_set_info(int fd, int attr_idx, PEvent &pevent,
                             uint32_t sample_stack_user) {
+  static bool log_once = true;
   pevent.fd = fd;
   pevent.mapfd = fd;
   int buffer_size_order =
       pevent_compute_min_mmap_order(DEFAULT_BUFF_SIZE_SHIFT, sample_stack_user);
-  LG_NTC("Buffer size order = %d", buffer_size_order);
+  if (buffer_size_order > DEFAULT_BUFF_SIZE_SHIFT && log_once) {
+    LG_NTC("Increasing size order of the ring buffer to %d (from %d)",
+           buffer_size_order, DEFAULT_BUFF_SIZE_SHIFT);
+    log_once = false; // avoid flooding for all CPUs
+  }
   pevent.ring_buffer_size = perf_mmap_size(buffer_size_order);
   pevent.custom_event = false;
   pevent.ring_buffer_type = RingBufferType::kPerfRingBuffer;

--- a/src/pevent_lib.cc
+++ b/src/pevent_lib.cc
@@ -185,9 +185,6 @@ DDRes pevent_mmap_event(PEvent *event) {
   if (event->mapfd != -1) {
     void *region = perfown_sz(event->mapfd, event->ring_buffer_size);
     if (!region) {
-      DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFMMAP,
-                             "Could not mmap memory for watcher #%d: %s",
-                             event->watcher_pos, strerror(errno));
       DDRES_RETURN_ERROR_LOG(
           DD_WHAT_PERFMMAP,
           "Could not mmap memory for watcher #%d: %s. "

--- a/src/presets.cc
+++ b/src/presets.cc
@@ -16,6 +16,7 @@
 namespace ddprof {
 
 DDRes add_preset(std::string_view preset, bool pid_or_global_mode,
+                 uint32_t default_sample_stack_user,
                  std::vector<PerfWatcher> &watchers) {
   using namespace std::literals;
   static Preset presets[] = {
@@ -38,7 +39,7 @@ DDRes add_preset(std::string_view preset, bool pid_or_global_mode,
   }
 
   std::vector<PerfWatcher> new_watchers;
-  if (!watchers_from_str(it->events, new_watchers)) {
+  if (!watchers_from_str(it->events, new_watchers, default_sample_stack_user)) {
     DDRES_RETURN_ERROR_LOG(DD_WHAT_INPUT_PROCESS,
                            "Invalid event/tracepoint (%s)", it->events);
   }

--- a/src/presets.cc
+++ b/src/presets.cc
@@ -16,7 +16,7 @@
 namespace ddprof {
 
 DDRes add_preset(std::string_view preset, bool pid_or_global_mode,
-                 uint32_t default_sample_stack_user,
+                 uint32_t default_stack_sample_size,
                  std::vector<PerfWatcher> &watchers) {
   using namespace std::literals;
   static Preset presets[] = {
@@ -39,7 +39,7 @@ DDRes add_preset(std::string_view preset, bool pid_or_global_mode,
   }
 
   std::vector<PerfWatcher> new_watchers;
-  if (!watchers_from_str(it->events, new_watchers, default_sample_stack_user)) {
+  if (!watchers_from_str(it->events, new_watchers, default_stack_sample_size)) {
     DDRES_RETURN_ERROR_LOG(DD_WHAT_INPUT_PROCESS,
                            "Invalid event/tracepoint (%s)", it->events);
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -419,3 +419,5 @@ add_test(
   NAME ddprof_help
   COMMAND ddprof -h
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_exe(deep_stacks deep_stacks.cc)

--- a/test/allocation_tracker-bench.cc
+++ b/test/allocation_tracker-bench.cc
@@ -28,7 +28,7 @@ void perform_memory_operations(bool track_allocations,
         rate,
         ddprof::AllocationTracker::kDeterministicSampling |
             ddprof::AllocationTracker::kTrackDeallocations,
-        k_default_perf_sample_stack_user, ring_buffer.get_buffer_info());
+        k_default_perf_stack_sample_size, ring_buffer.get_buffer_info());
   }
 
   int nb_threads = 4;

--- a/test/allocation_tracker-bench.cc
+++ b/test/allocation_tracker-bench.cc
@@ -28,7 +28,7 @@ void perform_memory_operations(bool track_allocations,
         rate,
         ddprof::AllocationTracker::kDeterministicSampling |
             ddprof::AllocationTracker::kTrackDeallocations,
-        ring_buffer.get_buffer_info());
+        k_default_perf_sample_stack_user, ring_buffer.get_buffer_info());
   }
 
   int nb_threads = 4;

--- a/test/allocation_tracker-ut.cc
+++ b/test/allocation_tracker-ut.cc
@@ -46,7 +46,7 @@ TEST(allocation_tracker, start_stop) {
       rate,
       ddprof::AllocationTracker::kDeterministicSampling |
           ddprof::AllocationTracker::kTrackDeallocations,
-      k_default_perf_sample_stack_user, ring_buffer.get_buffer_info());
+      k_default_perf_stack_sample_size, ring_buffer.get_buffer_info());
 
   ASSERT_TRUE(ddprof::AllocationTracker::is_active());
   my_func_calling_malloc(1);
@@ -113,7 +113,7 @@ TEST(allocation_tracker, stale_lock) {
       rate,
       ddprof::AllocationTracker::kDeterministicSampling |
           ddprof::AllocationTracker::kTrackDeallocations,
-      k_default_perf_sample_stack_user, ring_buffer.get_buffer_info());
+      k_default_perf_stack_sample_size, ring_buffer.get_buffer_info());
 
   // simulate stale lock
   ring_buffer.get_ring_buffer().spinlock->lock();
@@ -135,7 +135,7 @@ TEST(allocation_tracker, max_tracked_allocs) {
       rate,
       ddprof::AllocationTracker::kDeterministicSampling |
           ddprof::AllocationTracker::kTrackDeallocations,
-      k_default_perf_sample_stack_user, ring_buffer.get_buffer_info());
+      k_default_perf_stack_sample_size, ring_buffer.get_buffer_info());
 
   ASSERT_TRUE(ddprof::AllocationTracker::is_active());
 

--- a/test/allocation_tracker-ut.cc
+++ b/test/allocation_tracker-ut.cc
@@ -46,7 +46,7 @@ TEST(allocation_tracker, start_stop) {
       rate,
       ddprof::AllocationTracker::kDeterministicSampling |
           ddprof::AllocationTracker::kTrackDeallocations,
-      ring_buffer.get_buffer_info());
+      k_default_perf_sample_stack_user, ring_buffer.get_buffer_info());
 
   ASSERT_TRUE(ddprof::AllocationTracker::is_active());
   my_func_calling_malloc(1);
@@ -113,7 +113,7 @@ TEST(allocation_tracker, stale_lock) {
       rate,
       ddprof::AllocationTracker::kDeterministicSampling |
           ddprof::AllocationTracker::kTrackDeallocations,
-      ring_buffer.get_buffer_info());
+      k_default_perf_sample_stack_user, ring_buffer.get_buffer_info());
 
   // simulate stale lock
   ring_buffer.get_ring_buffer().spinlock->lock();
@@ -135,7 +135,7 @@ TEST(allocation_tracker, max_tracked_allocs) {
       rate,
       ddprof::AllocationTracker::kDeterministicSampling |
           ddprof::AllocationTracker::kTrackDeallocations,
-      ring_buffer.get_buffer_info());
+      k_default_perf_sample_stack_user, ring_buffer.get_buffer_info());
 
   ASSERT_TRUE(ddprof::AllocationTracker::is_active());
 

--- a/test/configs/deep_stacks.toml
+++ b/test/configs/deep_stacks.toml
@@ -1,0 +1,2 @@
+sample_stack_user=65528
+log_level="notice"

--- a/test/configs/deep_stacks.toml
+++ b/test/configs/deep_stacks.toml
@@ -1,2 +1,0 @@
-sample_stack_user=65528
-log_level="notice"

--- a/test/ddprof_context-ut.cc
+++ b/test/ddprof_context-ut.cc
@@ -381,5 +381,46 @@ TEST(DDProfContext, env_variable_with_extra_semicolons) {
   EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
   EXPECT_EQ(ctx.watchers[0].sample_period, 1000);
 }
+TEST(DDProfContext, stack_size) {
+  LogHandle handle;
+  // Set environment variable
+  setenv(k_events_env_variable, "sCPU sample_stack_user=65536;", 1);
+  defer { unsetenv(k_events_env_variable); };
+
+  // Init CLI and parse inputs
+  DDProfCLI ddprof_cli;
+  const char *input_values[] = {MYNAME, "my_program"};
+
+  int res = ddprof_cli.parse(std::size(input_values), input_values);
+  ASSERT_EQ(res, 0);
+  ASSERT_EQ(ddprof_cli.command_line.size(), 1);
+  EXPECT_EQ(ddprof_cli.command_line.back(), "my_program");
+
+  // Assert parsed parameters
+  ASSERT_EQ(ddprof_cli.events.size(), 1);
+
+  DDProfContext ctx;
+  DDRes ddres = context_set(ddprof_cli, ctx);
+  EXPECT_TRUE(IsDDResOK(ddres));
+
+  ASSERT_EQ(ctx.watchers.size(), 1);
+  EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
+  EXPECT_EQ(ctx.watchers[0].options.sample_stack_user, 65536);
+}
+
+TEST(DDProfContext, default_stack_size) {
+  LogHandle handle;
+  // Init CLI and parse inputs
+  DDProfCLI ddprof_cli;
+  const char *input_values[] = {MYNAME, "--sample_stack_user", "65536",
+                                "--show_config", "my_program"};
+  int res = ddprof_cli.parse(std::size(input_values), input_values);
+  ASSERT_EQ(res, 0);
+  DDProfContext ctx;
+  DDRes ddres = context_set(ddprof_cli, ctx);
+  EXPECT_TRUE(IsDDResOK(ddres));
+  EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
+  EXPECT_EQ(ctx.watchers[0].options.sample_stack_user, 65536);
+}
 
 } // namespace ddprof

--- a/test/ddprof_context-ut.cc
+++ b/test/ddprof_context-ut.cc
@@ -384,7 +384,7 @@ TEST(DDProfContext, env_variable_with_extra_semicolons) {
 TEST(DDProfContext, stack_size) {
   LogHandle handle;
   // Set environment variable
-  setenv(k_events_env_variable, "sCPU sample_stack_user=65536;", 1);
+  setenv(k_events_env_variable, "sCPU sample_stack_user=65528;", 1);
   defer { unsetenv(k_events_env_variable); };
 
   // Init CLI and parse inputs
@@ -405,14 +405,17 @@ TEST(DDProfContext, stack_size) {
 
   ASSERT_EQ(ctx.watchers.size(), 1);
   EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
-  EXPECT_EQ(ctx.watchers[0].options.sample_stack_user, 65536);
+  EXPECT_EQ(ctx.watchers[0].options.sample_stack_user, 65528);
 }
 
 TEST(DDProfContext, default_stack_size) {
   LogHandle handle;
   // Init CLI and parse inputs
   DDProfCLI ddprof_cli;
-  const char *input_values[] = {MYNAME, "--sample_stack_user", "65536",
+  uint32_t big_sample_size = 65528;
+  std::string big_sample_size_str = std::to_string(big_sample_size);
+  const char *input_values[] = {MYNAME, "--sample_stack_user",
+                                big_sample_size_str.c_str(),
                                 "--show_config", "my_program"};
   int res = ddprof_cli.parse(std::size(input_values), input_values);
   ASSERT_EQ(res, 0);
@@ -420,7 +423,7 @@ TEST(DDProfContext, default_stack_size) {
   DDRes ddres = context_set(ddprof_cli, ctx);
   EXPECT_TRUE(IsDDResOK(ddres));
   EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
-  EXPECT_EQ(ctx.watchers[0].options.sample_stack_user, 65536);
+  EXPECT_EQ(ctx.watchers[0].options.sample_stack_user, big_sample_size);
 }
 
 } // namespace ddprof

--- a/test/ddprof_context-ut.cc
+++ b/test/ddprof_context-ut.cc
@@ -384,7 +384,7 @@ TEST(DDProfContext, env_variable_with_extra_semicolons) {
 TEST(DDProfContext, stack_size) {
   LogHandle handle;
   // Set environment variable
-  setenv(k_events_env_variable, "sCPU sample_stack_user=65528;", 1);
+  setenv(k_events_env_variable, "sCPU stack_sample_size=65528;", 1);
   defer { unsetenv(k_events_env_variable); };
 
   // Init CLI and parse inputs
@@ -405,7 +405,7 @@ TEST(DDProfContext, stack_size) {
 
   ASSERT_EQ(ctx.watchers.size(), 1);
   EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
-  EXPECT_EQ(ctx.watchers[0].options.sample_stack_user, 65528);
+  EXPECT_EQ(ctx.watchers[0].options.stack_sample_size, 65528);
 }
 
 TEST(DDProfContext, default_stack_size) {
@@ -414,16 +414,38 @@ TEST(DDProfContext, default_stack_size) {
   DDProfCLI ddprof_cli;
   uint32_t big_sample_size = 65528;
   std::string big_sample_size_str = std::to_string(big_sample_size);
-  const char *input_values[] = {MYNAME, "--sample_stack_user",
-                                big_sample_size_str.c_str(),
-                                "--show_config", "my_program"};
+  const char *input_values[] = {MYNAME, "--stack_sample_size",
+                                big_sample_size_str.c_str(), "--show_config",
+                                "my_program"};
   int res = ddprof_cli.parse(std::size(input_values), input_values);
   ASSERT_EQ(res, 0);
   DDProfContext ctx;
   DDRes ddres = context_set(ddprof_cli, ctx);
   EXPECT_TRUE(IsDDResOK(ddres));
   EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
-  EXPECT_EQ(ctx.watchers[0].options.sample_stack_user, big_sample_size);
+  EXPECT_EQ(ctx.watchers[0].options.stack_sample_size, big_sample_size);
+}
+
+TEST(DDProfContext, double_stack_size_setting) {
+  LogHandle handle;
+  // Init CLI and parse inputs
+  DDProfCLI ddprof_cli;
+  uint32_t big_sample_size = 65528;
+  std::string big_sample_size_str = std::to_string(big_sample_size);
+  const char *input_values[] = {MYNAME,
+                                "--stack_sample_size",
+                                big_sample_size_str.c_str(),
+                                "--show_config",
+                                "-e",
+                                "sCPU stack_sample_size=32768",
+                                "my_program"};
+  int res = ddprof_cli.parse(std::size(input_values), input_values);
+  ASSERT_EQ(res, 0);
+  DDProfContext ctx;
+  DDRes ddres = context_set(ddprof_cli, ctx);
+  EXPECT_TRUE(IsDDResOK(ddres));
+  EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
+  EXPECT_EQ(ctx.watchers[0].options.stack_sample_size, 32768);
 }
 
 } // namespace ddprof

--- a/test/deep_stacks.cc
+++ b/test/deep_stacks.cc
@@ -1,0 +1,29 @@
+#include <chrono>
+#include <iostream>
+#include <string>
+
+template <int N> std::string compute() {
+  char arr[N];
+
+  for (int i = 0; i < N - 1; ++i) {
+    arr[i] = 'a' + i % 26;
+  }
+  arr[N - 1] = '\0';
+
+  std::string ret_arr(arr, N);
+  if constexpr (N > 100) {
+    ret_arr = ret_arr + compute<N - 100>();
+  }
+  return ret_arr;
+}
+
+int main() {
+  using namespace std::chrono;
+  auto start = high_resolution_clock::now();
+  auto end = start + seconds(2); // set a time limit of 10 seconds
+  while (high_resolution_clock::now() < end) {
+    volatile auto str = compute<3000>();
+    //    std::cout << str;
+  }
+  return 0;
+}

--- a/test/deep_stacks.cc
+++ b/test/deep_stacks.cc
@@ -29,7 +29,7 @@ int main() {
   auto start = high_resolution_clock::now();
   auto end = start + seconds(2); // set a time limit of 10 seconds
   while (high_resolution_clock::now() < end) {
-    volatile auto str = compute<3000>();
+    auto str = compute<3000>();
     ddprof::DoNotOptimize(str);
     //    std::cout << str;
   }

--- a/test/deep_stacks.cc
+++ b/test/deep_stacks.cc
@@ -1,8 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
 #include <chrono>
 #include <iostream>
 #include <string>
 
-template <int N> std::string compute() {
+#include "../include/ddprof_base.hpp"
+
+template <int N> DDPROF_NOINLINE std::string compute() {
   char arr[N];
 
   for (int i = 0; i < N - 1; ++i) {
@@ -23,6 +30,7 @@ int main() {
   auto end = start + seconds(2); // set a time limit of 10 seconds
   while (high_resolution_clock::now() < end) {
     volatile auto str = compute<3000>();
+    ddprof::DoNotOptimize(str);
     //    std::cout << str;
   }
   return 0;

--- a/test/deep_stacks.cc
+++ b/test/deep_stacks.cc
@@ -27,7 +27,7 @@ template <int N> DDPROF_NOINLINE std::string compute() {
 int main() {
   using namespace std::chrono;
   auto start = high_resolution_clock::now();
-  auto end = start + seconds(2); // set a time limit of 10 seconds
+  auto end = start + seconds(2);
   while (high_resolution_clock::now() < end) {
     auto str = compute<3000>();
     ddprof::DoNotOptimize(str);

--- a/test/deep_stacks.sh
+++ b/test/deep_stacks.sh
@@ -6,12 +6,11 @@ CONFIG_DEEP_STACK="../test/configs/deep_stacks.toml"
 
 # Check for truncated stack traces
 truncated_input=$(awk -F': ' '/datadog.profiling.native.unwind.stack.truncated_input/ { print $NF }' ./log_ddprof.txt)
-truncated_output=$(awk -F': ' '/datadog.profiling.native.unwind.stack.truncated_output/ { print $NF }' ./log_ddprof.txt)
 
-# If we fail to run ddprof we should also be missing the metric (so this test should fail)
-if [ "$truncated_input" != "0" ] || [ "$truncated_output" != "0" ]; then
+# If we fail to run ddprof we should also be missing the metric
+if [ "$truncated_input" != "0" ]; then
   echo "Found truncated stack traces!"
-  echo "Truncated input: $truncated_input, Truncated output: $truncated_output"
+  echo "Truncated input: $truncated_input"
   exit 1
 else
   echo "No truncated stack traces found."

--- a/test/deep_stacks.sh
+++ b/test/deep_stacks.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-CONFIG_DEEP_STACK="../test/configs/deep_stacks.toml"
+set -euo pipefail
 
-./ddprof --config ${CONFIG_DEEP_STACK} ./test/deep_stacks | tee ./log_ddprof.txt
+./ddprof --stack_sample_size=65528 -l notice ./test/deep_stacks | tee ./log_ddprof.txt
 
 # Check for truncated stack traces
 truncated_input=$(awk -F': ' '/datadog.profiling.native.unwind.stack.truncated_input/ { print $NF }' ./log_ddprof.txt)

--- a/test/deep_stacks.sh
+++ b/test/deep_stacks.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+CONFIG_DEEP_STACK="../test/configs/deep_stacks.toml"
+
+./ddprof --config ${CONFIG_DEEP_STACK} ./test/deep_stacks | tee ./log_ddprof.txt
+
+# Check for truncated stack traces
+truncated_input=$(awk -F': ' '/datadog.profiling.native.unwind.stack.truncated_input/ { print $NF }' ./log_ddprof.txt)
+truncated_output=$(awk -F': ' '/datadog.profiling.native.unwind.stack.truncated_output/ { print $NF }' ./log_ddprof.txt)
+
+# If we fail to run ddprof we should also be missing the metric (so this test should fail)
+if [ "$truncated_input" != "0" ] || [ "$truncated_output" != "0" ]; then
+  echo "Found truncated stack traces!"
+  echo "Truncated input: $truncated_input, Truncated output: $truncated_output"
+  exit 1
+else
+  echo "No truncated stack traces found."
+fi
+exit 0

--- a/test/savecontext-bench.cc
+++ b/test/savecontext-bench.cc
@@ -35,7 +35,7 @@ DDPROF_NOINLINE static void *get_stack_start_tls() {
 
 static void BM_SaveContext(benchmark::State &state) {
   uint64_t regs[PERF_REGS_COUNT];
-  std::byte stack[k_default_perf_sample_stack_user];
+  std::byte stack[k_default_perf_stack_sample_size];
   ddprof::span<const std::byte> stack_bounds = retrieve_stack_bounds();
   if (stack_bounds.empty()) {
     exit(1);

--- a/test/savecontext-bench.cc
+++ b/test/savecontext-bench.cc
@@ -35,7 +35,7 @@ DDPROF_NOINLINE static void *get_stack_start_tls() {
 
 static void BM_SaveContext(benchmark::State &state) {
   uint64_t regs[PERF_REGS_COUNT];
-  std::byte stack[PERF_SAMPLE_STACK_SIZE];
+  std::byte stack[k_default_perf_sample_stack_user];
   ddprof::span<const std::byte> stack_bounds = retrieve_stack_bounds();
   if (stack_bounds.empty()) {
     exit(1);

--- a/test/savecontext-ut.cc
+++ b/test/savecontext-ut.cc
@@ -13,6 +13,7 @@
 #include "unwind.hpp"
 #include "unwind_state.hpp"
 
+#include "ddprof_defs.hpp"
 #include <algorithm>
 #include <condition_variable>
 #include <mutex>
@@ -22,7 +23,7 @@
 DDPROF_NOINLINE void funcA();
 DDPROF_NOINLINE void funcB();
 
-std::byte stack[PERF_SAMPLE_STACK_SIZE];
+std::byte stack[k_default_perf_sample_stack_user];
 
 void funcB() {
   UnwindState state;

--- a/test/savecontext-ut.cc
+++ b/test/savecontext-ut.cc
@@ -22,7 +22,7 @@
 DDPROF_NOINLINE void funcA();
 DDPROF_NOINLINE void funcB();
 
-std::byte stack[k_default_perf_sample_stack_user];
+std::byte stack[k_default_perf_stack_sample_size];
 
 void funcB() {
   UnwindState state;

--- a/test/savecontext-ut.cc
+++ b/test/savecontext-ut.cc
@@ -13,7 +13,6 @@
 #include "unwind.hpp"
 #include "unwind_state.hpp"
 
-#include "ddprof_defs.hpp"
 #include <algorithm>
 #include <condition_variable>
 #include <mutex>


### PR DESCRIPTION
# What does this PR do?

Add a parameter to configure the size of samples.

# Motivation

Ensure we can unwind deeper stacks.
Discussions in https://github.com/DataDog/ddprof/issues/276

# Additional Notes

For now the maximum value allowed by linux is the closest value to USHORT_MAX, 8 byte aligned:
`65528`
If this is not enough we should consider a different kernel API.

# How to test the change?

A test with deep stacks was added. I will run this in CI.
https://github.com/DataDog/ddprof-build/pull/101