### PR TITLE
Allocation profiling fix - pthread TLS storage

### DIFF
--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -69,7 +69,7 @@ public:
 
   static inline bool is_active();
 
-  static TrackerThreadLocalState* init_tl_state();
+  static TrackerThreadLocalState *init_tl_state();
 
 private:
   using AdressSet = std::unordered_set<uintptr_t>;
@@ -100,7 +100,7 @@ private:
 
   static AllocationTracker *create_instance();
 
-  static void delete_tl_state(void* tl_state);
+  static void delete_tl_state(void *tl_state);
 
   static void make_key();
 
@@ -127,7 +127,6 @@ private:
   bool _deterministic_sampling;
   AdressSet _address_set;
 
-
   // These can not be tied to the internal state of the instance.
   // The creation of the instance depends on this
   static pthread_once_t _key_once; // ensures we call key creation a single time
@@ -135,7 +134,6 @@ private:
 
   static AllocationTracker *_instance;
 };
-
 
 void AllocationTracker::track_allocation(uintptr_t addr, size_t size) {
   AllocationTracker *instance = _instance;
@@ -153,7 +151,8 @@ void AllocationTracker::track_allocation(uintptr_t addr, size_t size) {
   // tls_get_addr can call into malloc, which can create a recursive loop
   // instead we call pthread APIs to control the creation of TLS objects
   pthread_once(&_key_once, make_key);
-  TrackerThreadLocalState* tl_state = (TrackerThreadLocalState*)pthread_getspecific(tl_state_key);
+  TrackerThreadLocalState *tl_state =
+      (TrackerThreadLocalState *)pthread_getspecific(tl_state_key);
   if (unlikely(!tl_state)) {
     tl_state = init_tl_state();
     if (!tl_state) {
@@ -185,7 +184,8 @@ void AllocationTracker::track_deallocation(uintptr_t addr) {
   }
 
   pthread_once(&_key_once, make_key);
-  TrackerThreadLocalState* tl_state = (TrackerThreadLocalState*)pthread_getspecific(tl_state_key);
+  TrackerThreadLocalState *tl_state =
+      (TrackerThreadLocalState *)pthread_getspecific(tl_state_key);
   if (unlikely(!tl_state)) {
     tl_state = init_tl_state();
     if (!tl_state) {

--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -8,6 +8,7 @@
 #include "ddprof_base.hpp"
 #include "ddres_def.hpp"
 #include "pevent.hpp"
+#include "reentry_guard.hpp"
 #include "span.hpp"
 #include "unlikely.hpp"
 
@@ -73,18 +74,6 @@ public:
 
 private:
   using AdressSet = std::unordered_set<uintptr_t>;
-  friend class TLReentryGuard;
-  class ThreadEntries {
-  public:
-    static constexpr size_t max_threads = 10;
-    std::array<std::atomic<pid_t>, max_threads> thread_entries;
-    ThreadEntries() { reset(); }
-    void reset() {
-      for (auto &entry : thread_entries) {
-        entry.store(-1, std::memory_order_relaxed);
-      }
-    }
-  };
 
   struct TrackerState {
     void init(bool track_alloc, bool track_dealloc) {

--- a/include/lib/allocation_tracker_tls.hpp
+++ b/include/lib/allocation_tracker_tls.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "span.hpp"
+
+#include <cstdint>
+#include <random>
+#include <sys/types.h>
+
+namespace ddprof {
+
+struct TrackerThreadLocalState {
+  int64_t remaining_bytes; // remaining allocation bytes until next sample
+  bool remaining_bytes_initialized; // false if remaining_bytes is not
+                                    // initialized
+  ddprof::span<const byte> stack_bounds;
+
+  // In the choice of random generators, this one is smaller
+  // - smaller than mt19937 (8 vs 5K)
+  std::minstd_rand _gen{std::random_device{}()};
+
+  pid_t tid; // cache of tid
+
+  bool reentry_guard;         // prevent reentry in AllocationTracker (eg. when
+                              // allocation are done inside AllocationTracker)
+  bool double_tracking_guard; // prevent mmap tracking within a malloc
+};
+
+} // namespace ddprof

--- a/include/lib/lib_logger.hpp
+++ b/include/lib/lib_logger.hpp
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
 #pragma once
 
 #include <cstdarg>
@@ -7,7 +12,11 @@
 namespace ddprof {
 template <typename... Args>
 void log_once(char const *const format, Args... args) {
+#ifndef DEBUG
   static std::once_flag flag;
   std::call_once(flag, [&, format]() { fprintf(stderr, format, args...); });
+#else
+  fprintf(stderr, format, args...);
+#endif
 }
 } // namespace ddprof

--- a/include/lib/lib_logger.hpp
+++ b/include/lib/lib_logger.hpp
@@ -1,15 +1,13 @@
 #pragma once
 
-#include <mutex>
 #include <cstdarg>
 #include <cstdio>
+#include <mutex>
 
 namespace ddprof {
-template<typename... Args>
-void log_once(char const* const format, Args... args) {
+template <typename... Args>
+void log_once(char const *const format, Args... args) {
   static std::once_flag flag;
-  std::call_once(flag, [&, format]() {
-    fprintf(stderr, format, args...);
-  });
+  std::call_once(flag, [&, format]() { fprintf(stderr, format, args...); });
 }
-}
+} // namespace ddprof

--- a/include/lib/lib_logger.hpp
+++ b/include/lib/lib_logger.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <mutex>
+#include <cstdarg>
+#include <cstdio>
+
+namespace ddprof {
+template<typename... Args>
+void log_once(char const* const format, Args... args) {
+  static std::once_flag flag;
+  std::call_once(flag, [&, format]() {
+    fprintf(stderr, format, args...);
+  });
+}
+}

--- a/include/lib/reentry_guard.hpp
+++ b/include/lib/reentry_guard.hpp
@@ -30,7 +30,7 @@ public:
     while (true) {
       for (size_t i = 0; i < ThreadEntries::max_threads; ++i) {
         pid_t expected = -1;
-        if (_entries.thread_entries[i].compare_exchange_strong(
+        if (_entries.thread_entries[i].compare_exchange_weak(
                 expected, tid, std::memory_order_acq_rel)) {
           _ok = true;
           _index = i;

--- a/include/lib/reentry_guard.hpp
+++ b/include/lib/reentry_guard.hpp
@@ -67,13 +67,30 @@ private:
 class ReentryGuard {
 public:
   explicit ReentryGuard(bool *reentry_guard)
-      : _reentry_guard(reentry_guard), _ok(!*reentry_guard) {
-    *_reentry_guard = true;
+      : _reentry_guard(reentry_guard), _ok(false) {
+    if (_reentry_guard) {
+      _ok = (!*_reentry_guard);
+      *_reentry_guard = true;
+    }
   }
+
   ~ReentryGuard() {
     if (_ok) {
       *_reentry_guard = false;
     }
+  }
+
+  bool register_guard(bool *reentry_guard) {
+    if (_reentry_guard) {
+      // not supported (already registered to other bool)
+      return false;
+    }
+    if (reentry_guard) {
+      _reentry_guard = reentry_guard;
+      _ok = (!*_reentry_guard);
+      *_reentry_guard = true;
+    }
+    return _ok;
   }
 
   explicit operator bool() const { return _ok; }

--- a/include/lib/reentry_guard.hpp
+++ b/include/lib/reentry_guard.hpp
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <thread>
+
+namespace ddprof {
+
+class ThreadEntries {
+public:
+  static constexpr size_t max_threads = 10;
+  std::array<std::atomic<pid_t>, max_threads> thread_entries;
+  ThreadEntries() { reset(); }
+  void reset() {
+    for (auto &entry : thread_entries) {
+      entry.store(-1, std::memory_order_relaxed);
+    }
+  }
+};
+
+class TLReentryGuard {
+public:
+  explicit TLReentryGuard(ThreadEntries &entries, pid_t tid)
+      : _entries(entries), _tid(tid), _ok(false), _index(-1) {
+    while (true) {
+      for (size_t i = 0; i < ThreadEntries::max_threads; ++i) {
+        pid_t expected = -1;
+        if (_entries.thread_entries[i].compare_exchange_strong(
+                expected, tid, std::memory_order_acq_rel)) {
+          _ok = true;
+          _index = i;
+          return;
+        } else if (expected == tid) {
+          // This thread is already in the entries.
+          return;
+        }
+      }
+      // If we've reached here, all slots are occupied and none of them belongs
+      // to this thread. Let's yield to other threads and then try again.
+      std::this_thread::yield();
+    }
+  }
+
+  ~TLReentryGuard() {
+    if (_ok) {
+      _entries.thread_entries[_index].store(-1, std::memory_order_release);
+    }
+  }
+
+  explicit operator bool() const { return _ok; }
+
+  TLReentryGuard(const TLReentryGuard &) = delete;
+  TLReentryGuard &operator=(const TLReentryGuard &) = delete;
+
+private:
+  ThreadEntries &_entries;
+  pid_t _tid;
+  bool _ok;
+  int _index;
+};
+
+class ReentryGuard {
+public:
+  explicit ReentryGuard(bool *reentry_guard)
+      : _reentry_guard(reentry_guard), _ok(!*reentry_guard) {
+    *_reentry_guard = true;
+  }
+  ~ReentryGuard() {
+    if (_ok) {
+      *_reentry_guard = false;
+    }
+  }
+
+  explicit operator bool() const { return _ok; }
+
+  ReentryGuard(const ReentryGuard &) = delete;
+  ReentryGuard &operator=(const ReentryGuard &) = delete;
+
+private:
+  bool *_reentry_guard;
+  bool _ok;
+};
+
+} // namespace ddprof

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -336,6 +336,8 @@ add_unit_test(ddprof_process-ut ddprof_process-ut.cc ../src/container_id.cc
 
 add_unit_test(glibc_fixes-ut glibc_fixes-ut.cc ../src/lib/glibc_fixes.c LIBRARIES pthread)
 
+add_unit_test(reentry_guard-ut reentry_guard-ut.cc)
+
 add_unit_test(
   ddprof_cli-ut
   ddprof_cli-ut.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -334,6 +334,8 @@ add_unit_test(live_allocation-ut live_allocation-ut.cc ../src/live_allocation.cc
 add_unit_test(ddprof_process-ut ddprof_process-ut.cc ../src/container_id.cc
               ../src/ddprof_process.cc)
 
+add_unit_test(glibc_fixes-ut glibc_fixes-ut.cc ../src/lib/glibc_fixes.c LIBRARIES pthread)
+
 add_unit_test(
   ddprof_cli-ut
   ddprof_cli-ut.cc
@@ -343,6 +345,8 @@ add_unit_test(
   ../src/perf_watcher.cc
   ../src/tracepoint_config.cc
   LIBRARIES DDProf::Parser)
+
+add_unit_test(pthread_tls-ut pthread_tls-ut.cc)
 
 add_benchmark(savecontext-bench savecontext-bench.cc ../src/lib/pthread_fixes.cc
               ../src/lib/savecontext.cc ../src/lib/saveregisters.cc)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,8 @@
 find_package(GTest REQUIRED)
 find_package(benchmark REQUIRED)
 
+add_subdirectory(no_tls)
+
 enable_testing()
 
 # On arm builds Leak Detection is barely usable: https://github.com/google/sanitizers/issues/703
@@ -395,6 +397,11 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "SanitizedDebug")
   add_test(
     NAME simple_malloc
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/simple_malloc-ut.sh
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+  add_test(
+    NAME check_no_tls
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/check_no_tls-ut.sh
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
   if(BUILD_UNIVERSAL_DDPROF)

--- a/test/allocation_tracker-bench.cc
+++ b/test/allocation_tracker-bench.cc
@@ -1,31 +1,62 @@
 #include <benchmark/benchmark.h>
 
-#include "allocation_tracker.hpp"
+#include <thread>
+#include <condition_variable>
+#include <vector>
+#include <mutex>
+#include <atomic>
+#include <random>
+
 #include "loghandle.hpp"
+#include "allocation_tracker.hpp"
 #include "ringbuffer_holder.hpp"
 
-#include <thread>
+// Global bench settings
+// Activate live heap tracking
+// #define LIVE_HEAP
+// Sampling rate: default rate is 524288
+static constexpr uint64_t k_rate = 20000;
+
+#define READER_THREAD
+std::atomic<bool> reader_continue{true};
+
+// Reader worker thread function
+void read_buffer(ddprof::RingBufferHolder &holder) {
+  int nb_samples = 0;
+  while(reader_continue){
+    ddprof::MPSCRingBufferReader reader(holder.get_ring_buffer());
+    auto buf = reader.read_sample();
+    if (!buf.empty()) {
+      ++nb_samples;
+      //      fprintf(stderr, "Yep, got sample ! \n");
+    }
+    std::chrono::microseconds(10000);
+  }
+  fprintf(stderr, "Reader thread exit, nb_samples=%d\n", nb_samples);
+}
 
 DDPROF_NOINLINE void my_malloc(size_t size, uintptr_t addr = 0xdeadbeef) {
   ddprof::AllocationTracker::track_allocation(addr, size);
-  // prevent tail call optimization
   DDPROF_BLOCK_TAIL_CALL_OPTIMIZATION();
 }
 
 DDPROF_NOINLINE void my_free(uintptr_t addr) {
   ddprof::AllocationTracker::track_deallocation(addr);
-  // prevent tail call optimization
   DDPROF_BLOCK_TAIL_CALL_OPTIMIZATION();
 }
+
 // Function to perform allocations and deallocations
 void perform_memory_operations(bool track_allocations,
                                benchmark::State &state) {
   LogHandle handle;
-  const uint64_t rate = 1;
+  const uint64_t rate = k_rate;
   const size_t buf_size_order = 8;
+#ifndef LIVE_HEAP
   uint32_t flags = ddprof::AllocationTracker::kDeterministicSampling;
-  //  uint32_t flags = ddprof::AllocationTracker::kDeterministicSampling |
-  //      ddprof::AllocationTracker::kTrackDeallocations;
+#else
+  uint32_t flags = ddprof::AllocationTracker::kDeterministicSampling |
+      ddprof::AllocationTracker::kTrackDeallocations;
+#endif
 
   ddprof::RingBufferHolder ring_buffer{buf_size_order,
                                        RingBufferType::kMPSCRingBuffer};
@@ -43,9 +74,13 @@ void perform_memory_operations(bool track_allocations,
   std::random_device rd;
   std::mt19937 gen(rd());
 
-  for (auto _ : state) {
-    //    state.PauseTiming();
+#ifdef READER_THREAD
+  // create reader worker thread
+  reader_continue = true;
+  std::thread reader_thread{read_buffer, std::ref(ring_buffer)};
+#endif
 
+  for (auto _ : state) {
     // Initialize threads and clear addresses
     threads.clear();
     std::vector<std::vector<uintptr_t>> thread_addresses(nb_threads);
@@ -67,8 +102,6 @@ void perform_memory_operations(bool track_allocations,
       t.join();
     }
 
-    //    state.ResumeTiming();
-
     threads.clear();
     for (int i = 0; i < nb_threads; ++i) {
       threads.emplace_back([&, i] {
@@ -82,18 +115,158 @@ void perform_memory_operations(bool track_allocations,
       t.join();
     }
   }
+#ifdef READER_THREAD
+  reader_continue = false;
+  reader_thread.join();
+#endif
   ddprof::AllocationTracker::allocation_tracking_free();
 }
 
 // Benchmark without allocation tracking
-static void BM_ThreadedAllocations_NoTracking(benchmark::State &state) {
+static void BM_ShortLived_NoTracking(benchmark::State &state) {
   perform_memory_operations(false, state);
 }
 
 // Benchmark with allocation tracking
-static void BM_ThreadedAllocations_Tracking(benchmark::State &state) {
+static void BM_ShortLived_Tracking(benchmark::State &state) {
   perform_memory_operations(true, state);
 }
 
-BENCHMARK(BM_ThreadedAllocations_NoTracking);
-BENCHMARK(BM_ThreadedAllocations_Tracking);
+class WorkerThread {
+public:
+  std::vector<uintptr_t> addresses;
+  bool allocate;
+
+  WorkerThread() : stop(false), perform_task(false) {
+    worker_thread = std::thread([this] {
+      while (!stop) {
+        std::unique_lock<std::mutex> lock(mutex);
+        cv.wait(lock, [this]{ return perform_task || stop; });
+        if (stop)
+          return;
+
+        // Here you can perform the task for the thread
+        if (allocate) {
+          for (auto addr : addresses) {
+            my_malloc(1024, addr);
+          }
+        } else {
+          for (auto addr : addresses) {
+            my_free(addr);
+          }
+        }
+
+        perform_task = false;
+      }
+    });
+  }
+
+  void signal_task(bool allocate_task, const std::vector<uintptr_t>& addrs) {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      addresses = addrs;
+      allocate = allocate_task;
+      perform_task = true;
+    }
+    cv.notify_one();
+  }
+
+  ~WorkerThread() {
+    stop = true;
+    cv.notify_one();
+    if (worker_thread.joinable()) {
+      worker_thread.join();
+    }
+  }
+
+private:
+  std::thread worker_thread;
+  std::condition_variable cv;
+  std::mutex mutex;
+  std::atomic<bool> stop;
+  std::atomic<bool> perform_task;
+};
+
+void perform_memory_operations_2(bool track_allocations,
+                                benchmark::State &state) {
+  LogHandle handle;
+  const uint64_t rate = k_rate;
+  const size_t buf_size_order = 8;
+#ifndef LIVE_HEAP
+  uint32_t flags = ddprof::AllocationTracker::kDeterministicSampling;
+#else
+    uint32_t flags = ddprof::AllocationTracker::kDeterministicSampling |
+        ddprof::AllocationTracker::kTrackDeallocations;
+#endif
+  ddprof::RingBufferHolder ring_buffer{buf_size_order,
+                                       RingBufferType::kMPSCRingBuffer};
+
+  if (track_allocations) {
+    ddprof::AllocationTracker::allocation_tracking_init(
+        rate, flags, k_default_perf_stack_sample_size,
+        ring_buffer.get_buffer_info());
+  }
+
+#ifdef READER_THREAD
+  reader_continue = true;
+  std::thread reader_thread{read_buffer, std::ref(ring_buffer)};
+#endif
+  const int nb_threads = 4;
+  std::vector<WorkerThread> workers(nb_threads);
+  std::vector<std::vector<uintptr_t>> thread_addresses(nb_threads);
+
+  int num_allocations = 1000;
+  size_t page_size = 0x1000;
+  std::random_device rd;
+  std::mt19937 gen(rd());
+
+  for (int i = 0; i < nb_threads; ++i) {
+    std::uniform_int_distribution<> dis(i * page_size, (i + 1) * page_size - 1);
+    for (int j = 0; j < num_allocations; ++j) {
+      uintptr_t addr = dis(gen);
+      thread_addresses[i].push_back(addr);
+    }
+  }
+
+  for (auto _ : state) {
+    // Allocation phase
+    for (int i = 0; i < nb_threads; ++i) {
+      workers[i].signal_task(true, thread_addresses[i]);
+    }
+    // Add delay
+    std::this_thread::sleep_for(std::chrono::microseconds(100));
+
+    // Deallocation phase
+    for (int i = 0; i < nb_threads; ++i) {
+      workers[i].signal_task(false, thread_addresses[i]);
+    }
+    // Add delay
+    std::this_thread::sleep_for(std::chrono::microseconds(100));
+  }
+
+#ifdef READER_THREAD
+  reader_continue = false;
+  reader_thread.join();
+#endif
+
+  ddprof::AllocationTracker::allocation_tracking_free();
+}
+
+// Benchmark without allocation tracking
+static void BM_LongLived_NoTracking(benchmark::State &state) {
+  perform_memory_operations_2(false, state);
+}
+
+// Benchmark with allocation tracking
+static void BM_LongLived_Tracking(benchmark::State &state) {
+  perform_memory_operations_2(true, state);
+}
+
+
+// short lived threads
+BENCHMARK(BM_ShortLived_NoTracking)->MeasureProcessCPUTime()->UseRealTime();
+BENCHMARK(BM_ShortLived_Tracking)->MeasureProcessCPUTime()->UseRealTime();
+
+// longer lived threads (worker threads)
+BENCHMARK(BM_LongLived_NoTracking)->MeasureProcessCPUTime();
+BENCHMARK(BM_LongLived_Tracking)->MeasureProcessCPUTime();

--- a/test/allocation_tracker-bench.cc
+++ b/test/allocation_tracker-bench.cc
@@ -36,7 +36,8 @@ void read_buffer(ddprof::RingBufferHolder &holder) {
 }
 
 DDPROF_NOINLINE void my_malloc(size_t size, uintptr_t addr = 0xdeadbeef) {
-  ddprof::AllocationTracker::track_allocation(addr, size);
+  ddprof::ReentryGuard guard(nullptr);
+  ddprof::AllocationTracker::track_allocation(addr, size, guard);
   DDPROF_BLOCK_TAIL_CALL_OPTIMIZATION();
 }
 

--- a/test/allocation_tracker-bench.cc
+++ b/test/allocation_tracker-bench.cc
@@ -36,13 +36,16 @@ void read_buffer(ddprof::RingBufferHolder &holder) {
 }
 
 DDPROF_NOINLINE void my_malloc(size_t size, uintptr_t addr = 0xdeadbeef) {
-  ddprof::ReentryGuard guard(nullptr);
-  ddprof::AllocationTracker::track_allocation(addr, size, guard);
-  DDPROF_BLOCK_TAIL_CALL_OPTIMIZATION();
+  ddprof::TrackerThreadLocalState *tl_state =
+      ddprof::AllocationTracker::get_tl_state();
+  if (tl_state) { // tl_state is null if we are not tracking allocations
+    ddprof::AllocationTracker::track_allocation_s(addr, size, *tl_state);
+    DDPROF_BLOCK_TAIL_CALL_OPTIMIZATION();
+  }
 }
 
 DDPROF_NOINLINE void my_free(uintptr_t addr) {
-  ddprof::AllocationTracker::track_deallocation(addr);
+  ddprof::AllocationTracker::track_deallocation_s(addr);
   DDPROF_BLOCK_TAIL_CALL_OPTIMIZATION();
 }
 

--- a/test/allocation_tracker-bench.cc
+++ b/test/allocation_tracker-bench.cc
@@ -1,14 +1,14 @@
 #include <benchmark/benchmark.h>
 
-#include <thread>
-#include <condition_variable>
-#include <vector>
-#include <mutex>
 #include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include <random>
+#include <thread>
+#include <vector>
 
-#include "loghandle.hpp"
 #include "allocation_tracker.hpp"
+#include "loghandle.hpp"
 #include "ringbuffer_holder.hpp"
 
 // Global bench settings
@@ -23,7 +23,7 @@ std::atomic<bool> reader_continue{true};
 // Reader worker thread function
 void read_buffer(ddprof::RingBufferHolder &holder) {
   int nb_samples = 0;
-  while(reader_continue){
+  while (reader_continue) {
     ddprof::MPSCRingBufferReader reader(holder.get_ring_buffer());
     auto buf = reader.read_sample();
     if (!buf.empty()) {
@@ -141,7 +141,7 @@ public:
     worker_thread = std::thread([this] {
       while (!stop) {
         std::unique_lock<std::mutex> lock(mutex);
-        cv.wait(lock, [this]{ return perform_task || stop; });
+        cv.wait(lock, [this] { return perform_task || stop; });
         if (stop)
           return;
 
@@ -161,7 +161,7 @@ public:
     });
   }
 
-  void signal_task(bool allocate_task, const std::vector<uintptr_t>& addrs) {
+  void signal_task(bool allocate_task, const std::vector<uintptr_t> &addrs) {
     {
       std::lock_guard<std::mutex> lock(mutex);
       addresses = addrs;
@@ -188,15 +188,15 @@ private:
 };
 
 void perform_memory_operations_2(bool track_allocations,
-                                benchmark::State &state) {
+                                 benchmark::State &state) {
   LogHandle handle;
   const uint64_t rate = k_rate;
   const size_t buf_size_order = 8;
 #ifndef LIVE_HEAP
   uint32_t flags = ddprof::AllocationTracker::kDeterministicSampling;
 #else
-    uint32_t flags = ddprof::AllocationTracker::kDeterministicSampling |
-        ddprof::AllocationTracker::kTrackDeallocations;
+  uint32_t flags = ddprof::AllocationTracker::kDeterministicSampling |
+      ddprof::AllocationTracker::kTrackDeallocations;
 #endif
   ddprof::RingBufferHolder ring_buffer{buf_size_order,
                                        RingBufferType::kMPSCRingBuffer};
@@ -261,7 +261,6 @@ static void BM_LongLived_NoTracking(benchmark::State &state) {
 static void BM_LongLived_Tracking(benchmark::State &state) {
   perform_memory_operations_2(true, state);
 }
-
 
 // short lived threads
 BENCHMARK(BM_ShortLived_NoTracking)->MeasureProcessCPUTime()->UseRealTime();

--- a/test/allocation_tracker-ut.cc
+++ b/test/allocation_tracker-ut.cc
@@ -18,7 +18,8 @@
 #include <unistd.h>
 
 DDPROF_NOINLINE void my_malloc(size_t size, uintptr_t addr = 0xdeadbeef) {
-  ddprof::AllocationTracker::track_allocation(addr, size);
+  ddprof::ReentryGuard guard(nullptr);
+  ddprof::AllocationTracker::track_allocation(addr, size, guard);
   // prevent tail call optimization
   getpid();
 }
@@ -120,7 +121,8 @@ TEST(allocation_tracker, stale_lock) {
 
   for (uint32_t i = 0;
        i < ddprof::AllocationTracker::k_max_consecutive_failures; ++i) {
-    ddprof::AllocationTracker::track_allocation(0xdeadbeef, 1);
+    ddprof::ReentryGuard guard(nullptr);
+    ddprof::AllocationTracker::track_allocation(0xdeadbeef, 1, guard);
   }
   ASSERT_FALSE(ddprof::AllocationTracker::is_active());
   ddprof::AllocationTracker::allocation_tracking_free();

--- a/test/check_no_tls-ut.sh
+++ b/test/check_no_tls-ut.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+LD_PRELOAD=./test/no_tls/libno_tls.so ./ddprof sleep 1

--- a/test/glibc_fixes-ut.cc
+++ b/test/glibc_fixes-ut.cc
@@ -1,0 +1,39 @@
+#include <atomic>
+#include <csignal>
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+// assuming this variable is accessible from your test file
+static std::atomic<bool> g_child_called;
+static std::atomic<bool> g_parent_called;
+static std::atomic<bool> g_prepare_called;
+
+void prepare() { g_prepare_called = true; }
+
+void parent() { g_parent_called = true; }
+
+void child() { g_child_called = true; }
+
+TEST(GlibcFixes, pthread_atfork) {
+  g_child_called = false;
+  g_parent_called = false;
+  g_prepare_called = false;
+
+  // register handlers
+  EXPECT_EQ(0, pthread_atfork(prepare, parent, child));
+
+  pid_t child_pid = fork();
+
+  if (child_pid == 0) {
+    // This is the child process
+    EXPECT_TRUE(g_child_called);
+    exit(0);
+  } else {
+
+    // validate that the handlers were called
+    EXPECT_TRUE(g_prepare_called);
+    EXPECT_TRUE(g_parent_called);
+
+    waitpid(child_pid, nullptr, 0); // wait for child to finish
+  }
+}

--- a/test/glibc_fixes-ut.cc
+++ b/test/glibc_fixes-ut.cc
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
 #include <atomic>
 #include <csignal>
 #include <gtest/gtest.h>

--- a/test/no_tls/CMakeLists.txt
+++ b/test/no_tls/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(no_tls_lib SHARED no_tls_lib.c)

--- a/test/no_tls/no_tls_lib.c
+++ b/test/no_tls/no_tls_lib.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+void *__tls_get_addr(void *v) {
+  fprintf(stderr, "__tls_get_addr was called, which is not allowed!\n");
+  abort();
+}

--- a/test/no_tls/no_tls_lib.h
+++ b/test/no_tls/no_tls_lib.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void *__tls_get_addr(void *v);

--- a/test/pthread_tls-ut.cc
+++ b/test/pthread_tls-ut.cc
@@ -1,0 +1,81 @@
+#include <gtest/gtest.h>
+
+#include <pthread.h>
+#include <unistd.h>
+
+constexpr int num_threads = 10;
+static pthread_key_t key;
+// +1 for main thread
+static std::array<bool, num_threads + 1> is_set = {};
+
+void *set_get_key(void *threadid) {
+  long tid = *((long *)(threadid));
+  void *ret_val = pthread_getspecific(key);
+  EXPECT_EQ(ret_val, nullptr);
+  pthread_setspecific(key, (void *)threadid);
+  ret_val = pthread_getspecific(key);
+  EXPECT_EQ(*(reinterpret_cast<long *>(ret_val)), tid);
+  is_set[tid] = true;
+  // Check that set does not clear
+  ret_val = pthread_getspecific(key);
+  EXPECT_EQ(*(reinterpret_cast<long *>(ret_val)), tid);
+  return nullptr;
+}
+static std::array<long, num_threads> thread_ids;
+
+TEST(PThreadTest, SetGetSpecific) {
+  pthread_key_create(&key, nullptr);
+  pthread_t threads[num_threads];
+
+  // Create threads
+
+  for (int i = 0; i < num_threads; ++i) {
+    thread_ids[i] = i;
+    pthread_create(&threads[i], nullptr, set_get_key, &(thread_ids[i]));
+  }
+
+  // Join threads
+  for (auto &thread : threads) {
+    pthread_join(thread, nullptr);
+  }
+  // check behaviour for main thread
+  static long main_thread_id = num_threads;
+  set_get_key(&main_thread_id);
+
+  // Check if set for all threads
+  for (bool val : is_set) {
+    EXPECT_TRUE(val);
+  }
+
+  if (fork() == 0) {
+    // Child process
+    // Reset the set values
+    for (bool &val : is_set) {
+      val = false;
+    }
+
+    // Create and join threads again
+    for (long i = 0; i < num_threads; ++i) {
+      pthread_create(&threads[i], nullptr, set_get_key, &(thread_ids[i]));
+    }
+    for (auto &thread : threads) {
+      pthread_join(thread, nullptr);
+    }
+
+    // Expect main thread to be set already
+    void *ret_val = pthread_getspecific(key);
+    EXPECT_EQ(*(reinterpret_cast<long *>(ret_val)), main_thread_id);
+    is_set[main_thread_id] = true;
+
+    // Check if set for all threads
+    for (bool val : is_set) {
+      EXPECT_TRUE(val);
+    }
+    _exit(0);
+  } else {
+    // Parent process
+    // Wait for the child process to finish
+    wait(nullptr);
+  }
+  pthread_key_delete(key);
+}

--- a/test/pthread_tls-ut.cc
+++ b/test/pthread_tls-ut.cc
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
 #include <gtest/gtest.h>
 
 #include <pthread.h>

--- a/test/reentry_guard-ut.cc
+++ b/test/reentry_guard-ut.cc
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include <gtest/gtest.h>
+
+#include "lib/reentry_guard.hpp"
+#include "syscalls.hpp"
+
+TEST(ReentryGuardTest, basic) {
+  bool reentry_guard = false;
+  {
+    ddprof::ReentryGuard guard(&reentry_guard);
+    EXPECT_TRUE(static_cast<bool>(guard));
+    EXPECT_TRUE(reentry_guard);
+  }
+  EXPECT_FALSE(reentry_guard);
+}
+
+TEST(TLReentryGuardTest, basic) {
+  ddprof::ThreadEntries entries;
+  pid_t tid = ddprof::gettid();
+
+  {
+    ddprof::TLReentryGuard guard(entries, tid);
+    EXPECT_TRUE(static_cast<bool>(guard));
+    // Reenter a second time
+    ddprof::TLReentryGuard guard2(entries, tid);
+    EXPECT_FALSE(static_cast<bool>(guard2));
+  }
+}
+
+TEST(TLReentryGuardTest, many_threads) {
+  ddprof::ThreadEntries entries;
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 100; ++i) {
+    threads.emplace_back([&]() {
+      pid_t tid = ddprof::gettid();
+      ddprof::TLReentryGuard guard(entries, tid);
+      EXPECT_TRUE(static_cast<bool>(guard));
+      // Sleep to simulate work
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    });
+  }
+  // Join all threads
+  for (auto &thread : threads) {
+    thread.join();
+  }
+  // Check that all entries are reset
+  for (auto &entry : entries.thread_entries) {
+    EXPECT_EQ(entry.load(), -1);
+  }
+}
+
+TEST(TLReentryGuardTest, reqcuisition_many_threads) {
+  ddprof::ThreadEntries entries;
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 100; ++i) {
+    threads.emplace_back([&]() {
+      pid_t tid = ddprof::gettid();
+
+      // First acquisition
+      {
+        ddprof::TLReentryGuard guard(entries, tid);
+        EXPECT_TRUE(static_cast<bool>(guard));
+        // Sleep to simulate work
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+      }
+      // Re-acquisition
+      {
+        ddprof::TLReentryGuard guard(entries, tid);
+        EXPECT_TRUE(static_cast<bool>(guard));
+      }
+    });
+  }
+
+  // Join all threads
+  for (auto &thread : threads) {
+    thread.join();
+  }
+
+  // Check that all entries are reset
+  for (auto &entry : entries.thread_entries) {
+    EXPECT_EQ(entry.load(), -1);
+  }
+}

--- a/test/reentry_guard-ut.cc
+++ b/test/reentry_guard-ut.cc
@@ -18,6 +18,20 @@ TEST(ReentryGuardTest, basic) {
   EXPECT_FALSE(reentry_guard);
 }
 
+TEST(ReentryGuardTest, null_init) {
+  bool reentry_guard = false;
+  {
+    ddprof::ReentryGuard guard(nullptr);
+    EXPECT_FALSE(guard);
+    guard.register_guard(&reentry_guard);
+    EXPECT_TRUE(guard);
+    {
+      ddprof::ReentryGuard guard(&reentry_guard);
+      EXPECT_FALSE(guard);
+    }
+  }
+}
+
 TEST(TLReentryGuardTest, basic) {
   ddprof::ThreadEntries entries;
   pid_t tid = ddprof::gettid();

--- a/test/simple_malloc-ut.sh
+++ b/test/simple_malloc-ut.sh
@@ -21,6 +21,7 @@ test_cpu_mask=$(python3 -c 'import random,os;print(hex(1 << random.choice(list(o
 
 opts="--loop 1000 --spin 100"
 log_file=$(mktemp "${PWD}/log.XXXXXX")
+echo "logs available here $log_file"
 rm "${log_file}"
 export DD_PROFILING_NATIVE_LOG_MODE="${log_file}"
 
@@ -36,6 +37,7 @@ check() {
     expected_pids="$2"
     expected_tids="${3-$2}"
     # shellcheck disable=SC2086
+    echo "runnint :${cmd}"
     taskset "${test_cpu_mask}" ${cmd}
     if [[ "${expected_pids}" -eq 1 ]]; then
         # Ugly workaround for tail bug that makes it wait indefinitely for new lines when `grep -q` exists:

--- a/test/simple_malloc-ut.sh
+++ b/test/simple_malloc-ut.sh
@@ -21,7 +21,7 @@ test_cpu_mask=$(python3 -c 'import random,os;print(hex(1 << random.choice(list(o
 
 opts="--loop 1000 --spin 100"
 log_file=$(mktemp "${PWD}/log.XXXXXX")
-echo "logs available here $log_file"
+# echo "logs available here $log_file"
 rm "${log_file}"
 export DD_PROFILING_NATIVE_LOG_MODE="${log_file}"
 

--- a/test/simple_malloc-ut.sh
+++ b/test/simple_malloc-ut.sh
@@ -37,7 +37,7 @@ check() {
     expected_pids="$2"
     expected_tids="${3-$2}"
     # shellcheck disable=SC2086
-    echo "runnint :${cmd}"
+    # echo "running :${cmd}"
     taskset "${test_cpu_mask}" ${cmd}
     if [[ "${expected_pids}" -eq 1 ]]; then
         # Ugly workaround for tail bug that makes it wait indefinitely for new lines when `grep -q` exists:


### PR DESCRIPTION
# What does this PR do?

- Manage TLS storage with pthread APIs.
A user provided a case where `__tls_get_addr` was calling back into Go, which was calling back into mmap.
This was causing an infinite recursive loop
By managing the lifetime of TLS variables, we can fix this.

- Add a test to check if TLS variables are being used

- Minor fix on the usage of wrong pointer for realloc array

- Add some settings to the allocation tracking benchmark

# Motivation

Fix a crash when TLS calls into malloc

# Additional Notes

Performance look very slightly worse
Thank you to @nsavoire for discussing these fixes with me.

# How to test the change?

I tested this on the Go service thanks to @dforciea 
I added some unit tests