### PR TITLE
Add support for dynamically linked jemalloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ if(ON)
 endif()
 
 if("${DDPROF_ALLOCATOR}" STREQUAL "JEMALLOC")
-  list(PREPEND DDPROF_LIBRARY_LIST ${JEMALLOC_LIBRARIES})
+  list(PREPEND DDPROF_LIBRARY_LIST JeMalloc::JeMalloc)
 endif()
 
 # libcap, can be removed from version distributed to client
@@ -174,6 +174,7 @@ if(USE_LOADER)
   set_target_properties(dd_loader PROPERTIES LINK_DEPENDS "${dd_profiling_linker_script}")
   target_link_options(dd_loader PRIVATE "LINKER:--version-script=${dd_profiling_linker_script}")
   target_static_libcxx(dd_loader)
+  target_static_sanitizer(dd_loader)
 
   if(BUILD_UNIVERSAL_DDPROF)
     target_link_options(dd_loader PRIVATE "-nolibc")
@@ -232,6 +233,7 @@ set_target_properties(dd_profiling-embedded
 
 # Link libstdc++/libgcc statically and export only profiler API
 target_static_libcxx(dd_profiling-embedded)
+target_static_sanitizer(dd_profiling-embedded)
 set_target_properties(dd_profiling-embedded PROPERTIES LINK_DEPENDS "${dd_profiling_linker_script}")
 target_link_options(dd_profiling-embedded PRIVATE
                     "LINKER:--version-script=${dd_profiling_linker_script}")
@@ -288,6 +290,7 @@ endif()
 
 target_include_directories(ddprof PRIVATE ${DDPROF_INCLUDE_LIST})
 target_static_libcxx(ddprof)
+target_static_sanitizer(ddprof)
 if(BUILD_UNIVERSAL_DDPROF)
   target_static_libc(ddprof)
 endif()
@@ -359,6 +362,7 @@ else()
 endif()
 
 target_static_libcxx(dd_profiling-shared)
+target_static_sanitizer(dd_profiling-shared)
 set_target_properties(dd_profiling-shared PROPERTIES LINK_DEPENDS "${dd_profiling_linker_script}")
 target_link_options(dd_profiling-shared PRIVATE
                     "LINKER:--version-script=${dd_profiling_linker_script}")

--- a/cmake/ExtendBuildTypes.cmake
+++ b/cmake/ExtendBuildTypes.cmake
@@ -19,7 +19,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wshadow=local)
   endif()
 else()
-  add_compile_options(-Wshadow -Wno-c99-designator)
+  add_compile_options(-Wshadow -Wno-c99-designator -fsized-deallocation)
 endif()
 
 set(SAN_FLAGS "-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize-recover")
