### PR TITLE
Backpopulate - allow more useful backpopulates

### DIFF
--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -371,7 +371,6 @@ bool DsoHdr::pid_backpopulate(PidMapping &pid_mapping, pid_t pid,
   if (bp_state._perm != kAllowed) { // retry
     return false;
   }
-  bp_state._perm = kForbidden;
   nb_elts_added = 0;
   LG_DBG("[DSO] Backpopulating PID %d", pid);
   auto proc_map_file_holder = open_proc_maps(pid, _path_to_proc.c_str());
@@ -393,6 +392,9 @@ bool DsoHdr::pid_backpopulate(PidMapping &pid_mapping, pid_t pid,
     if ((insert_erase_overlap(pid_mapping, std::move(dso))).second) {
       ++nb_elts_added;
     }
+  }
+  if (!nb_elts_added) {
+    bp_state._perm = kForbidden;
   }
   return true;
 }

--- a/src/perf.cc
+++ b/src/perf.cc
@@ -7,17 +7,10 @@
 
 #include "defer.hpp"
 #include "logger.hpp"
-#include "perf.hpp"
-#include "user_override.hpp"
 
 #include <cassert>
-#include <ctype.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>
 #include <sys/types.h>

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -331,7 +331,7 @@ TEST(DSOTest, backpopulate) {
   // manually erase the unit test's binary
   dso_hdr._pid_map[getpid()]._map.erase(find_res.first);
   find_res = dso_hdr.dso_find_or_backpopulate(getpid(), ip);
-  EXPECT_FALSE(find_res.second);
+  EXPECT_TRUE(find_res.second);
 }
 
 TEST(DSOTest, missing_dso) {


### PR DESCRIPTION
# What does this PR do?

If the state of the maps is changing and we are missing events we want to still allow backpopulates.

# Motivation

Discussions in https://github.com/DataDog/ddprof/issues/276
We can see that we are often trying to backpopulate.
