### PR TITLE
In use objects - add a profile type

### DIFF
--- a/docs/Build.md
+++ b/docs/Build.md
@@ -35,6 +35,21 @@ RelCMake ../
 make -j 4 .
 ```
 
+### Running static analysis
+
+cppcheck is run with a dedicated build target from within a build folder.
+```bash
+make cppcheck
+```
+
+Clang tidy checks require llvm 17 to be installed.
+Using the build image will guarantee this.
+```bash
+CXX=clang++-17 CC=clang-17 source ./setup_env.sh
+MkBuildDir ClangDeb
+    DebCMake -DENABLE_CLANG_TIDY=ON ../
+```
+
 ### Updating libdatadog
 
 Head over to the libdatadog, do your changes and copy the library back to your vendor directory.

--- a/include/event_config.hpp
+++ b/include/event_config.hpp
@@ -12,24 +12,24 @@
 #include <string>
 #include <vector>
 
-// Defines how a sample is aggregated when it is received
-enum class EventConfMode : uint32_t {
-  kDisabled = 0,
-  kCallgraph = 1 << 0,     // flamegraph of resource usage
-  kMetric = 1 << 1,        // gauge of resource usage
-  kLiveCallgraph = 1 << 2, // report callgraph of resources still in use
-  kAll = kCallgraph | kMetric | kLiveCallgraph,
+enum EventAggregationModePos {
+  kSumPos = 0,
+  kLiveSumPos = 1,
+  kNbEventAggregationModes
 };
 
-ALLOW_FLAGS_FOR_ENUM(EventConfMode)
+// Defines how a sample is aggregated when it is received
+enum class EventAggregationMode : uint32_t {
+  kDisabled = 0,
+  kSum = 1 << kSumPos,         // Sum of usage (example: overall CPU usage)
+  kLiveSum = 1 << kLiveSumPos, // Report live usage (example memory leaks)
+  kAll = kSum | kLiveSum,
+};
 
-constexpr bool Any(EventConfMode arg) {
-  return arg != EventConfMode::kDisabled;
-}
+ALLOW_FLAGS_FOR_ENUM(EventAggregationMode)
 
-constexpr bool AnyCallgraph(EventConfMode arg) {
-  return Any((arg & EventConfMode::kLiveCallgraph) |
-             (arg & EventConfMode::kCallgraph));
+constexpr bool Any(EventAggregationMode arg) {
+  return arg != EventAggregationMode::kDisabled;
 }
 
 // Defines how samples are weighted
@@ -135,7 +135,7 @@ enum class EventConfField {
 };
 
 struct EventConf {
-  EventConfMode mode{};
+  EventAggregationMode mode{};
 
   int64_t id{};
 

--- a/include/pprof/ddprof_pprof.hpp
+++ b/include/pprof/ddprof_pprof.hpp
@@ -36,7 +36,7 @@ DDRes pprof_create_profile(DDProfPProf *pprof, DDProfContext &ctx);
 DDRes pprof_aggregate(const UnwindOutput *uw_output,
                       const SymbolHdr &symbol_hdr, uint64_t value,
                       uint64_t count, const PerfWatcher *watcher,
-                      DDProfPProf *pprof);
+                      EventAggregationModePos value_pos, DDProfPProf *pprof);
 
 DDRes pprof_reset(DDProfPProf *pprof);
 
@@ -46,6 +46,7 @@ DDRes pprof_free_profile(DDProfPProf *pprof);
 
 void ddprof_print_sample(const UnwindOutput &uw_output,
                          const SymbolHdr &symbol_hdr, uint64_t value,
+                         EventAggregationModePos value_mode_pos,
                          const PerfWatcher &watcher);
 
 } // namespace ddprof

--- a/src/ddprof_cmdline.cc
+++ b/src/ddprof_cmdline.cc
@@ -90,15 +90,7 @@ bool watcher_from_config(EventConf *conf, PerfWatcher *watcher) {
   if (conf->value_scale != 0.0) {
     watcher->value_scale = conf->value_scale;
   }
-
-  // The output mode isn't set as part of the configuration templates; we
-  // always default to callgraph mode
-  if (conf->mode != EventConfMode::kDisabled) {
-    watcher->output_mode = conf->mode;
-  } else {
-    watcher->output_mode = EventConfMode::kCallgraph;
-  }
-
+  watcher->aggregation_mode = conf->mode;
   watcher->tracepoint_event = conf->eventname;
   watcher->tracepoint_group = conf->groupname;
   watcher->tracepoint_label = conf->label;
@@ -142,7 +134,10 @@ bool arg_yesno(const char *str, int mode) {
 bool watchers_from_str(const char *str, std::vector<PerfWatcher> &watchers,
                        uint32_t stack_sample_size) {
   std::vector<EventConf> configs;
-  const EventConf template_conf{.stack_sample_size = stack_sample_size};
+  const EventConf template_conf{
+      .mode = EventAggregationMode::kSum,
+      .stack_sample_size = stack_sample_size,
+  };
   if (EventConf_parse(str, template_conf, configs) != 0) {
     return false;
   }

--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -341,8 +341,8 @@ int start_profiler_internal(std::unique_ptr<DDProfContext> ctx,
         reply.loaded_libs_check_interval_ms =
             ctx->params.loaded_libs_check_interval.count();
 
-        if (ctx->watchers[alloc_watcher_idx].output_mode ==
-            EventConfMode::kLiveCallgraph) {
+        if (ctx->watchers[alloc_watcher_idx].aggregation_mode ==
+            EventAggregationMode::kLiveSum) {
           reply.allocation_flags |= (1 << ReplyMessage::kLiveCallgraph);
         }
       }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -162,7 +162,8 @@ add_unit_test(
   DEFINITIONS MYNAME="pevent-ut")
 
 add_unit_test(
-  ddprof_pprof-ut ../src/pprof/ddprof_pprof.cc ../src/perf_watcher.cc ddprof_pprof-ut.cc
+  ddprof_pprof-ut ddprof_pprof-ut.cc ../src/ddprof_cmdline.cc ../src/pprof/ddprof_pprof.cc
+  ../src/perf_watcher.cc ../src/tracepoint_config.cc
   LIBRARIES Datadog::Profiling DDProf::Parser
   DEFINITIONS MYNAME="ddprof_pprof-ut")
 

--- a/test/ddprof_context-ut.cc
+++ b/test/ddprof_context-ut.cc
@@ -186,9 +186,9 @@ TEST(DDProfContext, cpu_live_heap_preset) {
 
   ASSERT_EQ(ctx.watchers.size(), 2);
   EXPECT_EQ(ctx.watchers[1].ddprof_event_type, DDPROF_PWE_sALLOC);
-  EXPECT_EQ(ctx.watchers[1].output_mode, EventConfMode::kLiveCallgraph);
+  EXPECT_EQ(ctx.watchers[1].aggregation_mode, EventAggregationMode::kLiveSum);
   EXPECT_EQ(ctx.watchers[0].ddprof_event_type, DDPROF_PWE_sCPU);
-  EXPECT_EQ(ctx.watchers[0].output_mode, EventConfMode::kCallgraph);
+  EXPECT_EQ(ctx.watchers[0].aggregation_mode, EventAggregationMode::kSum);
 }
 
 TEST(DDProfContext, manual_live_allocation_setting) {
@@ -208,7 +208,7 @@ TEST(DDProfContext, manual_live_allocation_setting) {
   // there is a dummy in addition to the allocations
   ASSERT_EQ(ctx.watchers.size(), 2);
   EXPECT_EQ(ctx.watchers[1].ddprof_event_type, DDPROF_PWE_sALLOC);
-  EXPECT_EQ(ctx.watchers[1].output_mode, EventConfMode::kLiveCallgraph);
+  EXPECT_EQ(ctx.watchers[1].aggregation_mode, EventAggregationMode::kLiveSum);
 
   log_watcher(&ctx.watchers[0], 0);
   log_watcher(&ctx.watchers[1], 1);

--- a/test/ddprof_exporter-ut.cc
+++ b/test/ddprof_exporter-ut.cc
@@ -159,7 +159,7 @@ TEST(DDProfExporter, simple) {
     res = pprof_create_profile(&pprofs, ctx);
     EXPECT_TRUE(IsDDResOK(res));
     res = pprof_aggregate(&mock_output, symbol_hdr, 1000, 1, &ctx.watchers[0],
-                          &pprofs);
+                          kSumPos, &pprofs);
     EXPECT_TRUE(IsDDResOK(res));
   }
   {

--- a/test/ddprofcmdline-ut.cc
+++ b/test/ddprofcmdline-ut.cc
@@ -166,79 +166,48 @@ TEST(CmdLineTst, ParserKeyPatterns) {
   ASSERT_FALSE(watcher_from_str("e=hCPU label=14631", &watcher));
 
   // m|mode
-  ASSERT_TRUE(watcher_from_str("e=hCPU m=g", &watcher));
-  ASSERT_TRUE(watcher_from_str("e=hCPU mode=g", &watcher));
+  ASSERT_FALSE(watcher_from_str("e=hCPU m=g", &watcher));
+  ASSERT_TRUE(watcher_from_str("e=hCPU m=s", &watcher));
+  ASSERT_TRUE(watcher_from_str("e=hCPU mode=s", &watcher));
 
   // Mode is not permissive
   ASSERT_FALSE(watcher_from_str("e=hCPU mode=magnanimous", &watcher));
 
   // A or a designate all
   ASSERT_TRUE(watcher_from_str("e=hCPU mode=A", &watcher));
-  ASSERT_TRUE(Any(watcher.output_mode & EventConfMode::kCallgraph));
-  ASSERT_TRUE(Any(watcher.output_mode & EventConfMode::kMetric));
+  ASSERT_TRUE(Any(watcher.aggregation_mode & EventAggregationMode::kSum));
   ASSERT_TRUE(watcher_from_str("e=hCPU mode=a", &watcher));
-  ASSERT_TRUE(Any(watcher.output_mode &
-                  EventConfMode::kCallgraph)); // watcher.output_mode <=
-                                               // EventConfMode::kCallgraph
-  ASSERT_TRUE(Any(
-      watcher.output_mode &
-      EventConfMode::kMetric)); // watcher.output_mode <= EventConfMode::kMetric
+  ASSERT_TRUE(Any(watcher.aggregation_mode &
+                  EventAggregationMode::kSum)); // watcher.output_mode <=
+                                                // EventConfMode::kCallgraph
 
   // both m and g together designate all
-  ASSERT_TRUE(watcher_from_str("e=hCPU mode=MG", &watcher));
-  ASSERT_TRUE(Any(watcher.output_mode &
-                  EventConfMode::kCallgraph)); // watcher.output_mode <=
-                                               // EventConfMode::kCallgraph
-  ASSERT_TRUE(Any(
-      watcher.output_mode &
-      EventConfMode::kMetric)); // watcher.output_mode <= EventConfMode::kMetric
-  ASSERT_TRUE(watcher_from_str("e=hCPU mode=mg", &watcher));
-  ASSERT_TRUE(Any(watcher.output_mode &
-                  EventConfMode::kCallgraph)); // watcher.output_mode <=
-                                               // EventConfMode::kCallgraph
-  ASSERT_TRUE(Any(
-      watcher.output_mode &
-      EventConfMode::kMetric)); // watcher.output_mode <= EventConfMode::kMetric
+  ASSERT_TRUE(watcher_from_str("e=hCPU mode=SL", &watcher));
+  ASSERT_TRUE(Any(watcher.aggregation_mode &
+                  EventAggregationMode::kSum)); // watcher.output_mode <=
+                                                // EventConfMode::kCallgraph
+  ASSERT_TRUE(watcher_from_str("e=hCPU mode=sl", &watcher));
+  EXPECT_TRUE(Any(watcher.aggregation_mode & EventAggregationMode::kLiveSum));
+  EXPECT_TRUE(Any(watcher.aggregation_mode & EventAggregationMode::kSum));
+  ASSERT_TRUE(Any(watcher.aggregation_mode &
+                  EventAggregationMode::kSum)); // watcher.output_mode <=
+                                                // EventConfMode::kCallgraph
 
   // M or m is a metric (no callgraph unless specified)
-  ASSERT_TRUE(watcher_from_str("e=hCPU mode=M", &watcher));
-  ASSERT_FALSE(Any(watcher.output_mode &
-                   EventConfMode::kCallgraph)); // watcher.output_mode <=
+  ASSERT_TRUE(watcher_from_str("e=hCPU mode=s", &watcher));
+  ASSERT_TRUE(Any(watcher.aggregation_mode &
+                  EventAggregationMode::kSum)); // watcher.output_mode <=
                                                 // EventConfMode::kCallgraph
-  ASSERT_TRUE(Any(
-      watcher.output_mode &
-      EventConfMode::kMetric)); // watcher.output_mode <= EventConfMode::kMetric
-  ASSERT_TRUE(watcher_from_str("e=hCPU mode=m", &watcher));
-  ASSERT_FALSE(Any(watcher.output_mode &
-                   EventConfMode::kCallgraph)); // watcher.output_mode <=
+  ASSERT_TRUE(watcher_from_str("e=hCPU mode=S", &watcher));
+  ASSERT_TRUE(Any(watcher.aggregation_mode &
+                  EventAggregationMode::kSum)); // watcher.output_mode <=
                                                 // EventConfMode::kCallgraph
-  ASSERT_TRUE(Any(
-      watcher.output_mode &
-      EventConfMode::kMetric)); // watcher.output_mode <= EventConfMode::kMetric
 
   // G or g designate callgraph (default)
   ASSERT_TRUE(watcher_from_str("e=hCPU", &watcher));
-  ASSERT_TRUE(Any(watcher.output_mode &
-                  EventConfMode::kCallgraph)); // watcher.output_mode <=
-                                               // EventConfMode::kCallgraph
-  ASSERT_FALSE(Any(
-      watcher.output_mode &
-      EventConfMode::kMetric)); // watcher.output_mode <= EventConfMode::kMetric
-  ASSERT_TRUE(watcher_from_str("e=hCPU mode=G", &watcher));
-  ASSERT_TRUE(Any(watcher.output_mode &
-                  EventConfMode::kCallgraph)); // watcher.output_mode <=
-                                               // EventConfMode::kCallgraph
-  ASSERT_FALSE(Any(
-      watcher.output_mode &
-      EventConfMode::kMetric)); // watcher.output_mode <= EventConfMode::kMetric
-  ASSERT_TRUE(watcher_from_str("e=hCPU mode=g", &watcher));
-  ASSERT_TRUE(Any(watcher.output_mode &
-                  EventConfMode::kCallgraph)); // watcher.output_mode <=
-                                               // EventConfMode::kCallgraph
-  ASSERT_FALSE(Any(
-      watcher.output_mode &
-      EventConfMode::kMetric)); // watcher.output_mode <= EventConfMode::kMetric
-
+  ASSERT_TRUE(Any(watcher.aggregation_mode &
+                  EventAggregationMode::kSum)); // watcher.output_mode <=
+                                                // EventConfMode::kCallgraph
   // n|arg_num|argno
   ASSERT_TRUE(watcher_from_str("e=hCPU n=1", &watcher));
   ASSERT_TRUE(watcher_from_str("e=hCPU argno=1", &watcher));
@@ -355,6 +324,13 @@ TEST(CmdLineTst, LiteralEventWithVeryBadValue) {
   char const *str = "hCPU period=apples";
   PerfWatcher watcher = {};
   ASSERT_FALSE(watcher_from_str(str, &watcher));
+}
+
+TEST(CmdLineTst, LiteralEventWithRedundantSettings) {
+  char const *str = "hCPU mode=l mode=a";
+  PerfWatcher watcher = {};
+  // todo this parsing should not be OK
+  ASSERT_TRUE(watcher_from_str(str, &watcher));
 }
 
 TEST(CmdLineTst, LiteralEventWithKindaBadValue) {

--- a/tools/launch_local_build.sh
+++ b/tools/launch_local_build.sh
@@ -162,6 +162,6 @@ else
   MOUNT_TOOLS_DIR=""
 fi
 
-CMD="docker run -it --rm  -w /app ${MOUNT_SSH_AGENT} ${MOUNT_TOOLS_DIR} --cap-add CAP_SYS_PTRACE --cap-add SYS_ADMIN ${MOUNT_CMD} \"${DOCKER_NAME}${DOCKER_TAG}\" /bin/bash"
+CMD="docker run -it --rm -u $(id -u):$(id -g) -w /app ${MOUNT_SSH_AGENT} ${MOUNT_TOOLS_DIR} --cap-add CAP_SYS_PTRACE --cap-add SYS_ADMIN ${MOUNT_CMD} \"${DOCKER_NAME}${DOCKER_TAG}\" /bin/bash"
 
 eval "$CMD"

--- a/tools/style-check.sh
+++ b/tools/style-check.sh
@@ -12,7 +12,7 @@ cd "$SCRIPT_DIR/.."
 # Find most recent clang-format, defaulting to an unqualified default
 CLANG_FORMAT=$(command -v clang-format{-16,-15,-13,-12,-11,-10,-9,} | head -n1)
 if [ -z "${CLANG_FORMAT}" ]; then
-  echo "Please use clang format 16"
+  echo "Please install clang-format"
   exit 1
 fi
 eval "$CLANG_FORMAT --version"


### PR DESCRIPTION
# What does this PR do?

- Adjust the watcher configuration to define profile types for in use objects
- Remove the unused metric type
- Allow allocation samples to co-exist with in use objects

# Motivation

Insure in use objects are available as a separate profile type.

# Additional Notes

This is a rebase of following PR
- https://github.com/DataDog/ddprof/pull/302

Downstream test PR:
https://github.com/DataDog/ddprof-build/pull/113

# How to test the change?

The change is tested through simple_malloc