### PR TITLE
Julia uses start_task as the top frame

### DIFF
--- a/src/unwind.cc
+++ b/src/unwind.cc
@@ -68,7 +68,8 @@ static bool is_stack_complete(UnwindState *us) {
       "runtime.goexit.abi0"sv,
       "runtime.systemstack.abi0"sv,
       "_start"sv,
-      "start_thread"sv};
+      "start_thread"sv,
+      "start_task"sv};
 
   if (us->output.locs.size() == 0) {
     return false;


### PR DESCRIPTION
Julia uses the start_task as an indicator for the top frame. Adding this to the list of successful  unwinding symbols.