### PR TITLE
Fix handling of env variables by profiler lib

### DIFF
--- a/app/base-env-alpine/Dockerfile
+++ b/app/base-env-alpine/Dockerfile
@@ -23,6 +23,7 @@ RUN apk update \
     ca-certificates \
     clang \
     cmake \
+    coreutils \
     cppcheck \
     curl \
     flex \
@@ -31,6 +32,7 @@ RUN apk update \
     gcovr \
     gdb \
     git \
+    grep \
     gtest-dev \
     libcap-dev \
     libcap-static \

--- a/include/ddprof_context.hpp
+++ b/include/ddprof_context.hpp
@@ -11,18 +11,15 @@
 #include "ddprof_worker_context.hpp"
 #include "exporter_input.hpp"
 #include "perf_watcher.hpp"
+#include "unique_fd.hpp"
 
 #include <sched.h>
 #include <unistd.h>
 
 struct DDProfContext {
   DDProfContext() = default;
-  ~DDProfContext() {
-    if (params.sockfd != -1) {
-      close(params.sockfd);
-      params.sockfd = -1;
-    }
-  }
+  ~DDProfContext() = default;
+
   struct {
     bool enable{true};
     unsigned upload_period{};
@@ -32,8 +29,7 @@ struct DDProfContext {
     pid_t pid{0}; // ! only use for perf attach (can be -1 in global mode)
     uint32_t worker_period{}; // exports between worker refreshes
     int dd_profiling_fd{-1};  // opened file descriptor to our internal lib
-    int sockfd{-1};
-    bool wait_on_socket{false};
+    ddprof::UniqueFd sockfd;
     bool show_samples{false};
     cpu_set_t cpu_affinity{};
     std::string switch_user;

--- a/include/unique_fd.hpp
+++ b/include/unique_fd.hpp
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#pragma once
+
+#include <memory>
+#include <unistd.h>
+
+namespace ddprof {
+
+template <typename T, T NullValue = T()> class Handle {
+public:
+  // cppcheck-suppress noExplicitConstructor
+  Handle(std::nullptr_t) {}
+  // cppcheck-suppress noExplicitConstructor
+  Handle(T x) : _val(x) {}
+  Handle() = default;
+
+  explicit operator bool() const { return _val != NullValue; }
+  operator T() const { return _val; }
+
+  T get() const { return _val; }
+
+  friend bool operator==(Handle a, Handle b) = default;
+
+private:
+  T _val{NullValue};
+};
+
+using FdHandle = Handle<int, -1>;
+
+template <typename Handle, typename Deleter> struct HandleDeleter {
+  using pointer = Handle;
+  void operator()(pointer p) { Deleter{}(p); }
+};
+
+inline constexpr auto fdclose = [](auto fd) { ::close(fd); };
+
+using UniqueFd =
+    std::unique_ptr<int, HandleDeleter<FdHandle, decltype(fdclose)>>;
+
+} // namespace ddprof

--- a/src/daemonize.cc
+++ b/src/daemonize.cc
@@ -50,10 +50,10 @@ DaemonizeResult daemonize() {
         exit(1);
       }
 
-      // Block until our child exits or sends us a kill signal
-      // NOTE, current process is NOT expected to unblock here; rather it
-      // ends by SIGTERM.
-      waitpid(child_pid, NULL, 0);
+      // Block until our child exits or sends us a SIGTERM signal
+      // In the happy path, child will send us a SIGTERM signal, that we catch
+      // and then exit normally (to free resources and make valgrind happy).
+      waitpid(child_pid, nullptr, 0);
       return {DaemonizeResult::IntermediateProcess, temp_pid, parent_pid,
               child_pid};
     } else {

--- a/src/ddprof_context_lib.cc
+++ b/src/ddprof_context_lib.cc
@@ -77,10 +77,7 @@ void copy_cli_values(const DDProfCLI &ddprof_cli, DDProfContext &ctx) {
       ddprof_cli.initial_loaded_libs_check_delay;
   ctx.params.loaded_libs_check_interval = ddprof_cli.loaded_libs_check_interval;
 
-  ctx.params.sockfd = ddprof_cli.socket;
-  if (ctx.params.sockfd != -1) {
-    ctx.params.wait_on_socket = true;
-  }
+  ctx.params.sockfd.reset(ddprof_cli.socket);
 }
 
 DDRes context_add_watchers(const DDProfCLI &ddprof_cli, DDProfContext &ctx) {
@@ -101,8 +98,8 @@ DDRes context_add_watchers(const DDProfCLI &ddprof_cli, DDProfContext &ctx) {
   }
 
   if (!preset.empty()) {
-    bool pid_or_global_mode =
-        (ddprof_cli.global || ddprof_cli.pid) && ctx.params.sockfd == -1;
+    const bool pid_or_global_mode =
+        (ddprof_cli.global || ddprof_cli.pid) && !ctx.params.sockfd;
     DDRES_CHECK_FWD(add_preset(preset, pid_or_global_mode,
                                ddprof_cli.default_stack_sample_size, watchers));
   }

--- a/src/ddprof_module_lib.cc
+++ b/src/ddprof_module_lib.cc
@@ -9,6 +9,7 @@
 #include "ddres.hpp"
 #include "defer.hpp"
 #include "logger.hpp"
+#include "unique_fd.hpp"
 
 #include <algorithm>
 #include <cstring>
@@ -203,9 +204,8 @@ DDRes report_module(Dwfl *dwfl, ProcessAddress_t pc,
     return ddres_warn(DD_WHAT_MODULE);
   }
 
-  auto fd_holder = ddprof::make_unique_resource_checked(
-      ::open(filepath.c_str(), O_RDONLY), -1, &::close);
-  if (fd_holder.get() < 0) {
+  UniqueFd fd_holder{::open(filepath.c_str(), O_RDONLY)};
+  if (!fd_holder) {
     LG_WRN("[Mod] Couldn't open fd to module (%s)", filepath.c_str());
     return ddres_warn(DD_WHAT_MODULE);
   }

--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -123,6 +123,8 @@ static DDRes get_library_path(TempFileHolder &libdd_profiling_path,
   std::string profiling_path;
   std::string loader_path;
 
+  // If not forbidden by env variable, try first to locate profiling and loader
+  // libs in ddprof exe directory. This makes debugging easier.
   if (!getenv(k_profiler_use_embedded_libdd_profiling_env_variable)) {
     profiling_path = find_lib(k_libdd_profiling_embedded_name);
     loader_path = find_lib(k_libdd_loader_name);

--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -256,11 +256,15 @@ int start_profiler_internal(std::unique_ptr<DDProfContext> ctx,
         LG_DBG("Setting LD_PRELOAD=%s", preload_str.c_str());
         setenv("LD_PRELOAD", preload_str.c_str(), 1);
         if (!dd_loader_lib_path.empty()) {
-          setenv("DD_PROFILING_NATIVE_LIBRARY", dd_profiling_lib_path.c_str(),
-                 1);
+          setenv(k_profiler_lib_env_variable, dd_profiling_lib_path.c_str(), 1);
         }
         auto sock_str = std::to_string(parent_socket.get());
         setenv(k_profiler_lib_socket_env_variable, sock_str.c_str(), 1);
+        // Preset the env variable to determine if allocation profiler is
+        // active.
+        // This avoids having to create a new env variable in the target
+        // process.
+        setenv(k_profiler_active_env_variable, "0", 1);
       }
 
       parent_socket.release();

--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -208,7 +208,7 @@ int start_profiler_internal(std::unique_ptr<DDProfContext> ctx,
 
     if (allocation_profiling_started_from_wrapper) {
       int sockfds[2] = {-1, -1};
-      if (socketpair(AF_UNIX, SOCK_DGRAM, 0, sockfds) == -1) {
+      if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sockfds) == -1) {
         return -1;
       }
       parent_socket.reset(sockfds[0]);

--- a/src/lib/dd_profiling.cc
+++ b/src/lib/dd_profiling.cc
@@ -301,7 +301,7 @@ int ddprof_start_profiling_internal() {
     //    for a request and replies
     //  * both library and profiler close their socket and continue
     int sockfds[2];
-    if (socketpair(AF_UNIX, SOCK_DGRAM, 0, sockfds) == -1) {
+    if (socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sockfds) == -1) {
       return -1;
     }
 

--- a/test/ipc-ut.cc
+++ b/test/ipc-ut.cc
@@ -23,7 +23,7 @@ TEST(IPCTest, Positive) {
   std::string payload = "Interesting test.";
 
   int sockets[2] = {-1, -1};
-  ASSERT_EQ(socketpair(AF_UNIX, SOCK_DGRAM, 0, sockets), 0);
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sockets), 0);
   // Fork
   pid_t child_pid = fork();
   if (!child_pid) {
@@ -74,7 +74,7 @@ TEST(IPCTest, Positive) {
 
 TEST(IPCTest, timeout) {
   int sockets[2] = {-1, -1};
-  ASSERT_EQ(socketpair(AF_UNIX, SOCK_DGRAM, 0, sockets), 0);
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sockets), 0);
   ddprof::UnixSocket sock1(sockets[0]);
   ddprof::UnixSocket sock2(sockets[1]);
   std::error_code ec;


### PR DESCRIPTION
# What does this PR do?

* Improve handling of env variables by profiler lib
    * Use dlsym / RTLD_NEXT to retrieve original version of getenv / putenv
      / unsetenv when interposed (bash for example provides its own versions
      of these functions)
    * Preset DD_PROFILING_NATIVE_LIBRARY_ACTIVE before exec'ing, this avoid
      having to do a putenv later.
    * Keep a pointer on 0/1 char of DD_PROFILING_NATIVE_LIBRARY_ACTIVE to
      update library state.
* Improve pre-loading detection
    Check for libdd_profiling.so / libdd_profiling-embedded.so and
    libdd_loader.so
*  Introduce UniqueFd as RAII class for descriptors
* Use RAII for ddprof_context
   Use unique_ptr for managing ddprof_context lifetime.

[Related ddprof-build PR](https://github.com/DataDog/ddprof-build/pull/110)
[Successful build](https://gitlab.ddbuild.io/DataDog/apm-reliability/ddprof/-/pipelines/20667065) 