### PR TITLE
Crash fix - Fix segment matching

### DIFF
--- a/include/scope.hpp
+++ b/include/scope.hpp
@@ -80,7 +80,7 @@ template <typename T> class box {
 public:
   template <typename TT, typename GG>
     requires std::is_constructible_v<T, TT>
-  explicit box(TT &&t, GG &&guard) noexcept(noexcept(box((T &&)t)))
+  explicit box(TT &&t, GG &&guard) noexcept(noexcept(box((T &&) t)))
       : box(std::forward<TT>(t)) {
     guard.release();
   }
@@ -102,7 +102,7 @@ template <typename T> class box<T &> {
 public:
   template <typename TT, typename GG>
     requires std::is_convertible_v<TT, T &>
-  box(TT &&t, GG &&guard) noexcept(noexcept(static_cast<T &>((TT &&)t)))
+  box(TT &&t, GG &&guard) noexcept(noexcept(static_cast<T &>((TT &&) t)))
       : value(static_cast<T &>(t)) {
     guard.release();
   }
@@ -265,8 +265,8 @@ public: // should be private
                                          detail::_empty_scope_exit>
   unique_resource(RR &&r, DD &&d, bool should_run) noexcept(
       noexcept(detail::box<R>(std::forward<RR>(r), detail::_empty_scope_exit{}))
-          && noexcept(detail::box<D>(std::forward<DD>(d),
-                                     detail::_empty_scope_exit{})))
+          &&noexcept(detail::box<D>(std::forward<DD>(d),
+                                    detail::_empty_scope_exit{})))
       : resource(std::forward<RR>(r), scope_exit([&] {
                    if (should_run)
                      d(r);
@@ -302,16 +302,16 @@ public:
                                          detail::_empty_scope_exit>
   unique_resource(RR &&r, DD &&d) noexcept(
       noexcept(detail::box<R>(std::forward<RR>(r), detail::_empty_scope_exit{}))
-          && noexcept(detail::box<D>(std::forward<DD>(d),
-                                     detail::_empty_scope_exit{})))
+          &&noexcept(detail::box<D>(std::forward<DD>(d),
+                                    detail::_empty_scope_exit{})))
       : resource(std::forward<RR>(r), scope_exit([&] { d(r); })),
         deleter(std::forward<DD>(d), scope_exit([&, this] { d(get()); })),
         execute_on_destruction{true} {}
   unique_resource(unique_resource &&that) noexcept(
       noexcept(detail::box<R>(that.resource.move(),
                               detail::_empty_scope_exit{}))
-          && noexcept(detail::box<D>(that.deleter.move(),
-                                     detail::_empty_scope_exit{})))
+          &&noexcept(detail::box<D>(that.deleter.move(),
+                                    detail::_empty_scope_exit{})))
       : resource(that.resource.move(), detail::_empty_scope_exit{}),
         deleter(that.deleter.move(), scope_exit([&, this] {
                   if (that.execute_on_destruction)

--- a/include/scope.hpp
+++ b/include/scope.hpp
@@ -80,7 +80,7 @@ template <typename T> class box {
 public:
   template <typename TT, typename GG>
     requires std::is_constructible_v<T, TT>
-  explicit box(TT &&t, GG &&guard) noexcept(noexcept(box((T &&) t)))
+  explicit box(TT &&t, GG &&guard) noexcept(noexcept(box((T &&)t)))
       : box(std::forward<TT>(t)) {
     guard.release();
   }
@@ -102,7 +102,7 @@ template <typename T> class box<T &> {
 public:
   template <typename TT, typename GG>
     requires std::is_convertible_v<TT, T &>
-  box(TT &&t, GG &&guard) noexcept(noexcept(static_cast<T &>((TT &&) t)))
+  box(TT &&t, GG &&guard) noexcept(noexcept(static_cast<T &>((TT &&)t)))
       : value(static_cast<T &>(t)) {
     guard.release();
   }
@@ -265,8 +265,8 @@ public: // should be private
                                          detail::_empty_scope_exit>
   unique_resource(RR &&r, DD &&d, bool should_run) noexcept(
       noexcept(detail::box<R>(std::forward<RR>(r), detail::_empty_scope_exit{}))
-          &&noexcept(detail::box<D>(std::forward<DD>(d),
-                                    detail::_empty_scope_exit{})))
+          && noexcept(detail::box<D>(std::forward<DD>(d),
+                                     detail::_empty_scope_exit{})))
       : resource(std::forward<RR>(r), scope_exit([&] {
                    if (should_run)
                      d(r);
@@ -302,16 +302,16 @@ public:
                                          detail::_empty_scope_exit>
   unique_resource(RR &&r, DD &&d) noexcept(
       noexcept(detail::box<R>(std::forward<RR>(r), detail::_empty_scope_exit{}))
-          &&noexcept(detail::box<D>(std::forward<DD>(d),
-                                    detail::_empty_scope_exit{})))
+          && noexcept(detail::box<D>(std::forward<DD>(d),
+                                     detail::_empty_scope_exit{})))
       : resource(std::forward<RR>(r), scope_exit([&] { d(r); })),
         deleter(std::forward<DD>(d), scope_exit([&, this] { d(get()); })),
         execute_on_destruction{true} {}
   unique_resource(unique_resource &&that) noexcept(
       noexcept(detail::box<R>(that.resource.move(),
                               detail::_empty_scope_exit{}))
-          &&noexcept(detail::box<D>(that.deleter.move(),
-                                    detail::_empty_scope_exit{})))
+          && noexcept(detail::box<D>(that.deleter.move(),
+                                     detail::_empty_scope_exit{})))
       : resource(that.resource.move(), detail::_empty_scope_exit{}),
         deleter(that.deleter.move(), scope_exit([&, this] {
                   if (that.execute_on_destruction)

--- a/src/ddprof_module_lib.cc
+++ b/src/ddprof_module_lib.cc
@@ -105,11 +105,11 @@ find_matching_segment(std::span<const Segment> segments,
 
 MatchResult find_match(std::span<const Mapping> executable_mappings,
                        std::span<const Segment> elf_load_segments) {
-  unsigned nb_mappings = executable_mappings.size();
+  int nb_mappings = executable_mappings.size();
 
   MatchResult res = {nullptr, nullptr, false};
   int max_segments =
-      std::min(nb_mappings, static_cast<unsigned>(elf_load_segments.size()));
+      std::min(nb_mappings, static_cast<int>(elf_load_segments.size()));
   for (int mapping_idx = max_segments - 1; mapping_idx >= 0; --mapping_idx) {
     const auto &mapping = executable_mappings[mapping_idx];
     assert(static_cast<unsigned>(mapping_idx) < elf_load_segments.size());

--- a/test/ddprof_module_lib-ut.cc
+++ b/test/ddprof_module_lib-ut.cc
@@ -76,4 +76,13 @@ TEST(ddprof_module_lib, complex) {
   ASSERT_TRUE(res.is_ambiguous);
 }
 
+TEST(ddprof_module_lib, libcoreclr) {
+  Mapping mappings[] = {mapping(0x0), mapping(0x383000), mapping(0x384000),
+                        mapping(0x5d9000)};
+  Segment segments[] = {segment(0x000000, PROT_EXEC),
+                        segment(0x6b7ec0, PROT_READ)};
+  auto res = find_match(mappings, segments);
+  ASSERT_FALSE(res.is_ambiguous);
+}
+
 } // namespace ddprof

--- a/tools/style-check.sh
+++ b/tools/style-check.sh
@@ -10,12 +10,12 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR/.."
 
 # Find most recent clang-format, defaulting to an unqualified default
-CLANG_FORMAT=$(command -v clang-format{-15,-13,-12,-11,-10,-9,} | head -n1)
+CLANG_FORMAT=$(command -v clang-format{-16,-15,-13,-12,-11,-10,-9,} | head -n1)
 if [ -z "${CLANG_FORMAT}" ]; then
-  echo "No suitable clang-format found"
+  echo "Please use clang format 16"
   exit 1
 fi
-
+eval "$CLANG_FORMAT --version"
 # Process arguments
 [[ -z "${APPLY:-}" ]] && APPLY="no"
 [[ "${1:-,,}" == "apply" ]] && APPLY="yes"


### PR DESCRIPTION
# What does this PR do?

Ensure we consider the case where there are more loaded segments than elf segments

# Motivation

Fix a crash when running in whole host

# Additional Notes

This was introduced by recent changes to the way we match segments

# How to test the change?

This library was loaded by appgate on linux.
