### PR TITLE
Jitdump fix for wholehost

### DIFF
--- a/src/dso.cc
+++ b/src/dso.cc
@@ -83,13 +83,12 @@ Dso::Dso(pid_t pid, ElfAddress_t start, ElfAddress_t end, ElfAddress_t pgoff,
 bool Dso::is_jit_dump_str(std::string_view file_path, pid_t pid) {
   // test if we finish by .dump before creating a string
   if (file_path.ends_with(".dump")) {
-    // llvm uses this format
-    std::string jit_dump_str = string_format("jit-%d.dump", pid);
-    // this is to remove a gcc warning
-    if (jit_dump_str.size() >= PTRDIFF_MAX) {
-      return false;
-    }
-    if (file_path.ends_with(jit_dump_str)) {
+    // The string should end with: "jit-[0-9]+\\.dump"
+    // and the number should be the pid, however, in wholehost mode
+    // we don't have visibility on the namespace's PID value.
+    // So here we just check for the presence of "jit-"
+    size_t pos = file_path.rfind("jit-");
+    if (pos != std::string::npos) {
       return true;
     }
   }

--- a/src/dso.cc
+++ b/src/dso.cc
@@ -10,6 +10,7 @@
 #include "logger.hpp"
 #include "string_format.hpp"
 
+#include <algorithm>
 #include <string_view>
 
 namespace ddprof {
@@ -80,15 +81,6 @@ Dso::Dso(pid_t pid, ElfAddress_t start, ElfAddress_t end, ElfAddress_t pgoff,
   }
 }
 
-bool is_digits(std::string_view str) {
-  for (char ch : str) {
-    if (!isdigit(ch)) {
-      return false;
-    }
-  }
-  return true;
-}
-
 // The string should end with: "jit-[0-9]+\\.dump"
 // and the number should be the pid, however, in wholehost mode
 // we don't have visibility on the namespace's PID value.
@@ -105,7 +97,9 @@ bool Dso::is_jit_dump_str(std::string_view file_path, pid_t pid) {
   if (!file_path.starts_with(prefix))
     return false;
   file_path = file_path.substr(prefix.size());
-  return is_digits(file_path);
+  return std::all_of(file_path.begin(), file_path.end(), [](char c) {
+    return std::isdigit(static_cast<unsigned char>(c));
+  });
 }
 
 std::string Dso::to_string() const {

--- a/src/jit/jitdump.cc
+++ b/src/jit/jitdump.cc
@@ -30,13 +30,14 @@ DDRes jit_read_header(std::ifstream &file_stream, JITHeader &header) {
   if (!file_stream.read(reinterpret_cast<char *>(&header), sizeof(JITHeader))) {
     DDRES_RETURN_WARN_LOG(DD_WHAT_JIT, "incomplete jit file");
   }
+
   if (header.magic == k_header_magic) {
     // expected value (no need to swap data)
   } else if (header.magic == k_header_magic_rev) {
     // todo everything should be swapped throughout the parsing (not handled)
     DDRES_RETURN_WARN_LOG(DD_WHAT_JIT, "Swap data not handled");
   } else {
-    DDRES_RETURN_WARN_LOG(DD_WHAT_JIT, "Unknown jit format");
+    DDRES_RETURN_WARN_LOG(DD_WHAT_JIT, "Unknown jit format(%x)", header.magic);
   }
   int64_t remaining_size = header.total_size - sizeof(header);
   if (remaining_size > 0) {

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -300,6 +300,11 @@ TEST(DSOTest, dso_from_procline) {
         DsoHdr::dso_from_procline(3237589, const_cast<char *>(s_jitdump_line));
     EXPECT_EQ(jitdump_dso._type, dso::kJITDump);
   }
+  { // jitdump with a name different from PID (for wholehost)
+    Dso jitdump_dso =
+        DsoHdr::dso_from_procline(12, const_cast<char *>(s_jitdump_line));
+    EXPECT_EQ(jitdump_dso._type, dso::kJITDump);
+  }
 }
 
 // Retrieves instruction pointer

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -399,7 +399,6 @@ TEST(DSOTest, insert_jitdump) {
 }
 
 TEST(DSOTest, exe_name) {
-  LogHandle handle;
   ElfAddress_t ip = _THIS_IP_;
   DsoHdr dso_hdr;
   DsoFindRes find_res = dso_hdr.dso_find_or_backpopulate(getpid(), ip);


### PR DESCRIPTION
# What does this PR do?

In wholehost we were not considering the jitdump files. The format was required to include the PID in the name of the file. However the namespace's PID is not known in wholehost. This fix relaxes the test to just look for jit- and .dump in the name of the file.

# Motivation

A debug session with @aristotelhs 
