### PR TITLE
ddprof cli - port env var fix

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -29,7 +29,7 @@ Options:
   -H,--host TEXT [localhost]  (Env:DD_AGENT_HOST)
                               The hostname of the agent. This is combined with the port option to generate a URL
                               
-  -P,--port TEXT [8126]  (Env:DD_AGENT_HOST)
+  -P,--port TEXT [8126]  (Env:DD_TRACE_AGENT_PORT)
                               The communication port for the Datadog agent. This is combined with the host option to generate a URL
                               
   -T,--tags TEXT (Env:DD_TAGS)

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -125,7 +125,7 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
   app.add_option("--port,-P", exporter_input.port,
                  "The communication port for the Datadog agent. This is "
                  "combined with the host option to generate a URL\n")
-      ->envname("DD_AGENT_HOST")
+      ->envname("DD_TRACE_AGENT_PORT")
       ->default_val("8126");
 
   app.add_option("--tags,-T", tags,

--- a/test/ddprof_cli-ut.cc
+++ b/test/ddprof_cli-ut.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "ddprof_cli.hpp"
+#include "defer.hpp"
 #include "loghandle.hpp"
 
 namespace ddprof {
@@ -13,6 +14,7 @@ TEST(ddprof_cli, help) {
   EXPECT_EQ(0, res);
   EXPECT_FALSE(ddprof_cli.continue_exec);
 }
+
 TEST(ddprof_cli, help_events) {
   const char *argv[] = {MYNAME, "--event", "help"};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -41,6 +43,20 @@ TEST(ddprof_cli, no_options) {
   EXPECT_EQ(ddprof_cli.command_line[0], "some");
   EXPECT_EQ(ddprof_cli.command_line.size(), 3);
   EXPECT_TRUE(ddprof_cli.continue_exec);
+}
+
+TEST(ddprof_cli, port_env_var) {
+  LogHandle handle;
+  setenv("DD_TRACE_AGENT_PORT", "8122", 1);
+  defer { unsetenv("DD_TRACE_AGENT_PORT"); };
+
+  const char *argv[] = {MYNAME, "program"};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  ddprof::DDProfCLI ddprof_cli;
+  int res = ddprof_cli.parse(argc, argv);
+  EXPECT_EQ(0, res);
+  EXPECT_EQ(ddprof_cli.command_line[0], "program");
+  EXPECT_EQ(ddprof_cli.exporter_input.port, "8122");
 }
 
 TEST(ddprof_cli, hyphen_hyphen) {


### PR DESCRIPTION
# What does this PR do?

During the ddprof CLI refactoring, I introduced a regression. This reintroduces the DD_TRACE_AGENT_PORT environement variable.

# Motivation

Fix staging deployments that rely on this variable.