@@ -42,12 +42,6 @@ set(CMAKE_CXX_FLAGS_SANITIZEDDEBUG
 set(CMAKE_C_FLAGS_SANITIZEDDEBUG
     "${SAN_FLAGS} ${ASAN_FLAGS} ${STACK_FLAGS}"
     CACHE STRING "Flags used by the C compiler during sanitized builds." FORCE)
-set(CMAKE_EXE_LINKER_FLAGS_SANITIZEDDEBUG
-    ""
-    CACHE STRING "Flags used for linking binaries during sanitized builds." FORCE)
-set(CMAKE_SHARED_LINKER_FLAGS_SANITIZEDDEBUG
-    ""
-    CACHE STRING "Flags used by the shared libraries linker during sanitized builds." FORCE)
 
 # Add flags for thread-sanized debu
 set(CMAKE_CXX_FLAGS_THREADSANITIZEDDEBUG
@@ -56,26 +50,18 @@ set(CMAKE_CXX_FLAGS_THREADSANITIZEDDEBUG
 set(CMAKE_C_FLAGS_THREADSANITIZEDDEBUG
     "${SAN_FLAGS} ${TSAN_FLAGS} ${STACK_FLAGS}"
     CACHE STRING "Flags used by the C compiler during sanitized builds." FORCE)
-set(CMAKE_EXE_LINKER_FLAGS_THREADSANITIZEDDEBUG
-    ""
-    CACHE STRING "Flags used for linking binaries during sanitized builds." FORCE)
-set(CMAKE_SHARED_LINKER_FLAGS_THREADSANITIZEDDEBUG
-    ""
-    CACHE STRING "Flags used by the shared libraries linker during sanitized builds." FORCE)
 
-string(REPLACE ";" " " LD_FLAGS_STR "${LD_FLAGS}")
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  execute_process(
+    COMMAND ${CMAKE_CXX_COMPILER} --print-runtime-dir
+    OUTPUT_VARIABLE LLVM_RUNTIME_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY)
   # In clang static link is the default lsan is combined with asan CMake: Avoid usage of list to
   # make sure we have spaces (not ;) static ubsan is giving link errors : to be investigated
   set(CMAKE_EXE_LINKER_FLAGS_SANITIZEDDEBUG
-      "${CMAKE_EXE_LINKER_FLAGS_SANITIZEDDEBUG} -static-libasan -static-libubsan")
+      "${CMAKE_EXE_LINKER_FLAGS_SANITIZEDDEBUG} -shared-libsan -Wl,-rpath,${LLVM_RUNTIME_DIR}")
   set(CMAKE_SHARED_LINKER_FLAGS_SANITIZEDDEBUG
-      "${CMAKE_SHARED_LINKER_FLAGS_SANITIZEDDEBUG} -static-libasan -static-libubsan")
-  set(CMAKE_EXE_LINKER_FLAGS_THREADSANITIZEDDEBUG
-      "${CMAKE_EXE_LINKER_FLAGS_THREADSANITIZEDDEBUG} -static-libtsan -static-libubsan")
-  set(CMAKE_SHARED_LINKER_FLAGS_THREADSANITIZEDDEBUG
-      "${CMAKE_SHARED_LINKER_FLAGS_THREADSANITIZEDDEBUG} -static-libtsan -static-libubsan")
+      "${CMAKE_SHARED_LINKER_FLAGS_SANITIZEDDEBUG} -shared-libsan -Wl,-rpath,${LLVM_RUNTIME_DIR}")
 endif()
 
 mark_as_advanced(

--- a/cmake/Helperfunc.cmake
+++ b/cmake/Helperfunc.cmake
@@ -55,6 +55,17 @@ function(target_static_libc target)
   target_link_options(${target} PRIVATE "-static")
 endfunction()
 
+function(target_static_sanitizer target)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    target_link_options(${target} PRIVATE $<$<CONFIG:SanitizedDebug>:-static-libsan>)
+  else()
+    target_link_options(${target} PRIVATE $<$<CONFIG:SanitizedDebug>:-static-libasan
+                        -static-libubsan>)
+    target_link_options(${target} PRIVATE $<$<CONFIG:ThreadSanitizedDebug>:-static-libtsan
+                        -static-libubsan>)
+  endif()
+endfunction()
+
 function(detect_libc output_variable)
   file(WRITE "${CMAKE_BINARY_DIR}/temp.c" "int main() {}")
   try_compile(

--- a/cmake/Jemalloc.cmake
+++ b/cmake/Jemalloc.cmake
@@ -51,7 +51,7 @@ mark_as_advanced(
     JEMALLOC_LIBRARIES
     JEMALLOC_INCLUDE_DIR
 )
-if(JeMalloc_FOUND AND NOT (TARGET JeMalloc::JeMalloc))
+if(JeMalloc_FOUND)
    add_library(JeMalloc::JeMalloc STATIC IMPORTED)
    set_target_properties(JeMalloc::JeMalloc PROPERTIES
    INTERFACE_INCLUDE_DIRECTORIES "${JEMALLOC_INCLUDE_DIR}"

--- a/cmake/Jemalloc.cmake
+++ b/cmake/Jemalloc.cmake
@@ -29,6 +29,11 @@ find_library(JEMALLOC_LIBRARIES
     HINTS ${JEMALLOC_ROOT_DIR}/lib
 )
 
+find_library(JEMALLOC_SHARED_LIBRARIES
+    NAMES libjemalloc.so
+    HINTS ${JEMALLOC_ROOT_DIR}/lib
+)
+
 find_path(JEMALLOC_INCLUDE_DIR
     NAMES jemalloc/jemalloc.h
     HINTS ${JEMALLOC_ROOT_DIR}/include
@@ -37,6 +42,7 @@ find_path(JEMALLOC_INCLUDE_DIR
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(JeMalloc DEFAULT_MSG
     JEMALLOC_LIBRARIES
+    JEMALLOC_SHARED_LIBRARIES
     JEMALLOC_INCLUDE_DIR
 )
 
@@ -45,4 +51,17 @@ mark_as_advanced(
     JEMALLOC_LIBRARIES
     JEMALLOC_INCLUDE_DIR
 )
+if(JeMalloc_FOUND AND NOT (TARGET JeMalloc::JeMalloc))
+   add_library(JeMalloc::JeMalloc STATIC IMPORTED)
+   set_target_properties(JeMalloc::JeMalloc PROPERTIES
+   INTERFACE_INCLUDE_DIRECTORIES "${JEMALLOC_INCLUDE_DIR}"
+   IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+   IMPORTED_LOCATION "${JEMALLOC_LIBRARIES}")
+
+   add_library(JeMalloc::JeMallocShared SHARED IMPORTED)
+   set_target_properties(JeMalloc::JeMallocShared PROPERTIES
+   INTERFACE_INCLUDE_DIRECTORIES "${JEMALLOC_INCLUDE_DIR}"
+   IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+   IMPORTED_LOCATION "${JEMALLOC_SHARED_LIBRARIES}")
+endif()
 # cmake-format: on

--- a/include/lib/allocation_tracker_tls.hpp
+++ b/include/lib/allocation_tracker_tls.hpp
@@ -19,9 +19,10 @@ struct TrackerThreadLocalState {
 
   pid_t tid; // cache of tid
 
-  bool reentry_guard;         // prevent reentry in AllocationTracker (eg. when
-                              // allocation are done inside AllocationTracker)
-  bool double_tracking_guard; // prevent mmap tracking within a malloc
+  bool reentry_guard; // prevent reentry in AllocationTracker (eg. when
+                      // allocation are done inside AllocationTracker) and
+                      // double counting of allocations (eg. when new calls
+                      // malloc, or malloc calls mmap internally)
 };
 
 } // namespace ddprof

--- a/include/lib/reentry_guard.hpp
+++ b/include/lib/reentry_guard.hpp
@@ -26,7 +26,7 @@ public:
 class TLReentryGuard {
 public:
   explicit TLReentryGuard(ThreadEntries &entries, pid_t tid)
-      : _entries(entries), _tid(tid), _ok(false), _index(-1) {
+      : _entries(entries), _ok(false), _index(-1) {
     while (true) {
       for (size_t i = 0; i < ThreadEntries::max_threads; ++i) {
         pid_t expected = -1;
@@ -59,7 +59,6 @@ public:
 
 private:
   ThreadEntries &_entries;
-  pid_t _tid;
   bool _ok;
   int _index;
 };

--- a/include/ringbuffer_utils.hpp
+++ b/include/ringbuffer_utils.hpp
@@ -296,6 +296,7 @@ public:
     return {reinterpret_cast<std::byte *>(hdr + 1), sz};
   }
 
+  // Update ring buffer reader pos (usually done by destructor)
   void advance() {
     _initial_tail = _tail;
     __atomic_store_n(_rb.reader_pos, _initial_tail, __ATOMIC_RELEASE);

--- a/src/lib/savecontext.cc
+++ b/src/lib/savecontext.cc
@@ -35,8 +35,8 @@ DDPROF_NOINLINE std::span<const std::byte> retrieve_stack_bounds() {
 
 // Disable address sanitizer, otherwise it will report a stack-buffer-underflow
 // when we are grabbing the stack. But this is not enough, because ASAN
-// intercepts memcpy and reports a satck underflow there, empirically it appears
-// that both attribute and a suppression are required.
+// intercepts memcpy and reports a stack underflow there, empirically it appears
+// that both attributes and a suppression are required.
 static DDPROF_NO_SANITIZER_ADDRESS size_t
 save_stack(std::span<const std::byte> stack_bounds, const std::byte *stack_ptr,
            std::span<std::byte> buffer) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -251,52 +251,63 @@ add_unit_test(
   LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle
   DEFINITIONS MYNAME="savecontext-ut")
 
+set(ALLOCATION_TRACKER_UT_SRCS
+    allocation_tracker-ut.cc
+    ../src/lib/allocation_tracker.cc
+    ../src/lib/elfutils.cc
+    ../src/lib/symbol_overrides.cc
+    ../src/base_frame_symbol_lookup.cc
+    ../src/build_id.cc
+    ../src/container_id.cc
+    ../src/common_mapinfo_lookup.cc
+    ../src/common_symbol_lookup.cc
+    ../src/ddprof_cmdline.cc
+    ../src/ddprof_process.cc
+    ../src/ddprof_stats.cc
+    ../src/dso.cc
+    ../src/dso_hdr.cc
+    ../src/dso_symbol_lookup.cc
+    ../src/dwfl_hdr.cc
+    ../src/ddprof_module_lib.cc
+    ../src/dwfl_symbol.cc
+    ../src/dwfl_symbol_lookup.cc
+    ../src/dwfl_thread_callbacks.cc
+    ../src/demangler/demangler.cc
+    ../src/jit/jitdump.cc
+    ../src/failed_assumption.cc
+    ../src/pevent_lib.cc
+    ../src/perf.cc
+    ../src/perf_ringbuffer.cc
+    ../src/perf_watcher.cc
+    ../src/ringbuffer_utils.cc
+    ../src/lib/pthread_fixes.cc
+    ../src/lib/savecontext.cc
+    ../src/lib/saveregisters.cc
+    ../src/mapinfo_lookup.cc
+    ../src/procutils.cc
+    ../src/runtime_symbol_lookup.cc
+    ../src/symbol_map.cc
+    ../src/signal_helper.cc
+    ../src/statsd.cc
+    ../src/sys_utils.cc
+    ../src/tracepoint_config.cc
+    ../src/user_override.cc
+    ../src/unwind.cc
+    ../src/unwind_dwfl.cc
+    ../src/unwind_helpers.cc
+    ../src/unwind_metrics.cc)
+
 add_unit_test(
-  allocation_tracker-ut
-  allocation_tracker-ut.cc
-  ../src/lib/allocation_tracker.cc
-  ../src/base_frame_symbol_lookup.cc
-  ../src/build_id.cc
-  ../src/container_id.cc
-  ../src/common_mapinfo_lookup.cc
-  ../src/common_symbol_lookup.cc
-  ../src/ddprof_cmdline.cc
-  ../src/ddprof_process.cc
-  ../src/ddprof_stats.cc
-  ../src/dso.cc
-  ../src/dso_hdr.cc
-  ../src/dso_symbol_lookup.cc
-  ../src/dwfl_hdr.cc
-  ../src/ddprof_module_lib.cc
-  ../src/dwfl_symbol.cc
-  ../src/dwfl_symbol_lookup.cc
-  ../src/dwfl_thread_callbacks.cc
-  ../src/demangler/demangler.cc
-  ../src/jit/jitdump.cc
-  ../src/failed_assumption.cc
-  ../src/pevent_lib.cc
-  ../src/perf.cc
-  ../src/perf_ringbuffer.cc
-  ../src/perf_watcher.cc
-  ../src/ringbuffer_utils.cc
-  ../src/lib/pthread_fixes.cc
-  ../src/lib/savecontext.cc
-  ../src/lib/saveregisters.cc
-  ../src/mapinfo_lookup.cc
-  ../src/procutils.cc
-  ../src/runtime_symbol_lookup.cc
-  ../src/symbol_map.cc
-  ../src/signal_helper.cc
-  ../src/statsd.cc
-  ../src/sys_utils.cc
-  ../src/tracepoint_config.cc
-  ../src/user_override.cc
-  ../src/unwind.cc
-  ../src/unwind_dwfl.cc
-  ../src/unwind_helpers.cc
-  ../src/unwind_metrics.cc
-  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle DDProf::Parser
+  allocation_tracker-ut ${ALLOCATION_TRACKER_UT_SRCS}
+  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle DDProf::Parser dl rt
   DEFINITIONS ${DDPROF_DEFINITION_LIST} KMAX_TRACKED_ALLOCATIONS=100)
+
+if(TARGET JeMalloc::JeMalloc)
+  add_unit_test(
+    allocation_tracker_jemalloc-ut ${ALLOCATION_TRACKER_UT_SRCS}
+    LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle DDProf::Parser dl rt JeMalloc::JeMallocShared
+    DEFINITIONS ${DDPROF_DEFINITION_LIST} KMAX_TRACKED_ALLOCATIONS=100 USE_JEMALLOC=1)
+endif()
 
 add_unit_test(sys_utils-ut sys_utils-ut.cc ../src/sys_utils.cc)
 

--- a/test/allocation_tracker-bench.cc
+++ b/test/allocation_tracker-bench.cc
@@ -45,8 +45,12 @@ DDPROF_NOINLINE void my_malloc(size_t size, uintptr_t addr = 0xdeadbeef) {
 }
 
 DDPROF_NOINLINE void my_free(uintptr_t addr) {
-  ddprof::AllocationTracker::track_deallocation_s(addr);
-  DDPROF_BLOCK_TAIL_CALL_OPTIMIZATION();
+  ddprof::TrackerThreadLocalState *tl_state =
+      ddprof::AllocationTracker::get_tl_state();
+  if (tl_state) {
+    ddprof::AllocationTracker::track_deallocation_s(addr, *tl_state);
+    DDPROF_BLOCK_TAIL_CALL_OPTIMIZATION();
+  }
 }
 
 // Function to perform allocations and deallocations

--- a/test/allocation_tracker-ut.cc
+++ b/test/allocation_tracker-ut.cc
@@ -5,59 +5,90 @@
 #include "allocation_tracker.hpp"
 
 #include "ddprof_perf_event.hpp"
+#include "defer.hpp"
 #include "ipc.hpp"
 #include "live_allocation-c.hpp"
 #include "loghandle.hpp"
 #include "pevent_lib.hpp"
 #include "ringbuffer_holder.hpp"
+#include "symbol_overrides.hpp"
 #include "syscalls.hpp"
 #include "unwind.hpp"
 #include "unwind_state.hpp"
 
+#include <cstdlib>
 #include <gtest/gtest.h>
+#ifdef USE_JEMALLOC
+#  include <jemalloc/jemalloc.h>
+#endif
+#include <malloc.h>
+#include <sys/mman.h>
 #include <unistd.h>
 
+#if defined(__GNUC__) && !defined(__clang__)
+#  define NOEXCEPT noexcept
+#else
+#  define NOEXCEPT
+#endif
+
+extern "C" {
+// Declaration of reallocarray is only available starting from glibc 2.28
+__attribute__((weak)) void *reallocarray(void *ptr, size_t nmemb,
+                                         size_t size) NOEXCEPT;
+__attribute__((weak)) void *pvalloc(size_t size) NOEXCEPT;
+__attribute__((weak)) void *__mmap(void *addr, size_t length, int prot,
+                                   int flags, int fd, off_t offset);
+__attribute__((weak)) int __munmap(void *addr, size_t length);
+}
+
+namespace ddprof {
+
+static const uint64_t k_sampling_rate = 1;
+static const size_t k_buf_size_order = 5;
+
 DDPROF_NOINLINE void my_malloc(size_t size, uintptr_t addr = 0xdeadbeef) {
-  ddprof::TrackerThreadLocalState *tl_state =
-      ddprof::AllocationTracker::get_tl_state();
-  ddprof::ReentryGuard guard(tl_state ? &(tl_state->double_tracking_guard)
-                                      : nullptr);
+  TrackerThreadLocalState *tl_state = AllocationTracker::get_tl_state();
+  ReentryGuard guard(tl_state ? &(tl_state->reentry_guard) : nullptr);
   if (guard) {
-    ddprof::AllocationTracker::track_allocation_s(addr, size, *tl_state);
+    AllocationTracker::track_allocation_s(addr, size, *tl_state);
   }
   // prevent tail call optimization
-  getpid();
+  DDPROF_BLOCK_TAIL_CALL_OPTIMIZATION();
 }
 
 DDPROF_NOINLINE void my_free(uintptr_t addr) {
-  ddprof::AllocationTracker::track_deallocation_s(addr);
+  TrackerThreadLocalState *tl_state = AllocationTracker::get_tl_state();
+  ReentryGuard guard(tl_state ? &(tl_state->reentry_guard) : nullptr);
+  if (guard) {
+    AllocationTracker::track_deallocation_s(addr, *tl_state);
+  }
   // prevent tail call optimization
-  getpid();
+  DDPROF_BLOCK_TAIL_CALL_OPTIMIZATION();
 }
 
 extern "C" {
 DDPROF_NOINLINE void my_func_calling_malloc(size_t size) {
   my_malloc(size);
   // prevent tail call optimization
-  getpid();
+  DDPROF_BLOCK_TAIL_CALL_OPTIMIZATION();
 }
 }
 
 TEST(allocation_tracker, start_stop) {
-  const uint64_t rate = 1;
-  const size_t buf_size_order = 5;
-  ddprof::RingBufferHolder ring_buffer{buf_size_order,
-                                       RingBufferType::kMPSCRingBuffer};
-  ddprof::AllocationTracker::allocation_tracking_init(
-      rate,
-      ddprof::AllocationTracker::kDeterministicSampling |
-          ddprof::AllocationTracker::kTrackDeallocations,
+  RingBufferHolder ring_buffer{k_buf_size_order,
+                               RingBufferType::kMPSCRingBuffer};
+  AllocationTracker::allocation_tracking_init(
+      k_sampling_rate,
+      AllocationTracker::kDeterministicSampling |
+          AllocationTracker::kTrackDeallocations,
       k_default_perf_stack_sample_size, ring_buffer.get_buffer_info());
 
-  ASSERT_TRUE(ddprof::AllocationTracker::is_active());
+  defer { AllocationTracker::allocation_tracking_free(); };
+
+  ASSERT_TRUE(AllocationTracker::is_active());
   my_func_calling_malloc(1);
   { // check that we get the relevant info for this allocation
-    ddprof::MPSCRingBufferReader reader{ring_buffer.get_ring_buffer()};
+    MPSCRingBufferReader reader{ring_buffer.get_ring_buffer()};
     ASSERT_GT(reader.available_size(), 0);
 
     auto buf = reader.read_sample();
@@ -75,9 +106,9 @@ TEST(allocation_tracker, start_stop) {
     ASSERT_EQ(sample->addr, 0xdeadbeef);
 
     UnwindState state;
-    ddprof::unwind_init_sample(&state, sample->regs, sample->pid,
-                               sample->size_stack, sample->data_stack);
-    ddprof::unwindstate__unwind(&state);
+    unwind_init_sample(&state, sample->regs, sample->pid, sample->size_stack,
+                       sample->data_stack);
+    unwindstate__unwind(&state);
 
     const auto &symbol_table = state.symbol_hdr._symbol_table;
     ASSERT_GT(state.output.locs.size(), NB_FRAMES_TO_SKIP);
@@ -88,7 +119,7 @@ TEST(allocation_tracker, start_stop) {
   my_free(0xdeadbeef);
   // ensure we get a deallocation event
   {
-    ddprof::MPSCRingBufferReader reader{ring_buffer.get_ring_buffer()};
+    MPSCRingBufferReader reader{ring_buffer.get_ring_buffer()};
     ASSERT_GT(reader.available_size(), 0);
 
     auto buf = reader.read_sample();
@@ -96,66 +127,61 @@ TEST(allocation_tracker, start_stop) {
     const perf_event_header *hdr =
         reinterpret_cast<const perf_event_header *>(buf.data());
     ASSERT_EQ(hdr->type, PERF_CUSTOM_EVENT_DEALLOCATION);
-    const ddprof::DeallocationEvent *sample =
-        reinterpret_cast<const ddprof::DeallocationEvent *>(hdr);
+    const DeallocationEvent *sample =
+        reinterpret_cast<const DeallocationEvent *>(hdr);
     ASSERT_EQ(sample->ptr, 0xdeadbeef);
   }
   my_free(0xcafebabe);
   {
-    ddprof::MPSCRingBufferReader reader{ring_buffer.get_ring_buffer()};
+    MPSCRingBufferReader reader{ring_buffer.get_ring_buffer()};
     ASSERT_EQ(reader.available_size(), 0);
   }
-  ddprof::AllocationTracker::allocation_tracking_free();
-  ASSERT_FALSE(ddprof::AllocationTracker::is_active());
+  AllocationTracker::allocation_tracking_free();
+  ASSERT_FALSE(AllocationTracker::is_active());
 }
 
 TEST(allocation_tracker, stale_lock) {
   LogHandle log_handle;
   const uint64_t rate = 1;
   const size_t buf_size_order = 5;
-  ddprof::RingBufferHolder ring_buffer{buf_size_order,
-                                       RingBufferType::kMPSCRingBuffer};
-  ddprof::AllocationTracker::allocation_tracking_init(
+  RingBufferHolder ring_buffer{buf_size_order, RingBufferType::kMPSCRingBuffer};
+  AllocationTracker::allocation_tracking_init(
       rate,
-      ddprof::AllocationTracker::kDeterministicSampling |
-          ddprof::AllocationTracker::kTrackDeallocations,
+      AllocationTracker::kDeterministicSampling |
+          AllocationTracker::kTrackDeallocations,
       k_default_perf_stack_sample_size, ring_buffer.get_buffer_info());
+  defer { AllocationTracker::allocation_tracking_free(); };
 
   // simulate stale lock
   ring_buffer.get_ring_buffer().spinlock->lock();
 
-  for (uint32_t i = 0;
-       i < ddprof::AllocationTracker::k_max_consecutive_failures; ++i) {
-    ddprof::TrackerThreadLocalState *tl_state =
-        ddprof::AllocationTracker::get_tl_state();
+  for (uint32_t i = 0; i < AllocationTracker::k_max_consecutive_failures; ++i) {
+    TrackerThreadLocalState *tl_state = AllocationTracker::get_tl_state();
     assert(tl_state);
     if (tl_state) {
-      ddprof::AllocationTracker::track_allocation_s(0xdeadbeef, 1, *tl_state);
+      AllocationTracker::track_allocation_s(0xdeadbeef, 1, *tl_state);
     }
   }
-  ASSERT_FALSE(ddprof::AllocationTracker::is_active());
-  ddprof::AllocationTracker::allocation_tracking_free();
+  ASSERT_FALSE(AllocationTracker::is_active());
 }
 
 TEST(allocation_tracker, max_tracked_allocs) {
-  const uint64_t rate = 1;
-  const size_t buf_size_order = 9;
-  ddprof::RingBufferHolder ring_buffer{buf_size_order,
-                                       RingBufferType::kMPSCRingBuffer};
-  ddprof::AllocationTracker::allocation_tracking_init(
-      rate,
-      ddprof::AllocationTracker::kDeterministicSampling |
-          ddprof::AllocationTracker::kTrackDeallocations,
+  RingBufferHolder ring_buffer{k_buf_size_order,
+                               RingBufferType::kMPSCRingBuffer};
+  AllocationTracker::allocation_tracking_init(
+      k_sampling_rate,
+      AllocationTracker::kDeterministicSampling |
+          AllocationTracker::kTrackDeallocations,
       k_default_perf_stack_sample_size, ring_buffer.get_buffer_info());
+  defer { AllocationTracker::allocation_tracking_free(); };
 
-  ASSERT_TRUE(ddprof::AllocationTracker::is_active());
+  ASSERT_TRUE(AllocationTracker::is_active());
 
-  for (int i = 0; i <= ddprof::liveallocation::kMaxTracked + 1; ++i) {
+  for (int i = 0; i <= liveallocation::kMaxTracked + 1; ++i) {
     my_malloc(1, 0x1000 + i);
-    ddprof::MPSCRingBufferReader reader{ring_buffer.get_ring_buffer()};
-    if (i <=
-        ddprof::liveallocation::kMaxTracked) { // check that we get the relevant
-                                               // info for this allocation
+    MPSCRingBufferReader reader{ring_buffer.get_ring_buffer()};
+    if (i <= liveallocation::kMaxTracked) { // check that we get the relevant
+                                            // info for this allocation
       ASSERT_GT(reader.available_size(), 0);
       auto buf = reader.read_sample();
       ASSERT_FALSE(buf.empty());
@@ -173,7 +199,7 @@ TEST(allocation_tracker, max_tracked_allocs) {
     } else {
       bool clear_found = false;
       int nb_read = 0;
-      ddprof::ConstBuffer buf;
+      ConstBuffer buf;
       do {
         buf = reader.read_sample();
         ++nb_read;
@@ -190,3 +216,430 @@ TEST(allocation_tracker, max_tracked_allocs) {
     }
   }
 }
+
+class AllocFunctionChecker {
+public:
+  AllocFunctionChecker(RingBuffer &ring_buffer, size_t alloc_size)
+      : _ring_buffer(ring_buffer), _alloc_size(alloc_size) {}
+
+  void check_alloc(void *ptr, size_t alloc_size, void **ptr2 = nullptr) {
+    MPSCRingBufferReader reader{_ring_buffer};
+    ASSERT_GT(reader.available_size(), 0);
+
+    auto buf = reader.read_sample();
+    ASSERT_FALSE(buf.empty());
+    const perf_event_header *hdr =
+        reinterpret_cast<const perf_event_header *>(buf.data());
+    ASSERT_EQ(hdr->type, PERF_RECORD_SAMPLE);
+
+    perf_event_sample *sample =
+        hdr2samp(hdr, perf_event_default_sample_type() | PERF_SAMPLE_ADDR);
+
+    if (alloc_size > 0) {
+      ASSERT_EQ(sample->period, alloc_size);
+    }
+    ASSERT_EQ(sample->pid, getpid());
+    ASSERT_EQ(sample->tid, ddprof::gettid());
+    if (ptr) {
+      ASSERT_EQ(sample->addr, reinterpret_cast<uintptr_t>(ptr));
+    }
+    if (ptr2) {
+      *ptr2 = (void *)sample->addr;
+    }
+  }
+
+  void check_dealloc(void *ptr, bool only_last_one = false) {
+    MPSCRingBufferReader reader{_ring_buffer};
+    ASSERT_GT(reader.available_size(), 0);
+    auto buf = reader.read_sample();
+    if (only_last_one) {
+      while (reader.available_size()) {
+        buf = reader.read_sample();
+      }
+    }
+    ASSERT_FALSE(buf.empty());
+    const perf_event_header *hdr =
+        reinterpret_cast<const perf_event_header *>(buf.data());
+    ASSERT_EQ(hdr->type, PERF_CUSTOM_EVENT_DEALLOCATION);
+
+    auto sample = reinterpret_cast<const DeallocationEvent *>(hdr);
+    if (ptr) {
+      ASSERT_EQ(sample->ptr, reinterpret_cast<uintptr_t>(ptr));
+    }
+  }
+
+  void check_empty() {
+    MPSCRingBufferReader reader{_ring_buffer};
+    ASSERT_EQ(reader.available_size(), 0);
+  }
+
+  template <typename AllocFunc, typename DeallocFunc>
+  DDPROF_NOINLINE void test_alloc(AllocFunc alloc_func,
+                                  DeallocFunc dealloc_func,
+                                  size_t header_size = 0) {
+    empty_ring_buffer();
+    try {
+      auto ptr = alloc_func(_alloc_size);
+      decltype(ptr) ptr2 = decltype(ptr)(((char *)ptr) - header_size);
+      check_alloc(ptr2, _alloc_size + header_size);
+      check_empty();
+      dealloc_func(ptr, _alloc_size + header_size);
+      check_dealloc(ptr2);
+      check_empty();
+    } catch (const std::exception &e) {
+      void *ptr;
+      check_alloc(nullptr, _alloc_size + header_size, &ptr);
+      // There might be many allocations / deallocation for exception handling
+      // but the last one should be the deallocation of the initial alloc.
+      check_dealloc(ptr, true);
+      check_empty();
+    }
+  }
+
+  template <typename AllocFunc>
+  DDPROF_NOINLINE void test_alloc(AllocFunc alloc_func) {
+    test_alloc(alloc_func, [](void *ptr, size_t) { ::free(ptr); });
+  }
+
+  template <typename AllocFunc, typename ReallocFunc, typename DeallocFunc>
+  DDPROF_NOINLINE void test_realloc(AllocFunc alloc_func,
+                                    ReallocFunc realloc_func,
+                                    DeallocFunc dealloc_func) {
+    empty_ring_buffer();
+    auto ptr = alloc_func(_alloc_size);
+    check_alloc(ptr, _alloc_size);
+    check_empty();
+    auto new_alloc_size = 2 * _alloc_size;
+    auto [ptr2, size2] = realloc_func(ptr, new_alloc_size);
+    check_dealloc(ptr);
+    check_alloc(ptr2, size2);
+    check_empty();
+    dealloc_func(ptr2, size2);
+    check_dealloc(ptr2);
+    check_empty();
+  }
+
+  template <typename AllocFunc, typename ReallocFunc>
+  DDPROF_NOINLINE void test_realloc(AllocFunc alloc_func,
+                                    ReallocFunc realloc_func) {
+    test_realloc(alloc_func, realloc_func,
+                 [](void *ptr, size_t) { ::free(ptr); });
+  }
+
+  void empty_ring_buffer() {
+    MPSCRingBufferReader reader{_ring_buffer};
+    for (auto buf = reader.read_sample(); !buf.empty();
+         buf = reader.read_sample()) {}
+  }
+
+private:
+  RingBuffer &_ring_buffer;
+  size_t _alloc_size;
+};
+
+template <typename Func> auto aligned_wrapper(Func func, size_t alignment = 8) {
+  return [func, alignment](size_t sz) { return func(alignment, sz); };
+}
+
+template <typename Func> auto mmap_wrapper(Func func) {
+  return [func](size_t sz) {
+    return func(nullptr, sz, PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  };
+}
+
+template <size_t Size, bool Throw = false, size_t Alignment = 1>
+struct TestObj {
+  DDPROF_NOINLINE TestObj();
+  alignas(Alignment) char buf[Size];
+};
+
+// Try to defeat the optimizer by making the constructor (and throw expression)
+// noinline.
+template <size_t Size, bool Throw, size_t Alignment>
+TestObj<Size, Throw, Alignment>::TestObj() {
+  if (Throw) {
+    throw std::exception{};
+  }
+}
+
+template <size_t Size, bool Throw = false, size_t Alignment = 1>
+struct TestObjWithDestructor {
+  DDPROF_NOINLINE TestObjWithDestructor();
+  DDPROF_NOINLINE ~TestObjWithDestructor();
+  alignas(Alignment) char buf[Size];
+};
+
+template <size_t Size, bool Throw, size_t Alignment>
+TestObjWithDestructor<Size, Throw, Alignment>::TestObjWithDestructor() {
+  if (Throw) {
+    throw std::exception{};
+  }
+}
+
+template <size_t Size, bool Throw, size_t Alignment>
+TestObjWithDestructor<Size, Throw, Alignment>::~TestObjWithDestructor() {}
+
+DDPROF_NOINLINE void test_allocation_functions(RingBuffer &ring_buffer) {
+  static constexpr size_t alloc_size = 1024;
+  AllocFunctionChecker checker{ring_buffer, alloc_size};
+
+  {
+    SCOPED_TRACE("malloc/free");
+    checker.test_alloc(&::malloc);
+  }
+  {
+    SCOPED_TRACE("calloc/free");
+    checker.test_alloc(aligned_wrapper(&::calloc, 1));
+  }
+
+#ifndef USE_JEMALLOC
+  // jemalloc does not provide pvalloc and freeing a pointer allocated by
+  // pvalloc results in a segfault
+  if (pvalloc) {
+    SCOPED_TRACE("pvalloc/free");
+    checker.test_alloc(&::pvalloc);
+  }
+#else
+  {
+    SCOPED_TRACE("mallocx/dallocx");
+    checker.test_alloc([](size_t sz) { return ::mallocx(sz, 0); },
+                       [](void *ptr, size_t sz) { ::dallocx(ptr, 0); });
+  }
+#  if JEMALLOC_VERSION_MAJOR >= 4
+  {
+    SCOPED_TRACE("mallocx/sdallocx");
+    checker.test_alloc([](size_t sz) { return ::mallocx(sz, 0); },
+                       [](void *ptr, size_t sz) { ::sdallocx(ptr, sz, 0); });
+  }
+#  endif
+  {
+    SCOPED_TRACE("rallocx/dallocx");
+    checker.test_realloc([](size_t sz) { return ::mallocx(sz, 0); },
+                         [](void *ptr, size_t sz) {
+                           return std::make_pair(::rallocx(ptr, sz, 0), sz);
+                         },
+                         [](void *ptr, size_t sz) { ::dallocx(ptr, 0); });
+  }
+  {
+    SCOPED_TRACE("xallocx/dallocx");
+    checker.test_realloc([](size_t sz) { return ::mallocx(sz, 0); },
+                         [](void *ptr, size_t sz) {
+                           auto new_size = ::xallocx(ptr, sz, 0, 0);
+                           return std::make_pair(ptr, new_size);
+                         },
+                         [](void *ptr, size_t sz) { ::dallocx(ptr, 0); });
+  }
+#endif
+
+  {
+    SCOPED_TRACE("valloc/free");
+    checker.test_alloc(&::valloc);
+  }
+  {
+    SCOPED_TRACE("posix_memalign/free");
+    checker.test_alloc([](size_t sz) {
+      void *ptr = nullptr;
+      EXPECT_EQ(::posix_memalign(&ptr, 8, sz), 0);
+      return ptr;
+    });
+  }
+  {
+    SCOPED_TRACE("memalign/free");
+    checker.test_alloc(aligned_wrapper(&::memalign));
+  }
+  {
+    SCOPED_TRACE("aligned_alloc/free");
+    checker.test_alloc(aligned_wrapper(&::aligned_alloc));
+  }
+  {
+    SCOPED_TRACE("realloc/free");
+    checker.test_realloc(&::malloc, [](void *ptr, size_t sz) {
+      return std::make_pair(::realloc(ptr, sz), sz);
+    });
+  }
+  if (reallocarray) {
+    SCOPED_TRACE("realloarray/free");
+    checker.test_realloc(&::malloc, [](void *ptr, size_t sz) {
+      return std::make_pair(::reallocarray(ptr, 1, sz), sz);
+    });
+  }
+
+  {
+    SCOPED_TRACE("mmap/munmap");
+    checker.test_alloc(mmap_wrapper(&::mmap), &::munmap);
+  }
+  {
+    SCOPED_TRACE("mmap64/munmap");
+    checker.test_alloc(mmap_wrapper(&::mmap64), &::munmap);
+  }
+  if (__mmap && __munmap) {
+    SCOPED_TRACE("__mmap/__munmap");
+    checker.test_alloc(mmap_wrapper(&::__mmap), &::__munmap);
+  }
+
+  static constexpr size_t big_align = alignof(std::max_align_t) * 2;
+  static constexpr size_t array_size = 16;
+  static_assert((alloc_size / array_size) % big_align == 0);
+
+  using Obj = TestObj<alloc_size, false>;
+  using AlignedObj = TestObj<alloc_size, false, big_align>;
+  using ThrowingObj = TestObj<alloc_size, true>;
+  using ThrowingAlignedObj = TestObj<alloc_size, true, big_align>;
+  using ArrayObj = TestObj<alloc_size / array_size, false>;
+  using AlignedArrayObj = TestObj<alloc_size / array_size, false>;
+  using ThrowingArrayObj = TestObj<alloc_size / array_size, true>;
+  using ThrowingAlignedArrayObj =
+      TestObj<alloc_size / array_size, true, big_align>;
+
+  using NonTrivialArrayObj =
+      TestObjWithDestructor<alloc_size / array_size, false>;
+  using NonTrivialAlignedArrayObj =
+      TestObjWithDestructor<alloc_size / array_size, false, big_align>;
+  struct IncompleteObj;
+
+  {
+    SCOPED_TRACE("new/delete_sized");
+    checker.test_alloc([](size_t) { return new Obj; },
+                       [](auto ptr, size_t) { delete ptr; });
+  }
+  {
+    SCOPED_TRACE("new_nothrow/delete");
+    checker.test_alloc([](size_t) { return new (std::nothrow) Obj; },
+                       [](auto ptr, size_t) { delete ptr; });
+  }
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdelete-incomplete"
+  // Delete incomplete object to force use of `delete(void* ptr)` overload
+  // (otherwise sized version is used)
+  {
+    SCOPED_TRACE("new/delete");
+    checker.test_alloc([](size_t) { return new Obj; },
+                       [](auto ptr, size_t) { delete (IncompleteObj *)ptr; });
+  }
+#pragma GCC diagnostic pop
+  {
+    SCOPED_TRACE("new/delete_nothrow");
+    checker.test_alloc([](size_t) { return new ThrowingObj; },
+                       [](auto ptr, size_t) { FAIL(); });
+  }
+  {
+    SCOPED_TRACE("new_nothrow/delete_nothrow");
+    checker.test_alloc([](size_t) { return new (std::nothrow) ThrowingObj; },
+                       [](auto ptr, size_t) { FAIL(); });
+  }
+
+  {
+    SCOPED_TRACE("new[]/delete[]");
+    checker.test_alloc([](size_t sz) { return new ArrayObj[array_size]; },
+                       [](auto ptr, size_t) { delete[] ptr; });
+  }
+
+  {
+    // When allocating array of non-trivially destructible types, a header
+    // containing the number of objects is put before the start of the array.
+    SCOPED_TRACE("new[]/delete[]_sized");
+    checker.test_alloc(
+        [](size_t sz) { return new NonTrivialArrayObj[array_size]; },
+        [](auto ptr, size_t) { delete[] ptr; }, sizeof(size_t));
+  }
+  {
+    SCOPED_TRACE("new[]_aligned/delete[]_sized_aligned");
+    checker.test_alloc(
+        [](size_t sz) { return new NonTrivialAlignedArrayObj[array_size]; },
+        [](auto ptr, size_t) { delete[] ptr; }, big_align);
+  }
+  {
+    SCOPED_TRACE("new[]_nothrow/delete[]");
+    checker.test_alloc(
+        [](size_t sz) { return new (std::nothrow) ArrayObj[array_size]; },
+        [](auto ptr, size_t) { delete[] ptr; });
+  }
+  {
+    SCOPED_TRACE("new[]/delete[]_nothrow");
+    checker.test_alloc(
+        [](size_t sz) { return new ThrowingArrayObj[array_size]; },
+        [](auto ptr, size_t) { FAIL(); });
+  }
+  {
+    SCOPED_TRACE("new[]_nothrow/delete[]_nothrow");
+    checker.test_alloc(
+        [](size_t sz) {
+          return new (std::nothrow) ThrowingArrayObj[array_size];
+        },
+        [](auto ptr, size_t) { FAIL(); });
+  }
+  {
+    SCOPED_TRACE("new_aligned/delete_aligned");
+    checker.test_alloc([](size_t) { return new AlignedObj; },
+                       [](auto ptr, size_t) { delete ptr; });
+  }
+  {
+    SCOPED_TRACE("new_aligned_nothrow/delete_aligned");
+    checker.test_alloc([](size_t) { return new (std::nothrow) AlignedObj; },
+                       [](auto ptr, size_t) { delete ptr; });
+  }
+  {
+    SCOPED_TRACE("new[]_aligned/delete[]_aligned");
+    checker.test_alloc([](size_t) { return new AlignedArrayObj[array_size]; },
+                       [](auto ptr, size_t) { delete[] ptr; });
+  }
+  {
+    SCOPED_TRACE("new[]_aligned_nothrow/delete[]_aligned");
+    checker.test_alloc(
+        [](size_t) { return new (std::nothrow) AlignedArrayObj[array_size]; },
+        [](auto ptr, size_t) { delete[] ptr; });
+  }
+  {
+    SCOPED_TRACE("new_aligned/delete_aligned_nothrow");
+    checker.test_alloc([](size_t) { return new ThrowingAlignedObj; },
+                       [](auto ptr, size_t) { delete ptr; });
+  }
+  {
+    SCOPED_TRACE("new_aligned_nothrow/delete_aligned_nothrow");
+    checker.test_alloc(
+        [](size_t) { return new (std::nothrow) ThrowingAlignedObj; },
+        [](auto ptr, size_t) { delete ptr; });
+  }
+  {
+    SCOPED_TRACE("new[]_aligned/delete[]_aligned_nothrow");
+    checker.test_alloc(
+        [](size_t) { return new ThrowingAlignedArrayObj[array_size]; },
+        [](auto ptr, size_t) { delete[] ptr; });
+  }
+  {
+    SCOPED_TRACE("new[]_aligned_nothrow/delete[]_aligned_nothrow");
+    checker.test_alloc(
+        [](size_t) {
+          return new (std::nothrow) ThrowingAlignedArrayObj[array_size];
+        },
+        [](auto ptr, size_t) { delete[] ptr; });
+  }
+}
+
+TEST(allocation_tracker, test_allocation_functions) {
+  RingBufferHolder ring_buffer{k_buf_size_order,
+                               RingBufferType::kMPSCRingBuffer};
+  AllocationTracker::allocation_tracking_init(
+      k_sampling_rate,
+      AllocationTracker::kDeterministicSampling |
+          AllocationTracker::kTrackDeallocations,
+      k_default_perf_stack_sample_size, ring_buffer.get_buffer_info());
+  defer { AllocationTracker::allocation_tracking_free(); };
+
+  ASSERT_TRUE(AllocationTracker::is_active());
+  ddprof::setup_overrides(std::chrono::milliseconds{0},
+                          std::chrono::milliseconds{0});
+
+  // Put all tests in another nmn-inlined functions otherwise compiler may
+  // compute `&::malloc` and other allocation function addresses before
+  // overrides are setup, and thus effectively calling the true allocation
+  // functions instead of hooks. I observed this on clang/ARM, and even a
+  // compiler barrier did not prevent the compiler to reorder the computation of
+  // these addresses before `setup_overrides`.
+  test_allocation_functions(ring_buffer.get_ring_buffer());
+  ddprof::restore_overrides();
+}
+
+} // namespace ddprof

--- a/test/reentry_guard-ut.cc
+++ b/test/reentry_guard-ut.cc
@@ -26,8 +26,8 @@ TEST(ReentryGuardTest, null_init) {
     guard.register_guard(&reentry_guard);
     EXPECT_TRUE(guard);
     {
-      ddprof::ReentryGuard guard(&reentry_guard);
-      EXPECT_FALSE(guard);
+      ddprof::ReentryGuard guard2(&reentry_guard);
+      EXPECT_FALSE(guard2);
     }
   }
 }

--- a/test/savecontext-ut.cc
+++ b/test/savecontext-ut.cc
@@ -66,9 +66,10 @@ static std::mutex mutex;
 static std::condition_variable cv;
 static uint64_t regs[K_NB_REGS_UNWIND];
 static size_t stack_size;
+static std::span<const std::byte> thread_stack_bounds;
 
 DDPROF_NO_SANITIZER_ADDRESS void handler(int sig) {
-  stack_size = save_context(retrieve_stack_bounds(), regs, stack);
+  stack_size = save_context(thread_stack_bounds, regs, stack);
   stop = true;
 }
 
@@ -81,6 +82,7 @@ DDPROF_NOINLINE void funcD() {
 }
 
 DDPROF_NOINLINE void funcC() {
+  thread_stack_bounds = retrieve_stack_bounds();
   signal(SIGUSR1, &handler);
   defer { signal(SIGUSR1, SIG_DFL); };
   stop = false;


### PR DESCRIPTION
* Override jemalloc non-standard API (mallocx,rallocx,xallocx,...)
* Override all variants of operator new/delete:
This was not necessary when using glibc malloc because implementation of these operators in libstdc++ are calling malloc/free. But since jemalloc provides its own versions of these operators that call directly into some jemalloc internal functions, why we need to intercept these allocations at the operator new/delete level or otherwise we will miss all c++ allocations.
* Override sized free functions added by C23 (free_sized/free_aligned_sized)
* Add tests for all (de)allocation functions
