### PR TITLE
Improve ELF segment matching

### DIFF
--- a/include/ddprof_module_lib.hpp
+++ b/include/ddprof_module_lib.hpp
@@ -9,12 +9,53 @@
 #include "ddprof_module.hpp"
 #include "ddres_def.hpp"
 #include "dso.hpp"
+#include "dso_hdr.hpp"
 #include "dwfl_internals.hpp"
 
 namespace ddprof {
+
+// Convert elf flags to mmap prot flags
+inline uint32_t elf_flags_to_prot(Elf64_Word flags) {
+  return ((flags & PF_X) ? PROT_EXEC : 0) | ((flags & PF_R) ? PROT_READ : 0) |
+      ((flags & PF_W) ? PROT_WRITE : 0);
+}
+
+// Structure to represent both a mapping and a loadable elf segment
+struct Segment {
+  ElfAddress_t addr;
+  Offset_t offset;
+  uint64_t alignment;
+  uint32_t prot;
+};
+
+struct Mapping {
+  ElfAddress_t addr;
+  Offset_t offset;
+  uint32_t prot;
+};
+
+// Retrieve executable mappings from a Dso range
+std::vector<Mapping>
+get_executable_mappings(const DsoHdr::DsoConstRange &dsoRange);
+
+// Retrieve executable LOAD segments from a elf file
+DDRes get_executable_segments(int fd, const std::string &filepath,
+                              std::vector<Segment> &segments);
+
+struct MatchResult {
+  const Mapping *mapping;
+  const Segment *load_segment;
+  bool is_ambiguous;
+};
+
+// Find a matching mapping / load segment pair
+MatchResult find_match(std::span<const Mapping> executable_mappings,
+                       std::span<const Segment> elf_load_segments);
+
 // From a dso object (and the matching file), attach the module to the dwfl
 // object, return the associated Dwfl_Module
-DDRes report_module(Dwfl *dwfl, ProcessAddress_t pc, const Dso &dso,
+DDRes report_module(Dwfl *dwfl, ProcessAddress_t pc,
+                    const DsoHdr::DsoConstRange &dsoRange,
                     const FileInfoValue &fileInfoValue, DDProfMod &ddprof_mod);
 
 } // namespace ddprof

--- a/include/ddres_def.hpp
+++ b/include/ddres_def.hpp
@@ -21,7 +21,7 @@ typedef struct DDRes {
   union {
     // Not Enums as I could not specify size (except with gcc or c++)
     struct {
-      int16_t _what; // Type of result (define your lisqt of results)
+      int16_t _what; // Type of result (define your list of results)
       int16_t _sev;  // fatal, warn, OK...
     };
     int32_t _val;

--- a/include/ddres_list.hpp
+++ b/include/ddres_list.hpp
@@ -57,7 +57,10 @@
   X(SOCKET, "error during socket operation")                                   \
   X(TEMP_FILE, "error during temporary file creation")                         \
   X(CGROUP, "error while reading cgroup information")                          \
-  X(TSC, "failed to setup TSC")
+  X(TSC, "failed to setup TSC")                                                \
+  X(INVALID_ELF, "invalid elf file")                                           \
+  X(AMBIGUOUS_LOAD_SEGMENT, "ambiguous executable LOAD segment")               \
+  X(NO_MATCHING_LOAD_SEGMENT, "unable to find a LOAD segment matching mapping")
 
 // generic erno errors available from /usr/include/asm-generic/errno.h
 

--- a/include/defer.hpp
+++ b/include/defer.hpp
@@ -5,49 +5,24 @@
 
 #pragma once
 
-#include <utility>
+#include "scope.hpp"
 
 namespace details {
 
 struct DeferDummy {};
 
-template <typename F> class DeferHolder {
-public:
-  DeferHolder(DeferHolder &&) = default;
-  DeferHolder(const DeferHolder &) = delete;
-  DeferHolder &operator=(DeferHolder &&) = delete;
-  DeferHolder &operator=(const DeferHolder &) = delete;
-
-  template <typename T>
-  explicit DeferHolder(T &&f) : _func(std::forward<T>(f)) {}
-
-  ~DeferHolder() { reset(); }
-
-  void reset() {
-    if (_active) {
-      _func();
-      _active = false;
-    }
-  }
-
-  void release() { _active = false; }
-
-private:
-  F _func;
-  bool _active = true;
-};
-
-template <class F> DeferHolder<F> operator*(DeferDummy, F &&f) {
-  return DeferHolder<F>{std::forward<F>(f)};
+template <class F> ddprof::scope_exit<F> operator*(DeferDummy, F &&f) {
+  return ddprof::scope_exit<F>{std::forward<F>(f)};
 }
 
 } // namespace details
 
-template <class F> details::DeferHolder<F> make_defer(F &&f) {
-  return details::DeferHolder<F>{std::forward<F>(f)};
+template <class F> ddprof::scope_exit<F> make_defer(F &&f) {
+  return ddprof::scope_exit<F>{std::forward<F>(f)};
 }
 
 #define DEFER_(LINE) zz_defer##LINE
 #define DEFER(LINE) DEFER_(LINE)
 #define defer                                                                  \
-  [[gnu::unused]] const auto &DEFER(__COUNTER__) = details::DeferDummy{} *[&]()
+  [[maybe_unused]] const auto &DEFER(__COUNTER__) =                            \
+      ::details::DeferDummy{} *[&]()

--- a/include/dso.hpp
+++ b/include/dso.hpp
@@ -12,6 +12,7 @@
 
 #include <iostream>
 #include <string>
+#include <sys/mman.h>
 #include <utility>
 
 // Out of namespace to allow holding it in C object
@@ -25,7 +26,8 @@ public:
   // pid, start, end, offset, filename (copied once to avoid creating 3
   // different APIs)
   Dso(pid_t pid, ElfAddress_t start, ElfAddress_t end, ElfAddress_t pgoff = 0,
-      std::string &&filename = "", bool executable = true, inode_t inode = 0);
+      std::string &&filename = "", inode_t inode = 0,
+      uint32_t prot = PROT_EXEC);
   // copy parent and update pid
   Dso(const Dso &parent, pid_t new_pid) : Dso(parent) { _pid = new_pid; }
 
@@ -40,6 +42,8 @@ public:
   std::string to_string() const;
   std::string format_filename() const;
 
+  bool is_executable() const;
+
   // Adjust as linker can reduce size of mmap
   bool adjust_same(const Dso &o);
   size_t size() const { return _end - _start; }
@@ -50,8 +54,8 @@ public:
   ElfAddress_t _pgoff;
   std::string _filename; // path as perceived by the user
   inode_t _inode;
+  uint32_t _prot;
   dso::DsoType _type;
-  bool _executable;
   mutable FileInfoId_t _id;
 
 private:

--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -83,6 +83,7 @@ public:
 
   /* Range is assumed as [start, end) */
   using DsoRange = std::pair<DsoMapIt, DsoMapIt>;
+  using DsoConstRange = std::pair<DsoMapConstIt, DsoMapConstIt>;
   using DsoFindRes = std::pair<DsoMapConstIt, bool>;
 
   /******* MAIN APIS **********/
@@ -121,6 +122,9 @@ public:
 
   // Returns a range that points on _map.end() if nothing was found
   static DsoRange get_intersection(DsoMap &map, const Dso &dso);
+
+  // Return whole mapping range associated with the same elf file
+  DsoConstRange get_elf_range(const DsoMap &map, DsoMapConstIt it);
 
   // Helper to create a dso from a line in /proc/pid/maps
   static Dso dso_from_procline(int pid, char *line);

--- a/include/dwfl_hdr.hpp
+++ b/include/dwfl_hdr.hpp
@@ -10,6 +10,7 @@
 #include "ddprof_module.hpp"
 #include "ddres.hpp"
 #include "dso.hpp"
+#include "dso_hdr.hpp"
 #include "dwfl_internals.hpp"
 
 #include <sys/types.h>
@@ -43,8 +44,8 @@ struct DwflWrapper {
   DDProfMod *unsafe_get(FileInfoId_t file_info_id);
 
   // safe get
-  DDProfMod *register_mod(ProcessAddress_t pc, const Dso &dso,
-                          const FileInfoValue &fileInfoValue);
+  DDRes register_mod(ProcessAddress_t pc, const DsoHdr::DsoConstRange &dsoRange,
+                     const FileInfoValue &fileInfoValue, DDProfMod **mod);
 
   ~DwflWrapper();
 

--- a/include/scope.hpp
+++ b/include/scope.hpp
@@ -1,0 +1,421 @@
+/*
+ * MIT License
+
+Copyright (c) 2016/2017 Eric Niebler, slightly adapted by Peter Sommerlad
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+#pragma once
+
+#if __has_include(<experimental/scope>)
+
+#  include <experimental/scope>
+
+#  if __cpp_lib_experimental_scope >= 201902
+// if available use the STL implementation
+#    define USE_STD_EXPERIMENTAL_RESOURCE
+#  endif
+#endif
+
+#ifdef USE_STD_EXPERIMENTAL_RESOURCE
+namespace ddprof {
+using std::experimental::make_unique_resource_checked;
+using std::experimental::scope_exit;
+using std::experimental::scope_fail;
+using std::experimental::scope_success;
+using std::experimental::unique_resource;
+} // namespace ddprof
+#else
+
+#  include <exception> // for std::uncaught_exceptions
+#  include <functional>
+#  include <limits> // for maxint
+#  include <type_traits>
+#  include <utility>
+
+// modeled slightly after Andrescu's talk and article(s)
+
+namespace ddprof {
+// contribution by (c) Eric Niebler 2016, adapted by (c) 2017 Peter Sommerlad
+namespace detail {
+namespace hidden {
+
+// should this helper be standardized? // write testcase where recognizable.
+template <typename T>
+constexpr std::conditional_t<std::is_nothrow_move_assignable_v<T>, T &&,
+                             T const &>
+move_assign_if_noexcept(T &x) noexcept {
+  return std::move(x);
+}
+
+template <class T>
+constexpr typename std::conditional<!std::is_nothrow_move_constructible_v<T> &&
+                                        std::is_copy_constructible_v<T>,
+                                    const T &, T &&>::type
+move_if_noexcept(T &x) noexcept;
+
+} // namespace hidden
+template <typename T> class box {
+  [[no_unique_address]] T value;
+  explicit box(T const &t) noexcept(noexcept(T(t))) : value(t) {}
+  explicit box(T &&t) noexcept(noexcept(T(std::move_if_noexcept(t))))
+      : value(std::move_if_noexcept(t)) {}
+
+public:
+  template <typename TT, typename GG>
+    requires std::is_constructible_v<T, TT>
+  explicit box(TT &&t, GG &&guard) noexcept(noexcept(box((T &&)t)))
+      : box(std::forward<TT>(t)) {
+    guard.release();
+  }
+  box() = default;
+
+  T &get() noexcept { return value; }
+  T const &get() const noexcept { return value; }
+  T &&move() noexcept { return std::move(value); }
+  void reset(T const &t) noexcept(noexcept(value = t)) { value = t; }
+  void
+  reset(T &&t) noexcept(noexcept(value = hidden::move_assign_if_noexcept(t))) {
+    value = hidden::move_assign_if_noexcept(t);
+  }
+};
+
+template <typename T> class box<T &> {
+  std::reference_wrapper<T> value;
+
+public:
+  template <typename TT, typename GG>
+    requires std::is_convertible_v<TT, T &>
+  box(TT &&t, GG &&guard) noexcept(noexcept(static_cast<T &>((TT &&)t)))
+      : value(static_cast<T &>(t)) {
+    guard.release();
+  }
+  T &get() const noexcept { return value.get(); }
+  T &move() const noexcept { return get(); }
+  void reset(T &t) noexcept { value = std::ref(t); }
+};
+
+// new policy-based exception proof design by Eric Niebler
+struct on_exit_policy {
+  bool execute_{true};
+
+  void release() noexcept { execute_ = false; }
+
+  bool should_execute() const noexcept { return execute_; }
+};
+
+struct on_fail_policy {
+  int ec_{std::uncaught_exceptions()};
+
+  void release() noexcept { ec_ = std::numeric_limits<int>::max(); }
+
+  bool should_execute() const noexcept {
+    return ec_ < std::uncaught_exceptions();
+  }
+};
+
+struct on_success_policy {
+  int ec_{std::uncaught_exceptions()};
+
+  void release() noexcept { ec_ = -1; }
+
+  bool should_execute() const noexcept {
+    return ec_ >= std::uncaught_exceptions();
+  }
+};
+} // namespace detail
+
+template <class EF, class Policy = detail::on_exit_policy>
+class basic_scope_exit; // silence brain dead clang warning -Wmismatched-tags
+
+// PS: It would be nice if just the following would work in C++17
+// PS: however, we need a real class for template argument deduction
+// PS: and a deduction guide, because the ctors are partially instantiated
+// template<class EF>
+// using scope_exit = basic_scope_exit<EF, detail::on_exit_policy>;
+
+template <class EF>
+struct [[nodiscard]] scope_exit : basic_scope_exit<EF, detail::on_exit_policy> {
+  using basic_scope_exit<EF, detail::on_exit_policy>::basic_scope_exit;
+};
+
+template <class EF> scope_exit(EF) -> scope_exit<EF>;
+
+// template<class EF>
+// using scope_fail = basic_scope_exit<EF, detail::on_fail_policy>;
+
+template <class EF>
+struct scope_fail : basic_scope_exit<EF, detail::on_fail_policy> {
+  using basic_scope_exit<EF, detail::on_fail_policy>::basic_scope_exit;
+};
+
+template <class EF> scope_fail(EF) -> scope_fail<EF>;
+
+// template<class EF>
+// using scope_success = basic_scope_exit<EF, detail::on_success_policy>;
+
+template <class EF>
+struct scope_success : basic_scope_exit<EF, detail::on_success_policy> {
+  using basic_scope_exit<EF, detail::on_success_policy>::basic_scope_exit;
+};
+
+template <class EF> scope_success(EF) -> scope_success<EF>;
+
+namespace detail {
+// DETAIL:
+template <class Policy, class EF> auto _make_guard(EF &&ef) {
+  return basic_scope_exit<std::decay_t<EF>, Policy>(std::forward<EF>(ef));
+}
+struct _empty_scope_exit {
+  void release() const noexcept {}
+};
+
+} // namespace detail
+
+// Requires: EF is Callable
+// Requires: EF is nothrow MoveConstructible OR CopyConstructible
+template <class EF, class Policy /*= on_exit_policy*/>
+class [[nodiscard]] basic_scope_exit : Policy {
+  static_assert(std::is_invocable_v<EF>, "scope guard must be callable");
+  [[no_unique_address]] detail::box<EF> exit_function;
+
+  static auto _make_failsafe(std::true_type, const void *) {
+    return detail::_empty_scope_exit{};
+  }
+  static auto _make_failsafe(std::true_type, void (*)()) {
+    return detail::_empty_scope_exit{};
+  }
+  template <typename Fn> static auto _make_failsafe(std::false_type, Fn *fn) {
+    return basic_scope_exit<Fn &, Policy>(*fn);
+  }
+  template <typename EFP>
+  using _ctor_from =
+      std::is_constructible<detail::box<EF>, EFP, detail::_empty_scope_exit>;
+  template <typename EFP>
+  using _noexcept_ctor_from = std::bool_constant<noexcept(
+      detail::box<EF>(std::declval<EFP>(), detail::_empty_scope_exit{}))>;
+
+public:
+  template <typename EFP>
+    requires _ctor_from<EFP>::value
+  explicit basic_scope_exit(EFP &&ef) noexcept(_noexcept_ctor_from<EFP>::value)
+      : exit_function(std::forward<EFP>(ef),
+                      _make_failsafe(_noexcept_ctor_from<EFP>{}, &ef)) {}
+  basic_scope_exit(basic_scope_exit &&that) noexcept(
+      noexcept(detail::box<EF>(that.exit_function.move(), that)))
+      : Policy(that), exit_function(that.exit_function.move(), that) {}
+  ~basic_scope_exit() noexcept(noexcept(exit_function.get()())) {
+    if (this->should_execute())
+      exit_function.get()();
+  }
+  basic_scope_exit(const basic_scope_exit &) = delete;
+  basic_scope_exit &operator=(const basic_scope_exit &) = delete;
+  basic_scope_exit &operator=(basic_scope_exit &&) = delete;
+
+  using Policy::release;
+};
+
+template <class EF, class Policy>
+void swap(basic_scope_exit<EF, Policy> &,
+          basic_scope_exit<EF, Policy> &) = delete;
+
+template <typename R, typename D> class unique_resource {
+  static_assert(
+      (std::is_move_constructible_v<R> &&
+       std::is_nothrow_move_constructible_v<R>) ||
+          std::is_copy_constructible_v<R>,
+      "resource must be nothrow_move_constructible or copy_constructible");
+  static_assert(
+      (std::is_move_constructible_v<R> &&
+       std::is_nothrow_move_constructible_v<D>) ||
+          std::is_copy_constructible_v<D>,
+      "deleter must be nothrow_move_constructible or copy_constructible");
+
+  static const unique_resource
+      &this_; // never ODR used! Just for getting no_except() expr
+
+  [[no_unique_address]] detail::box<R> resource{};
+  [[no_unique_address]] detail::box<D> deleter{};
+  bool execute_on_destruction{false};
+
+  static constexpr auto is_nothrow_delete_v = std::bool_constant<noexcept(
+      std::declval<D &>()(std::declval<R &>()))>::value;
+
+public: // should be private
+  template <typename RR, typename DD>
+    requires std::is_constructible_v<detail::box<R>, RR,
+                                     detail::_empty_scope_exit> &&
+                 std::is_constructible_v<detail::box<D>, DD,
+                                         detail::_empty_scope_exit>
+  unique_resource(RR &&r, DD &&d, bool should_run) noexcept(
+      noexcept(detail::box<R>(std::forward<RR>(r), detail::_empty_scope_exit{}))
+          && noexcept(detail::box<D>(std::forward<DD>(d),
+                                     detail::_empty_scope_exit{})))
+      : resource(std::forward<RR>(r), scope_exit([&] {
+                   if (should_run)
+                     d(r);
+                 })),
+        deleter(std::forward<DD>(d), scope_exit([&, this] {
+                  if (should_run)
+                    d(get());
+                })),
+        execute_on_destruction{should_run} {}
+  // need help in making the factory a nice friend...
+  // the following two ICEs my g++ and gives compile errors about mismatche
+  // exception spec on clang7
+  //    template<typename RM, typename DM, typename S>
+  //    friend
+  //    auto make_unique_resource_checked(RM &&r, const S &invalid, DM &&d)
+  //    noexcept(noexcept(make_unique_resource(std::forward<RM>(r),
+  //    std::forward<DM>(d))));
+  // the following as well:
+  //    template<typename MR, typename MD, typename S>
+  //    friend
+  //	auto make_unique_resource_checked(MR &&r, const S &invalid, MD &&d)
+  //    noexcept(std::is_nothrow_constructible_v<std::decay_t<MR>,MR> &&
+  //    		std::is_nothrow_constructible_v<std::decay_t<MD>,MD>)
+  //    ->unique_resource<std::decay_t<MR>,std::decay_t<MD>>;
+
+public:
+  unique_resource() = default;
+
+  template <typename RR, typename DD>
+    requires std::is_constructible_v<detail::box<R>, RR,
+                                     detail::_empty_scope_exit> &&
+                 std::is_constructible_v<detail::box<D>, DD,
+                                         detail::_empty_scope_exit>
+  unique_resource(RR &&r, DD &&d) noexcept(
+      noexcept(detail::box<R>(std::forward<RR>(r), detail::_empty_scope_exit{}))
+          && noexcept(detail::box<D>(std::forward<DD>(d),
+                                     detail::_empty_scope_exit{})))
+      : resource(std::forward<RR>(r), scope_exit([&] { d(r); })),
+        deleter(std::forward<DD>(d), scope_exit([&, this] { d(get()); })),
+        execute_on_destruction{true} {}
+  unique_resource(unique_resource &&that) noexcept(
+      noexcept(detail::box<R>(that.resource.move(),
+                              detail::_empty_scope_exit{}))
+          && noexcept(detail::box<D>(that.deleter.move(),
+                                     detail::_empty_scope_exit{})))
+      : resource(that.resource.move(), detail::_empty_scope_exit{}),
+        deleter(that.deleter.move(), scope_exit([&, this] {
+                  if (that.execute_on_destruction)
+                    that.get_deleter()(get());
+                  that.release();
+                })),
+        execute_on_destruction(
+            std::exchange(that.execute_on_destruction, false)) {}
+
+  unique_resource &operator=(unique_resource &&that) noexcept(
+      is_nothrow_delete_v &&std::is_nothrow_move_assignable_v<R>
+          &&std::is_nothrow_move_assignable_v<D>) {
+    static_assert(
+        std::is_nothrow_move_assignable<R>::value ||
+            std::is_copy_assignable<R>::value,
+        "The resource must be nothrow-move assignable, or copy assignable");
+    static_assert(
+        std::is_nothrow_move_assignable<D>::value ||
+            std::is_copy_assignable<D>::value,
+        "The deleter must be nothrow-move assignable, or copy assignable");
+    if (&that != this) {
+      reset();
+      if constexpr (std::is_nothrow_move_assignable_v<detail::box<R>>)
+        if constexpr (std::is_nothrow_move_assignable_v<detail::box<D>>) {
+          resource = std::move(that.resource);
+          deleter = std::move(that.deleter);
+        } else {
+          deleter = _as_const(that.deleter);
+          resource = std::move(that.resource);
+        }
+      else if constexpr (std::is_nothrow_move_assignable_v<detail::box<D>>) {
+        resource = _as_const(that.resource);
+        deleter = std::move(that.deleter);
+      } else {
+        resource = _as_const(that.resource);
+        deleter = _as_const(that.deleter);
+      }
+      execute_on_destruction =
+          std::exchange(that.execute_on_destruction, false);
+    }
+    return *this;
+  }
+  ~unique_resource() // noexcept(is_nowthrow_delete_v) // removed deleter must
+                     // not throw
+  {
+    reset();
+  }
+
+  void reset() noexcept {
+    if (execute_on_destruction) {
+      execute_on_destruction = false;
+      get_deleter()(get());
+    }
+  }
+  template <typename RR>
+  auto reset(RR &&r) noexcept(noexcept(resource.reset(std::forward<RR>(r))))
+      -> decltype(resource.reset(std::forward<RR>(r)), void()) {
+    auto &&guard = scope_fail(
+        [&, this] { get_deleter()(r); }); // -Wunused-variable on clang
+    reset();
+    resource.reset(std::forward<RR>(r));
+    execute_on_destruction = true;
+  }
+  void release() noexcept { execute_on_destruction = false; }
+  decltype(auto) get() const noexcept { return resource.get(); }
+  decltype(auto) get_deleter() const noexcept { return deleter.get(); }
+  template <typename RR = R>
+    requires std::is_pointer_v<RR>
+  auto operator->() const
+      noexcept //(noexcept(detail::for_noexcept_on_copy_construction(this_.get())))
+      -> decltype(get()) {
+    return get();
+  }
+  template <typename RR = R>
+    requires std::is_pointer_v<RR> &&
+      (!std::is_void_v<std::remove_pointer_t<RR>>)
+  std::add_lvalue_reference_t<std::remove_pointer_t<R>>
+  operator*() const noexcept {
+    return *get();
+  }
+
+  unique_resource &operator=(const unique_resource &) = delete;
+  unique_resource(const unique_resource &) = delete;
+};
+
+template <typename R, typename D>
+unique_resource(R, D) -> unique_resource<R, D>;
+template <typename R, typename D>
+unique_resource(R, D, bool) -> unique_resource<R, D>;
+
+template <typename R, typename D, typename S>
+[[nodiscard]] auto make_unique_resource_checked(
+    R &&r, const S &invalid,
+    D &&d) noexcept(std::is_nothrow_constructible_v<std::decay_t<R>, R>
+                        &&std::is_nothrow_constructible_v<std::decay_t<D>, D>)
+    -> unique_resource<std::decay_t<R>, std::decay_t<D>> {
+  bool const mustrelease(r == invalid);
+  unique_resource resource{std::forward<R>(r), std::forward<D>(d),
+                           !mustrelease};
+  return resource;
+}
+
+// end of (c) Eric Niebler part
+} // namespace ddprof
+
+#  undef USE_STD_EXPERIMENTAL_RESOURCE
+#endif

--- a/src/ddprof_module_lib.cc
+++ b/src/ddprof_module_lib.cc
@@ -8,9 +8,7 @@
 #include "build_id.hpp"
 #include "ddres.hpp"
 #include "defer.hpp"
-#include "failed_assumption.hpp"
 #include "logger.hpp"
-#include "string_format.hpp"
 
 #include <cstring>
 #include <fcntl.h>
@@ -44,22 +42,36 @@ public:
   int _fd;
 };
 
-static bool get_elf_offsets(int fd, const std::string &filepath,
-                            Offset_t &bias_offset) {
+std::vector<Mapping>
+get_executable_mappings(const DsoHdr::DsoConstRange &dsoRange) {
+  std::vector<Mapping> exec_mappings;
+
+  for (auto it = dsoRange.first; it != dsoRange.second; ++it) {
+    const Dso &mapping = it->second;
+    if (mapping.is_executable()) {
+      exec_mappings.push_back(Mapping{.addr = mapping._start,
+                                      .offset = mapping._pgoff,
+                                      .prot = mapping._prot});
+    }
+  }
+  return exec_mappings;
+}
+
+DDRes get_executable_segments(int fd, const std::string &filepath,
+                              std::vector<Segment> &segments) {
   Elf *elf = elf_begin(fd, ELF_C_READ_MMAP, NULL);
-  if (elf == NULL) {
+  if (elf == nullptr) {
     LG_WRN("Invalid elf %s", filepath.c_str());
-    return false;
+    return ddres_error(DD_WHAT_INVALID_ELF);
   }
   defer { elf_end(elf); };
   GElf_Ehdr ehdr_mem;
   GElf_Ehdr *ehdr = gelf_getehdr(elf, &ehdr_mem);
   if (ehdr == nullptr) {
     LG_WRN("Invalid elf %s", filepath.c_str());
-    return false;
+    return ddres_error(DD_WHAT_INVALID_ELF);
   }
 
-  bool found_exec = false;
   switch (ehdr->e_type) {
   case ET_EXEC:
   case ET_CORE:
@@ -67,42 +79,128 @@ static bool get_elf_offsets(int fd, const std::string &filepath,
     size_t phnum;
     if (unlikely(elf_getphdrnum(elf, &phnum) != 0)) {
       LG_WRN("Invalid elf %s", filepath.c_str());
-      return false;
+      return ddres_error(DD_WHAT_INVALID_ELF);
     }
     for (size_t i = 0; i < phnum; ++i) {
       GElf_Phdr phdr_mem;
       GElf_Phdr *ph = gelf_getphdr(elf, i, &phdr_mem);
       if (unlikely(ph == NULL)) {
         LG_WRN("Invalid elf %s", filepath.c_str());
-        return false;
+        return ddres_error(DD_WHAT_INVALID_ELF);
       }
-      constexpr int rx = PF_X | PF_R;
-      if (ph->p_type == PT_LOAD) {
-        if ((ph->p_flags & rx) == rx) {
-          if (!found_exec) {
-            bias_offset = ph->p_vaddr - ph->p_offset;
-            found_exec = true;
-          } else {
-            report_failed_assumption(ddprof::string_format(
-                "Multiple exec LOAD segments: %s", filepath.c_str()));
-          }
-        }
+      if (ph->p_type == PT_LOAD && (ph->p_flags & PF_X)) {
+        segments.push_back(Segment{ph->p_vaddr, ph->p_offset, ph->p_align,
+                                   elf_flags_to_prot(ph->p_flags)});
       }
     }
     break;
   }
   default:
     LG_WRN("Unsupported elf type (%d) %s", ehdr->e_type, filepath.c_str());
-    return false;
+    return ddres_error(DD_WHAT_INVALID_ELF);
   }
 
-  if (!found_exec) {
-    LG_WRN("Not executable LOAD segment found in %s", filepath.c_str());
-  }
-  return found_exec;
+  return {};
 }
 
-DDRes report_module(Dwfl *dwfl, ProcessAddress_t pc, const Dso &dso,
+/** Find segment that matches mapping among segments.
+ * If several segments match, return {firs_matching_segment, true}
+ * If no segment matches, return {nullptr, false}
+ * If one segment matches, return {segment, false}
+ */
+static std::pair<const Segment *, bool>
+find_matching_segment(std::span<const Segment> segments,
+                      const Mapping &mapping) {
+  const Segment *matching_segment = nullptr;
+
+  for (const Segment &segment : segments) {
+    const auto aligned_offset = segment.offset & ~(segment.alignment - 1);
+    if (mapping.prot == segment.prot && mapping.offset == aligned_offset) {
+      if (matching_segment) {
+        // multiple matching segments
+        return {matching_segment, true};
+      }
+      matching_segment = &segment;
+    }
+  }
+  return {matching_segment, false};
+}
+
+MatchResult find_match(std::span<const Mapping> executable_mappings,
+                       std::span<const Segment> elf_load_segments) {
+  int nb_mappings = executable_mappings.size();
+
+  MatchResult res = {nullptr, nullptr, false};
+  for (int mapping_idx = nb_mappings - 1; mapping_idx >= 0; --mapping_idx) {
+    const auto &mapping = executable_mappings[mapping_idx];
+    auto [matching_segment, ambiguous] = find_matching_segment(
+        std::span{elf_load_segments}.subspan(mapping_idx), mapping);
+
+    if (matching_segment) {
+      res.load_segment = matching_segment;
+      res.mapping = &mapping;
+    }
+    if (!ambiguous) {
+      return res;
+    } else {
+      res.is_ambiguous = true;
+    }
+  }
+
+  return res;
+}
+
+static DDRes compute_elf_bias(int fd, const std::string &filepath,
+                              const DsoHdr::DsoConstRange &dsoRange,
+                              Offset_t &bias) {
+
+  // To compute elf bias, we need to match a Dso (ie. a mapping in process
+  // address space) with the coresponding LOAD segment in elf file. We consider
+  // only executable mappings LOAD segments (because we configure perf in such
+  // a way that we receive only executable mmap events).
+  // The matching is done by comparing mapping offset with aligned file offset
+  // (file offset may not be aligned, in particular with lld, but
+  // when segment is mmapped, mmap offset needs to be page aligned, file offset
+  // is rounded down to satisfy segment p_align alignment) and memory
+  // protection of segment.
+  // Several segments can have the same aligned offsets and protections though,
+  // thus making the matching ambiguous.
+  // Any mapping can be used for matching, but some mappings might be missing
+  // because of lost perf events. We start with the last mapping in address
+  // order, because it is the one that has the most constraints: if we observed
+  // n executable mappings, then we know that the last mapping is preceded by at
+  // least n-1 other exec mappings and therefore cannot match the first n-1 LOAD
+  // exec segments. If last mapping leads to an ambiguous match, we try again
+  // with the second to last mapping and so on...
+
+  // todo: use small/inlined vector
+  std::vector<Segment> elf_segments;
+  auto res = get_executable_segments(fd, filepath, elf_segments);
+  if (!IsDDResOK(res)) {
+    return res;
+  }
+
+  auto executable_mappings = get_executable_mappings(dsoRange);
+  MatchResult match_result = find_match(executable_mappings, elf_segments);
+
+  if (match_result.is_ambiguous) {
+    LG_WRN("Multiple matching segments: %s", filepath.c_str());
+    return ddres_error(DD_WHAT_AMBIGUOUS_LOAD_SEGMENT);
+  }
+  if (!match_result.load_segment || !match_result.mapping) {
+    LG_WRN("Not matching LOAD segment found in %s", filepath.c_str());
+    return ddres_error(DD_WHAT_NO_MATCHING_LOAD_SEGMENT);
+  }
+
+  auto &mapping = *match_result.mapping;
+  auto &segment = *match_result.load_segment;
+  bias = mapping.addr - mapping.offset - (segment.addr - segment.offset);
+
+  return {};
+}
+
+DDRes report_module(Dwfl *dwfl, ProcessAddress_t pc,
+                    const DsoHdr::DsoConstRange &dsoRange,
                     const FileInfoValue &fileInfoValue, DDProfMod &ddprof_mod) {
   const std::string &filepath = fileInfoValue.get_path();
   const char *module_name = strrchr(filepath.c_str(), '/') + 1;
@@ -120,8 +218,8 @@ DDRes report_module(Dwfl *dwfl, ProcessAddress_t pc, const Dso &dso,
     dwfl_module_info(mod, nullptr, &low_addr, &high_addr, 0, 0, &main_name, 0);
     LG_NTC("Incoherent modules[PID=%d]: module %s [%lx-%lx] is already "
            "loaded at %lx(%s[ID#%d])",
-           dso._pid, main_name, low_addr, high_addr, pc, filepath.c_str(),
-           fileInfoValue.get_id());
+           dsoRange.first->second._pid, main_name, low_addr, high_addr, pc,
+           filepath.c_str(), fileInfoValue.get_id());
     ddprof_mod._status = DDProfMod::kInconsistent;
     return ddres_warn(DD_WHAT_MODULE);
   }
@@ -131,15 +229,15 @@ DDRes report_module(Dwfl *dwfl, ProcessAddress_t pc, const Dso &dso,
 
   // Load the file at a matching DSO address
   dwfl_errno(); // erase previous error
-  Offset_t bias_offset{};
-  if (!get_elf_offsets(fd_holder._fd, filepath, bias_offset)) {
+  Offset_t bias = 0;
+  auto res = compute_elf_bias(fd_holder._fd, filepath, dsoRange, bias);
+  if (!IsDDResOK(res)) {
     fileInfoValue._errored = true;
     LG_WRN("Couldn't retrieve offsets from %s(%s)", module_name,
            fileInfoValue.get_path().c_str());
-    return ddres_warn(DD_WHAT_MODULE);
+    return res;
   }
 
-  Offset_t bias = dso._start - dso._pgoff - bias_offset;
   ddprof_mod._mod = dwfl_report_elf(dwfl, module_name, filepath.c_str(),
                                     fd_holder._fd, bias, true);
 
@@ -172,7 +270,7 @@ DDRes report_module(Dwfl *dwfl, ProcessAddress_t pc, const Dso &dso,
            ddprof_mod._build_id.c_str());
   }
   ddprof_mod._sym_bias = bias;
-  return ddres_init();
+  return {};
 }
 
 } // namespace ddprof

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -531,11 +531,12 @@ DDRes ddprof_worker_cycle(DDProfContext &ctx, int64_t now,
 
 void ddprof_pr_mmap(DDProfContext &ctx, const perf_event_mmap2 *map,
                     int watcher_pos) {
-  LG_DBG("<%d>(MAP)%d: %s (%lx/%lx/%lx) %02u:%02u %lu", watcher_pos, map->pid,
-         map->filename, map->addr, map->len, map->pgoff, map->maj, map->min,
-         map->ino);
+  LG_DBG("<%d>(MAP)%d: %s (%lx/%lx/%lx) %c%c%c %02u:%02u %lu", watcher_pos,
+         map->pid, map->filename, map->addr, map->len, map->pgoff,
+         map->prot & PROT_READ ? 'r' : '-', map->prot & PROT_WRITE ? 'w' : '-',
+         map->prot & PROT_EXEC ? 'x' : '-', map->maj, map->min, map->ino);
   ddprof::Dso new_dso(map->pid, map->addr, map->addr + map->len - 1, map->pgoff,
-                      std::string(map->filename), true, map->ino);
+                      std::string(map->filename), map->ino, map->prot);
   ctx.worker_ctx.us->dso_hdr.insert_erase_overlap(std::move(new_dso));
 }
 

--- a/src/dwfl_hdr.cc
+++ b/src/dwfl_hdr.cc
@@ -68,17 +68,22 @@ DDProfMod *DwflWrapper::unsafe_get(FileInfoId_t file_info_id) {
   return &it->second;
 }
 
-DDProfMod *DwflWrapper::register_mod(ProcessAddress_t pc, const Dso &dso,
-                                     const FileInfoValue &fileInfoValue) {
+DDRes DwflWrapper::register_mod(ProcessAddress_t pc,
+                                const DsoHdr::DsoConstRange &dsoRange,
+                                const FileInfoValue &fileInfoValue,
+                                DDProfMod **mod) {
 
   DDProfMod new_mod;
-  DDRes res = report_module(_dwfl, pc, dso, fileInfoValue, new_mod);
+  DDRes res = report_module(_dwfl, pc, dsoRange, fileInfoValue, new_mod);
   _inconsistent = new_mod._status == DDProfMod::kInconsistent;
+
   if (IsDDResNotOK(res)) {
-    return nullptr;
+    *mod = nullptr;
+    return res;
   }
-  return &_ddprof_mods.insert_or_assign(fileInfoValue.get_id(), new_mod)
+  *mod = &_ddprof_mods.insert_or_assign(fileInfoValue.get_id(), new_mod)
               .first->second;
+  return res;
 }
 
 std::vector<pid_t> DwflHdr::get_unvisited() const {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -444,3 +444,6 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_exe(deep_stacks deep_stacks.cc)
+
+add_unit_test(ddprof_module_lib-ut ddprof_module_lib-ut.cc ../src/ddprof_module_lib.cc
+              ../src/build_id.cc ../src/dso.cc LIBRARIES ${ELFUTILS_LIBRARIES})

--- a/test/ddprof_module_lib-ut.cc
+++ b/test/ddprof_module_lib-ut.cc
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include "ddprof_module_lib.hpp"
+
+#include <gtest/gtest.h>
+
+namespace ddprof {
+Segment segment(Offset_t offset, uint32_t prot = PROT_EXEC | PROT_READ) {
+  return {.addr = 0, .offset = offset, .alignment = 0x1000, .prot = prot};
+}
+
+Mapping mapping(Offset_t offset, uint32_t prot = PROT_EXEC | PROT_READ) {
+  return {.addr = 0, .offset = offset, .prot = prot};
+}
+
+TEST(ddprof_module_lib, empty) {
+  auto res = find_match({}, {});
+  ASSERT_EQ(res.load_segment, nullptr);
+  ASSERT_EQ(res.mapping, nullptr);
+  ASSERT_FALSE(res.is_ambiguous);
+}
+
+TEST(ddprof_module_lib, empty_segments) {
+  Mapping mappings[] = {mapping(0)};
+  auto res = find_match(mappings, {});
+  ASSERT_EQ(res.load_segment, nullptr);
+  ASSERT_EQ(res.mapping, nullptr);
+  ASSERT_FALSE(res.is_ambiguous);
+}
+
+TEST(ddprof_module_lib, empty_mappings) {
+  Segment segments[] = {segment(0x128)};
+  auto res = find_match({}, segments);
+  ASSERT_EQ(res.load_segment, nullptr);
+  ASSERT_EQ(res.mapping, nullptr);
+  ASSERT_FALSE(res.is_ambiguous);
+}
+
+TEST(ddprof_module_lib, simple) {
+  Mapping mappings[] = {mapping(0)};
+  Segment segments[] = {segment(0x128)};
+  auto res = find_match(mappings, segments);
+  ASSERT_EQ(res.load_segment, &segments[0]);
+  ASSERT_EQ(res.mapping, &mappings[0]);
+  ASSERT_FALSE(res.is_ambiguous);
+}
+
+TEST(ddprof_module_lib, simple2) {
+  Mapping mappings[] = {mapping(0)};
+  Segment segments[] = {segment(0, PROT_EXEC)};
+  auto res = find_match(mappings, segments);
+  ASSERT_EQ(res.load_segment, nullptr);
+  ASSERT_EQ(res.mapping, nullptr);
+  ASSERT_FALSE(res.is_ambiguous);
+}
+
+TEST(ddprof_module_lib, ambiguous) {
+  Mapping mappings[] = {mapping(0)};
+  Segment segments[] = {segment(0x128), segment(0x201)};
+  auto res = find_match(mappings, segments);
+  ASSERT_EQ(res.load_segment, &segments[0]);
+  ASSERT_EQ(res.mapping, &mappings[0]);
+  ASSERT_TRUE(res.is_ambiguous);
+}
+
+TEST(ddprof_module_lib, complex) {
+  Mapping mappings[] = {mapping(0x1000), mapping(0x5000)};
+  Segment segments[] = {segment(0x1100, PROT_EXEC), segment(0x1200),
+                        segment(0x5128), segment(0x5457)};
+  auto res = find_match(mappings, segments);
+  ASSERT_EQ(res.load_segment, &segments[1]);
+  ASSERT_EQ(res.mapping, &mappings[0]);
+  ASSERT_TRUE(res.is_ambiguous);
+}
+
+} // namespace ddprof

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -87,7 +87,7 @@ TEST(DSOTest, is_within) {
   DsoFindRes find_res = dso_hdr.dso_find_closest(10, 1300);
   EXPECT_TRUE(find_res.second);
   std::string dso_str = find_res.first->second.to_string();
-  EXPECT_EQ(dso_str, "PID[10] 3e8-5db 0 (bar.so.1)(T-Standard)(x)(ID#-1)");
+  EXPECT_EQ(dso_str, "PID[10] 3e8-5db 0 (bar.so.1)(T-Standard)(--x)(ID#-1)");
   DsoHdr::DsoFindRes not_found = dso_hdr.find_res_not_found(10);
   ASSERT_FALSE(find_res == not_found);
   EXPECT_EQ(find_res.first->second._pid, 10);
@@ -230,7 +230,7 @@ TEST(DSOTest, dso_from_procline) {
   Dso no_exec =
       DsoHdr::dso_from_procline(10, const_cast<char *>(s_line_noexec));
   EXPECT_EQ(no_exec._type, dso::kStandard);
-  EXPECT_EQ(no_exec._executable, false);
+  EXPECT_EQ(no_exec._prot, PROT_READ);
   EXPECT_EQ(no_exec._pid, 10);
   Dso standard_dso =
       DsoHdr::dso_from_procline(10, const_cast<char *>(s_exec_line));

--- a/test/dwfl_module-ut.cc
+++ b/test/dwfl_module-ut.cc
@@ -57,7 +57,7 @@ TEST(DwflModule, inconsistency_test) {
 
     for (auto it = dso_map.begin(); it != dso_map.end(); ++it) {
       Dso &dso = it->second;
-      if (!dso::has_relevant_path(dso._type) || !dso._executable) {
+      if (!dso::has_relevant_path(dso._type) || !dso.is_executable()) {
         continue; // skip non exec / non standard (anon/vdso...)
       }
 
@@ -66,23 +66,25 @@ TEST(DwflModule, inconsistency_test) {
 
       const FileInfoValue &file_info_value =
           dso_hdr.get_file_info_value(file_info_id);
-      DDProfMod *ddprof_mod =
-          dwfl_wrapper.register_mod(dso._start, dso, file_info_value);
+      DDProfMod *ddprof_mod = nullptr;
+      auto res = dwfl_wrapper.register_mod(dso._start,
+                                           dso_hdr.get_elf_range(dso_map, it),
+                                           file_info_value, &ddprof_mod);
+
+      ASSERT_TRUE(IsDDResOK(res));
       ASSERT_TRUE(ddprof_mod->_mod);
       if (find_res.first == it) {
         Symbol symbol;
         GElf_Sym elf_sym;
         Offset_t lbiais;
-        bool res =
-            symbol_get_from_dwfl(ddprof_mod->_mod, ip, symbol, elf_sym, lbiais);
-        EXPECT_TRUE(res);
+        EXPECT_TRUE(symbol_get_from_dwfl(ddprof_mod->_mod, ip, symbol, elf_sym,
+                                         lbiais));
         EXPECT_EQ("ddprof::DwflModule_inconsistency_test_Test::TestBody()",
                   symbol._demangle_name);
         EXPECT_EQ(lbiais, ddprof_mod->_sym_bias);
         FileAddress_t elf_addr = ip - ddprof_mod->_sym_bias;
         FileAddress_t start_sym, end_sym = {};
-        res = compute_elf_range(elf_addr, elf_sym, start_sym, end_sym);
-        EXPECT_TRUE(res);
+        EXPECT_TRUE(compute_elf_range(elf_addr, elf_sym, start_sym, end_sym));
         printf("Start --> 0x%lx - end %lx - lbiais 0x%lx <--\n", start_sym,
                end_sym, lbiais);
         EXPECT_GE(elf_addr, start_sym);
@@ -126,7 +128,7 @@ TEST(DwflModule, short_lived) {
 
     for (auto it = dso_map.begin(); it != dso_map.end(); ++it) {
       Dso &dso = it->second;
-      if (!dso::has_relevant_path(dso._type) || !dso._executable) {
+      if (!dso::has_relevant_path(dso._type) || !dso.is_executable()) {
         continue; // skip non exec / non standard (anon/vdso...)
       }
 
@@ -135,8 +137,11 @@ TEST(DwflModule, short_lived) {
 
       const FileInfoValue &file_info_value =
           dso_hdr.get_file_info_value(file_info_id);
-      DDProfMod *ddprof_mod =
-          dwfl_wrapper.register_mod(dso._start, dso, file_info_value);
+      DDProfMod *ddprof_mod = nullptr;
+      auto res = dwfl_wrapper.register_mod(dso._start,
+                                           dso_hdr.get_elf_range(dso_map, it),
+                                           file_info_value, &ddprof_mod);
+      ASSERT_TRUE(IsDDResOK(res));
       ASSERT_TRUE(ddprof_mod->_mod);
     }
   }
@@ -159,7 +164,7 @@ TEST(DwflModule, short_lived) {
 
     for (auto it = dso_map.begin(); it != dso_map.end(); ++it) {
       Dso &dso = it->second;
-      if (!dso::has_relevant_path(dso._type) || !dso._executable) {
+      if (!dso::has_relevant_path(dso._type) || !dso.is_executable()) {
         continue; // skip non exec / non standard (anon/vdso...)
       }
 
@@ -168,8 +173,11 @@ TEST(DwflModule, short_lived) {
 
       const FileInfoValue &file_info_value =
           dso_hdr.get_file_info_value(file_info_id);
-      DDProfMod *ddprof_mod =
-          dwfl_wrapper.register_mod(dso._start, dso, file_info_value);
+      DDProfMod *ddprof_mod = nullptr;
+      auto res = dwfl_wrapper.register_mod(dso._start,
+                                           dso_hdr.get_elf_range(dso_map, it),
+                                           file_info_value, &ddprof_mod);
+      ASSERT_TRUE(IsDDResOK(res));
       ASSERT_TRUE(ddprof_mod->_mod);
     }
   }


### PR DESCRIPTION
# What does this PR do?
To compute elf bias, we need to match a Dso (ie. a mapping in process address space) with the coresponding LOAD segment in elf file.
Before this change, we would use the Dso containing the address we want to unwind, and make the assumption that an elf file contains only one LOAD executable segment, and therefore that the matching segment would be the unique executable LOAD segment of the elf file.
This assumption turns out to be wrong: an elf file can contain multiple LOAD executable segments.
With this change, we use all the executable mappings of the elf file and try to match them with LOAD segments by using the aligned offset and the permissions of the mappings.
We consider only executable mappings LOAD segments (because we configure perf in such a way that we receive only executable mmap events).
The matching is done by comparing mapping offset with aligned file offset (file offset may not be aligned, in particular with lld, but when segment is mmapped, mmap offset needs to be page aligned, file offset is rounded down to satisfy segment p_align alignment) and memory protection of segment.
Several segments can have the same aligned offsets and protections though, thus making the matching ambiguous.
Any mapping can be used for matching, but some mappings might be missing because of lost perf events. We start with the last mapping in address order, because it is the one that has the most constraints: if we observed n executable mappings, then we know that the last mapping is preceded by at least n-1 other exec mappings and therefore cannot match the first n-1 LOAD exec segments. If last mapping leads to an ambiguous match, we try again with the second to last mapping and so on...

## Other changes:
* add an implementation of `std::unique_resource`/`std::scope_exit` (only available with gcc 13 currently) from [here](https://github.com/PeterSommerlad/SC22WG21_Papers/tree/master/workspace/P0052_scope_exit)
* reimplement defer on top of `scope_exit`