### PR TITLE
Improve performance of allocation profiling

### DIFF
--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -27,6 +27,11 @@ struct TrackerThreadLocalState {
   bool remaining_bytes_initialized; // false if remaining_bytes is not
                                     // initialized
   ddprof::span<const byte> stack_bounds;
+
+  // In the choice of random generators, this one is smaller
+  // - smaller than mt19937 (8 vs 5K)
+  std::minstd_rand _gen{std::random_device{}()};
+
   pid_t tid; // cache of tid
 
   bool reentry_guard; // prevent reentry in AllocationTracker (eg. when
@@ -83,7 +88,8 @@ private:
   };
 
   AllocationTracker();
-  uint64_t next_sample_interval();
+
+  uint64_t next_sample_interval(std::minstd_rand &gen);
 
   DDRes init(uint64_t mem_profile_interval, bool deterministic_sampling,
              uint32_t stack_sample_size, const RingBufferInfo &ring_buffer);
@@ -110,7 +116,6 @@ private:
   TrackerState _state;
   uint64_t _sampling_interval;
   uint32_t _stack_sample_size;
-  std::mt19937 _gen;
   PEvent _pevent;
   bool _deterministic_sampling;
   AdressSet _address_set;

--- a/src/lib/allocation_tracker.cc
+++ b/src/lib/allocation_tracker.cc
@@ -57,7 +57,7 @@ private:
 AllocationTracker *AllocationTracker::_instance;
 thread_local TrackerThreadLocalState AllocationTracker::_tl_state;
 
-AllocationTracker::AllocationTracker() : _gen(std::random_device{}()) {}
+AllocationTracker::AllocationTracker() {}
 
 AllocationTracker *AllocationTracker::create_instance() {
   static AllocationTracker tracker;
@@ -156,10 +156,6 @@ void AllocationTracker::track_allocation(uintptr_t addr, size_t size,
     return;
   }
 
-  // \fixme{nsavoire} reduce the scope of the mutex:
-  // change prng/make it thread local
-  std::lock_guard lock{_state.mutex};
-
   // recheck if profiling is enabled
   if (!_state.track_allocations) {
     return;
@@ -169,7 +165,7 @@ void AllocationTracker::track_allocation(uintptr_t addr, size_t size,
 
   if (unlikely(!tl_state.remaining_bytes_initialized)) {
     // tl_state.remaining bytes was not initialized yet for this thread
-    remaining_bytes -= next_sample_interval();
+    remaining_bytes -= next_sample_interval(tl_state._gen);
     tl_state.remaining_bytes_initialized = true;
     if (remaining_bytes < 0) {
       tl_state.remaining_bytes = remaining_bytes;
@@ -183,7 +179,7 @@ void AllocationTracker::track_allocation(uintptr_t addr, size_t size,
   remaining_bytes = remaining_bytes % sampling_interval;
 
   do {
-    remaining_bytes -= next_sample_interval();
+    remaining_bytes -= next_sample_interval(tl_state._gen);
     ++nsamples;
   } while (remaining_bytes >= 0);
 
@@ -194,6 +190,10 @@ void AllocationTracker::track_allocation(uintptr_t addr, size_t size,
   free_on_consecutive_failures(success);
 
   if (success && _state.track_deallocations) {
+    // \fixme{r1viollet} adjust set to be lock free
+    // We should still lock the clear of live allocations (which is unlikely)
+    std::lock_guard lock{_state.mutex};
+
     // ensure we track this dealloc if it occurs
     _address_set.insert(addr);
     if (unlikely(_address_set.size() > ddprof::liveallocation::kMaxTracked)) {
@@ -218,18 +218,16 @@ void AllocationTracker::track_deallocation(uintptr_t addr,
     // This is an internal dealloc, so we don't need to keep track of this
     return;
   }
-  std::lock_guard lock{_state.mutex};
 
-  // recheck if profiling is enabled
-  if (!_state.track_deallocations) {
-    return;
+  { // Grab the lock to check if this allocation was stored in the set
+    std::lock_guard lock{_state.mutex};
+    if (!_state.track_deallocations || !_address_set.erase(addr)) {
+      return;
+    }
   }
 
-  // Inserting / Erasing addresses is done within the lock
-  if (_address_set.erase(addr)) {
-    bool success = IsDDResOK(push_dealloc_sample(addr, tl_state));
-    free_on_consecutive_failures(success);
-  }
+  bool success = IsDDResOK(push_dealloc_sample(addr, tl_state));
+  free_on_consecutive_failures(success);
 }
 
 DDRes AllocationTracker::push_lost_sample(MPSCRingBufferWriter &writer,
@@ -427,7 +425,7 @@ DDRes AllocationTracker::push_alloc_sample(uintptr_t addr,
   return {};
 }
 
-uint64_t AllocationTracker::next_sample_interval() {
+uint64_t AllocationTracker::next_sample_interval(std::minstd_rand &gen) {
   if (_sampling_interval == 1) {
     return 1;
   }
@@ -436,7 +434,7 @@ uint64_t AllocationTracker::next_sample_interval() {
   }
   double sampling_rate = 1.0 / static_cast<double>(_sampling_interval);
   std::exponential_distribution<> dist(sampling_rate);
-  double value = dist(_gen);
+  double value = dist(gen);
   const size_t max_value = _sampling_interval * 20;
   const size_t min_value = 8;
   if (value > max_value) {


### PR DESCRIPTION
# What does this PR do?

- Adjust the pseudo random generator to be thread local
- Change the generator to be smaller
- Remove the lock from the allocation profiling path

Credit for this idea goes to @nsavoire 

# Motivation

Improve performance of allocation profiling. This really brings down the allocation profiling to numbers that are comparable. 
```
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_ThreadedAllocations_NoTracking     343085 ns       172913 ns         4525
BM_ThreadedAllocations_Tracking       483263 ns       244706 ns         2886
```

The numbers were 4x worse prior to this change.

After this change I will need to focus on the deallocation code path.

# Additional Notes

This needs extensive testing.
Risks are:
- Accuracy 
- Thread safety

# How to test the change?

The benchmark only tests parts of this. We will need to be careful when deploying this change.