### PR TITLE
Fix elf segment matching (again)

### DIFF
--- a/include/ddprof_module_lib.hpp
+++ b/include/ddprof_module_lib.hpp
@@ -38,9 +38,10 @@ struct Mapping {
 std::vector<Mapping>
 get_executable_mappings(const DsoHdr::DsoConstRange &dsoRange);
 
-// Retrieve executable LOAD segments from a elf file
-DDRes get_executable_segments(int fd, const std::string &filepath,
-                              std::vector<Segment> &segments);
+// Retrieve LOAD segments from a elf file
+DDRes get_elf_load_segments(int fd, const std::string &filepath,
+                            bool keep_only_executable_segments,
+                            std::vector<Segment> &segments);
 
 struct MatchResult {
   const Mapping *mapping;
@@ -49,8 +50,9 @@ struct MatchResult {
 };
 
 // Find a matching mapping / load segment pair
-MatchResult find_match(std::span<const Mapping> executable_mappings,
-                       std::span<const Segment> elf_load_segments);
+MatchResult find_match(std::span<const Mapping> mappings,
+                       std::span<const Segment> elf_load_segments,
+                       bool possible_missing_mappings);
 
 // From a dso object (and the matching file), attach the module to the dwfl
 // object, return the associated Dwfl_Module

--- a/include/dso.hpp
+++ b/include/dso.hpp
@@ -55,7 +55,7 @@ public:
   std::string _filename; // path as perceived by the user
   inode_t _inode;
   uint32_t _prot;
-  dso::DsoType _type;
+  DsoType _type;
   mutable FileInfoId_t _id;
 
 private:

--- a/include/dso.hpp
+++ b/include/dso.hpp
@@ -35,9 +35,9 @@ public:
 
   // Check if the provided address falls within the provided dso
   bool is_within(ProcessAddress_t addr) const;
-  // Avoid use of strict == as we do not consider _end in comparison
-  bool operator==(const Dso &o) const = delete;
-  // perf gives larger regions than proc maps (keep the largest of them)
+
+  // strict comparison
+  bool operator==(const Dso &o) const = default;
 
   bool intersects(const Dso &o) const;
 
@@ -48,6 +48,13 @@ public:
 
   // Adjust as linker can reduce size of mmap
   bool adjust_same(const Dso &o);
+  void adjust_end(ProcessAddress_t new_end);
+  void adjust_start(ProcessAddress_t new_start);
+
+  // check that o is the same as this except for the size that can be smaller
+  bool is_same_or_smaller(const Dso &o) const;
+  bool is_same_file(const Dso &o) const;
+
   size_t size() const { return _end - _start; }
   ProcessAddress_t start() const { return _start; }
   // Beware, end is inclusive !

--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -175,7 +175,7 @@ private:
     BackpopulatePermission _perm;
   };
 
-  // Associate pid to a backpopulation state
+  // Associate pid to a backpopulate state
   typedef std::unordered_map<pid_t, BackpopulateState> BackpopulateStateMap;
 
   // erase range of elements
@@ -201,7 +201,7 @@ private:
 
   int _dd_profiling_fd;
   // Assumption is that we have a single version of the dd_profiling library
-  // accross all PIDs.
+  // across all PIDs.
   FileInfoId_t _dd_profiling_file_info = k_file_info_undef;
 };
 

--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -131,7 +131,7 @@ public:
   static DsoConstRange get_elf_range(const DsoMap &map, DsoMapConstIt it);
 
   // Helper to create a dso from a line in /proc/pid/maps
-  static Dso dso_from_proc_line(int pid, char *line);
+  static Dso dso_from_proc_line(int pid, const char *line);
 
   static DsoFindRes find_res_not_found(const DsoMap &map) {
     return {map.end(), false};

--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -180,7 +180,7 @@ private:
   typedef std::unordered_map<pid_t, BackpopulateState> BackpopulateStateMap;
 
   // erase range of elements
-  static void erase_range(DsoMap &map, const DsoConstRange &range);
+  static void erase_range(DsoMap &map, DsoRange range, const Dso &new_mapping);
 
   // parse procfs to look for dso elements
   bool pid_backpopulate(PidMapping &pid_mapping, pid_t pid, int &nb_elts_added);

--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -35,9 +35,9 @@ public:
     DSO_EVENT_TABLE(X_DSO_EVENT_ENUM) kNbDsoEventTypes,
   };
 
-  void incr_metric(DsoEventType dso_event, dso::DsoType path_type) {
+  void incr_metric(DsoEventType dso_event, DsoType path_type) {
     assert(dso_event < kNbDsoEventTypes);
-    ++_metrics[dso_event][path_type];
+    ++_metrics[dso_event][static_cast<size_t>(path_type)];
   }
 
   uint64_t sum_event_metric(DsoEventType dso_event) const;
@@ -49,13 +49,14 @@ public:
   }
 
 private:
+  using MetricPerDsoType =
+      std::array<uint64_t, static_cast<size_t>(DsoType::kNbDsoTypes)>;
   static const char *s_event_dbg_str[kNbDsoEventTypes];
-  static void
-  reset_event_metric(std::array<uint64_t, dso::kNbDsoTypes> &metric_array) {
+  static void reset_event_metric(MetricPerDsoType &metric_array) {
     std::fill(metric_array.begin(), metric_array.end(), 0);
   }
   // log events according to dso types
-  std::array<std::array<uint64_t, dso::kNbDsoTypes>, kNbDsoEventTypes> _metrics;
+  std::array<MetricPerDsoType, kNbDsoEventTypes> _metrics;
 };
 
 /**************

--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -131,7 +131,7 @@ public:
   static DsoConstRange get_elf_range(const DsoMap &map, DsoMapConstIt it);
 
   // Helper to create a dso from a line in /proc/pid/maps
-  static Dso dso_from_procline(int pid, char *line);
+  static Dso dso_from_proc_line(int pid, char *line);
 
   static DsoFindRes find_res_not_found(const DsoMap &map) {
     return {map.end(), false};

--- a/include/dso_symbol_lookup.hpp
+++ b/include/dso_symbol_lookup.hpp
@@ -30,7 +30,7 @@ private:
   SymbolIdx_t get_or_insert_unhandled_type(const Dso &dso,
                                            SymbolTable &symbol_table);
   // map of maps --> the aim is to monitor usage of some maps and clear them
-  // toghether
+  // together
   // TODO : find efficient clear on symbol table before we do this
   typedef std::unordered_map<FileAddress_t, SymbolIdx_t> AddressMap;
   typedef std::unordered_map<std::string, AddressMap> DsoPathMap;

--- a/include/dso_symbol_lookup.hpp
+++ b/include/dso_symbol_lookup.hpp
@@ -36,8 +36,7 @@ private:
   typedef std::unordered_map<std::string, AddressMap> DsoPathMap;
   DsoPathMap _map_dso_path;
   // For non-standard DSO types, address is not relevant
-  std::unordered_map<dso::DsoType, SymbolIdx_t, EnumClassHash>
-      _map_unhandled_dso;
+  std::unordered_map<DsoType, SymbolIdx_t, EnumClassHash> _map_unhandled_dso;
 };
 
 } // namespace ddprof

--- a/include/dso_type.hpp
+++ b/include/dso_type.hpp
@@ -5,9 +5,11 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace ddprof {
-namespace dso {
-enum DsoType {
+
+enum class DsoType : uint8_t {
   kStandard = 0, // meaning backed by a file that we can open
   kVdso,
   kVsysCall,
@@ -22,49 +24,48 @@ enum DsoType {
   kNbDsoTypes
 };
 
-static inline bool has_relevant_path(dso::DsoType dso_type) {
-  if (dso_type == kDDProfiling) {
+inline bool has_relevant_path(DsoType dso_type) {
+  if (dso_type == DsoType::kDDProfiling) {
     return true;
   }
-  if (dso_type == kStandard) {
+  if (dso_type == DsoType::kStandard) {
     return true;
   }
   return false;
 }
 
 // some runtimes such as java or .NET can publish maps to populate the symbols
-static inline bool has_runtime_symbols(dso::DsoType dso_type) {
-  return dso_type == kRuntime || dso_type == kAnon;
+inline bool has_runtime_symbols(DsoType dso_type) {
+  return dso_type == DsoType::kRuntime || dso_type == DsoType::kAnon;
 }
 
 // todo : find an enum that supports to_str
-static inline const char *dso_type_str(DsoType path_type) {
+inline const char *dso_type_str(DsoType path_type) {
   switch (path_type) {
-  case kStandard:
+  case DsoType::kStandard:
     return "Standard";
-  case kVdso:
+  case DsoType::kVdso:
     return "Vdso";
-  case kVsysCall:
+  case DsoType::kVsysCall:
     return "VsysCall";
-  case kStack:
+  case DsoType::kStack:
     return "Stack";
-  case kHeap:
+  case DsoType::kHeap:
     return "Heap";
-  case kUndef:
+  case DsoType::kUndef:
     return "Undefined";
-  case kAnon:
+  case DsoType::kAnon:
     return "Anonymous";
-  case kRuntime:
+  case DsoType::kRuntime:
     return "Runtime";
-  case kSocket:
+  case DsoType::kSocket:
     return "kSocket";
-  case kDDProfiling:
+  case DsoType::kDDProfiling:
     return "kDDProfiling";
   default:
     break;
   }
   return "Unhandled";
 }
-} // namespace dso
 
 } // namespace ddprof

--- a/include/perf_watcher.hpp
+++ b/include/perf_watcher.hpp
@@ -25,7 +25,7 @@ struct PerfWatcherOptions {
   bool is_freq;
   uint8_t nb_frames_to_skip; // number of bottom frames to skip in stack trace
                              // (useful for allocation profiling to remove
-                             // frames belonging to lib_ddprofiling.so)
+                             // frames belonging to libdd_profiling.so)
   uint32_t stack_sample_size{
       k_default_perf_stack_sample_size}; // size of the user stack to capture
 };
@@ -63,7 +63,7 @@ struct PerfWatcher {
   bool suppress_pid;
   bool suppress_tid;
   PProfIndices pprof_indices[kNbEventAggregationModes]; // std and live
-  bool instrument_self; // do my own perfopen, etc
+  bool instrument_self; // do my own perf_event_open, etc
   EventAggregationMode aggregation_mode;
 };
 

--- a/src/base_frame_symbol_lookup.cc
+++ b/src/base_frame_symbol_lookup.cc
@@ -26,7 +26,7 @@ BaseFrameSymbolLookup::insert_bin_symbol(pid_t pid, SymbolTable &symbol_table,
 
   DsoHdr::DsoFindRes const find_res =
       dso_hdr.dso_find_first_std_executable(pid);
-  if (find_res.second && dso::has_relevant_path(find_res.first->second._type)) {
+  if (find_res.second && has_relevant_path(find_res.first->second._type)) {
     // todo : how to tie lifetime of DSO to this ?
     symbol_idx =
         dso_symbol_lookup.get_or_insert(find_res.first->second, symbol_table);

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -207,7 +207,7 @@ DDRes ddprof_unwind_sample(DDProfContext &ctx, perf_event_sample *sample,
   }
 
   if (us->_dwfl_wrapper->_inconsistent) {
-    // Loaded modules were inconsistend, assume we should flush everything.
+    // Loaded modules were inconsistent, assume we should flush everything.
     LG_WRN("(Inconsistent DWFL/DSOs)%d - Free associated objects", us->pid);
     DDRES_CHECK_FWD(worker_pid_free(ctx, us->pid));
   }
@@ -413,7 +413,7 @@ DDRes ddprof_pr_sample(DDProfContext &ctx, perf_event_sample *sample,
 
 void *ddprof_worker_export_thread(void *arg) {
   auto *worker = static_cast<DDProfWorkerContext *>(arg);
-  // export the one we are not writting to
+  // export the one we are not writing to
   int const i = 1 - worker->i_current_pprof;
   // Increase number of sequences in persistent storage
   // This should start at 0, and if exporter thread
@@ -450,11 +450,11 @@ DDRes ddprof_worker_cycle(DDProfContext &ctx,
   if (ctx.worker_ctx.exp_tid) {
     struct timespec waittime;
     clock_gettime(CLOCK_REALTIME, &waittime);
-    auto waitsec =
+    auto wait_sec =
         std::chrono::seconds{k_export_timeout - ctx.params.upload_period}
             .count();
-    waitsec = waitsec > 1 ? waitsec : 1;
-    waittime.tv_sec += waitsec;
+    wait_sec = wait_sec > 1 ? wait_sec : 1;
+    waittime.tv_sec += wait_sec;
     if (pthread_timedjoin_np(ctx.worker_ctx.exp_tid, nullptr, &waittime)) {
       LG_WRN("Exporter took too long");
       return ddres_create(DD_SEVERROR, DD_WHAT_EXPORT_TIMEOUT);
@@ -672,7 +672,7 @@ DDRes ddprof_worker_free(DDProfContext &ctx) {
 }
 
 // Simple wrapper over perf_event_hdr in order to filter by PID in a uniform
-// way.  Whenver PID is a valid concept for the given event type, the
+// way.  Whenever PID is a valid concept for the given event type, the
 // interface uniformly presents PID as the element immediately after the
 // header.
 struct perf_event_hdr_wpid : perf_event_header {

--- a/src/dso.cc
+++ b/src/dso.cc
@@ -82,7 +82,7 @@ Dso::Dso(pid_t pid, ElfAddress_t start, ElfAddress_t end, ElfAddress_t pgoff,
 }
 
 // The string should end with: "jit-[0-9]+\\.dump"
-// and the number should be the pid, however, in wholehost mode
+// and the number should be the pid, however, in whole host mode
 // we don't have visibility on the namespace's PID value.
 bool Dso::is_jit_dump_str(std::string_view file_path) {
   const std::string_view prefix = "jit-";
@@ -153,7 +153,7 @@ bool Dso::adjust_same(const Dso &o) {
 
 bool Dso::intersects(const Dso &o) const {
   // Check order of points
-  // Test that we have lowest-start <-> lowest-end  ... highiest-start
+  // Test that we have lowest-start <-> lowest-end  ... highest-start
   if (_start < o._start) {
     // this Dso comes first check then it ends before the other
     if (_end < o._start) {

--- a/src/dso.cc
+++ b/src/dso.cc
@@ -124,8 +124,16 @@ std::ostream &operator<<(std::ostream &os, const Dso &dso) {
 // Example :
 // PID<1> 7f763019e000-7f76304ddfff (//anon)
 // PID<1> 7f763019e000-7f76304de000 ()
-
 bool Dso::adjust_same(const Dso &o) {
+  if (is_same_or_smaller(o)) {
+    _end = o._end;
+     _origin = o._origin;
+    return true;
+  }
+  return false;
+}
+
+bool Dso::is_same_or_smaller(const Dso &o) const {
   if (_start != o._start) {
     return false;
   }
@@ -143,9 +151,7 @@ bool Dso::adjust_same(const Dso &o) {
   if (_prot != o._prot) {
     return false;
   }
-  _end = o._end;
-  _origin = o._origin;
-  return true;
+  return o._end <= _end;
 }
 
 bool Dso::intersects(const Dso &o) const {

--- a/src/dso.cc
+++ b/src/dso.cc
@@ -127,11 +127,15 @@ std::ostream &operator<<(std::ostream &os, const Dso &dso) {
 bool Dso::adjust_same(const Dso &o) {
   if (is_same_or_smaller(o)) {
     _end = o._end;
-     _origin = o._origin;
+    _origin = o._origin;
     return true;
   }
   return false;
 }
+
+void Dso::adjust_end(ProcessAddress_t new_end) { _end = new_end; }
+
+void Dso::adjust_start(ProcessAddress_t new_start) { _start = new_start; }
 
 bool Dso::is_same_or_smaller(const Dso &o) const {
   if (_start != o._start) {
@@ -152,6 +156,11 @@ bool Dso::is_same_or_smaller(const Dso &o) const {
     return false;
   }
   return o._end <= _end;
+}
+
+bool Dso::is_same_file(const Dso &o) const {
+  return _type == o._type && (_type == DsoType::kStandard) &&
+      _filename == o._filename && _inode == o._inode;
 }
 
 bool Dso::intersects(const Dso &o) const {

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -488,7 +488,6 @@ Dso DsoHdr::dso_from_procline(int pid, char *line) {
     ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
   */
   // clang-format on
-  static const char spec[] = "%lx-%lx %4c %lx %x:%x %lu%n";
   uint64_t m_start = 0;
   uint64_t m_end = 0;
   uint64_t m_off = 0;
@@ -498,13 +497,15 @@ Dso DsoHdr::dso_from_procline(int pid, char *line) {
   uint32_t m_dev_minor = 0;
   uint64_t m_inode = 0;
 
-  // Check for formatting errors
+  // %n specifier does not increase count returned by sscanf
   constexpr int k_expected_number_of_matches = 7;
+  // Check for formatting errors
   if (k_expected_number_of_matches !=
-      sscanf(line, spec, &m_start, &m_end, m_mode, &m_off, &m_dev_major,
-             &m_dev_minor, &m_inode, &m_p)) {
-    LG_ERR("[DSO] Failed to scan mapfile line");
-    throw DDException(DD_SEVERROR, DD_WHAT_DSO);
+      // NOLINTNEXTLINE(cert-err34-c)
+      sscanf(line, "%lx-%lx %4c %lx %x:%x %lu%n", &m_start, &m_end, m_mode,
+             &m_off, &m_dev_major, &m_dev_minor, &m_inode, &m_p)) {
+    LG_ERR("[DSO] Failed to scan proc line: %s", line);
+    return {};
   }
 
   // Make sure the name index points to a valid char

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -471,14 +471,14 @@ Dso DsoHdr::dso_from_procline(int pid, char *line) {
     *q = '\0';
   }
 
-  // Should we store non exec dso ?
   return {pid,
           m_start,
           m_end - 1,
           m_off,
           std::string(p),
           m_inode,
-          mode_string_to_prot(m_mode)};
+          mode_string_to_prot(m_mode),
+          DsoOrigin::kProcMaps};
 }
 
 FileInfo DsoHdr::find_file_info(const Dso &dso) {

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -208,7 +208,7 @@ DsoHdr::DsoRange DsoHdr::get_intersection(DsoMap &map, const Dso &dso) {
   auto start = map.end();
   auto end = map.end();
 
-  // Loop accross the possible range keeping track of first and last
+  // Loop across the possible range keeping track of first and last
   while (first_el != map.end()) {
     if (dso.intersects(first_el->second)) {
       if (start == map.end()) {

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -73,12 +73,11 @@ const char *DsoStats::s_event_dbg_str[] = {
 void DsoStats::log() const {
   for (int event_type = 0; event_type < kNbDsoEventTypes; ++event_type) {
     const auto &metric_vec = _metrics[event_type];
-    for (int i = 0; i < dso::kNbDsoTypes; ++i) {
+    for (int i = 0; i < static_cast<int>(DsoType::kNbDsoTypes); ++i) {
       if (metric_vec[i]) {
-        const char *dso_type_str =
-            dso::dso_type_str(static_cast<dso::DsoType>(i));
+        const char *dso_type = dso_type_str(static_cast<DsoType>(i));
         LG_NTC("[DSO] %10s | %10s | %8lu |", s_event_dbg_str[event_type],
-               dso_type_str, metric_vec[i]);
+               dso_type, metric_vec[i]);
       }
     }
   }
@@ -137,7 +136,7 @@ DsoHdr::DsoFindRes DsoHdr::dso_find_first_std_executable(pid_t pid) {
   auto it = map.lower_bound(0);
   // look for the first executable standard region
   while (it != map.end() && !it->second.is_executable() &&
-         it->second._type != dso::kStandard) {
+         it->second._type != DsoType::kStandard) {
     ++it;
   }
   if (it == map.end()) {
@@ -307,12 +306,12 @@ FileInfoId_t DsoHdr::update_id_from_path(const Dso &dso) {
 }
 
 FileInfoId_t DsoHdr::update_id_from_dso(const Dso &dso) {
-  if (!dso::has_relevant_path(dso._type)) {
+  if (!has_relevant_path(dso._type)) {
     dso._id = k_file_info_error; // no file associated
     return dso._id;
   }
 
-  if (dso._type == dso::DsoType::kDDProfiling) {
+  if (dso._type == DsoType::kDDProfiling) {
     return update_id_dd_profiling(dso);
   }
 
@@ -335,7 +334,7 @@ DsoHdr::DsoFindRes DsoHdr::insert_erase_overlap(PidMapping &pid_mapping,
     erase_range(map, range);
   }
   // JITDump Marker was detected for this PID
-  if (dso._type == dso::kJITDump) {
+  if (dso._type == DsoType::kJITDump) {
     pid_mapping._jitdump_addr = dso._start;
   }
   _stats.incr_metric(DsoStats::kNewDso, dso._type);

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -455,7 +455,7 @@ bool DsoHdr::pid_backpopulate(PidMapping &pid_mapping, pid_t pid,
   size_t sz_buf = 0;
 
   while (-1 != getline(&buf, &sz_buf, proc_map_file_holder.get())) {
-    Dso dso = dso_from_procline(pid, buf);
+    Dso dso = dso_from_proc_line(pid, buf);
     if (dso._pid == -1) { // invalid dso
       continue;
     }
@@ -469,7 +469,7 @@ bool DsoHdr::pid_backpopulate(PidMapping &pid_mapping, pid_t pid,
   return true;
 }
 
-Dso DsoHdr::dso_from_procline(int pid, char *line) {
+Dso DsoHdr::dso_from_proc_line(int pid, char *line) {
   // clang-format off
   // Example of format
   /*

--- a/src/dso_symbol_lookup.cc
+++ b/src/dso_symbol_lookup.cc
@@ -17,7 +17,7 @@ namespace ddprof {
 namespace {
 
 Symbol symbol_from_unhandled_dso(const Dso &dso) {
-  return {std::string(), std::string(), 0, dso::dso_type_str(dso._type)};
+  return {std::string(), std::string(), 0, dso_type_str(dso._type)};
 }
 
 Symbol symbol_from_dso(ElfAddress_t normalized_addr, const Dso &dso,
@@ -51,8 +51,8 @@ SymbolIdx_t DsoSymbolLookup::get_or_insert(FileAddress_t normalized_addr,
                                            SymbolTable &symbol_table,
                                            std::string_view addr_type) {
   // Only add address information for relevant dso types
-  if (!dso::has_relevant_path(dso._type) && dso._type != dso::kVdso &&
-      dso._type != dso::kVsysCall) {
+  if (!has_relevant_path(dso._type) && dso._type != DsoType::kVdso &&
+      dso._type != DsoType::kVsysCall) {
     return get_or_insert_unhandled_type(dso, symbol_table);
   }
   // Note: using file ID could be more generic

--- a/src/mapinfo_lookup.cc
+++ b/src/mapinfo_lookup.cc
@@ -22,7 +22,7 @@ MapInfoIdx_t MapInfoLookup::get_or_insert(pid_t pid,
         ? dso._filename
         : dso._filename.substr(pos + 1);
     MapInfoIdx_t const map_info_idx = mapinfo_table.size();
-    mapinfo_table.emplace_back(dso._start, dso._end, dso._pgoff,
+    mapinfo_table.emplace_back(dso._start, dso._end, dso._offset,
                                std::move(sname_str),
                                build_id ? *build_id : BuildIdStr{});
     addr_map.emplace(dso._start, map_info_idx);

--- a/src/pevent_lib.cc
+++ b/src/pevent_lib.cc
@@ -101,7 +101,7 @@ DDRes pevent_register_cpu_0(const PerfWatcher *watcher, int watcher_idx,
   if (pes[pevent_idx].attr_idx == -1) {
     display_system_config();
     DDRES_RETURN_ERROR_LOG(DD_WHAT_PERFOPEN,
-                           "Error calling perfopen on watcher %d.0 (%s)",
+                           "Error calling perf_event_open on watcher %d.0 (%s)",
                            watcher_idx, strerror(errno));
   }
 

--- a/src/unwind_dwfl.cc
+++ b/src/unwind_dwfl.cc
@@ -118,7 +118,7 @@ DDRes add_symbol(Dwfl_Frame *dwfl_frame, UnwindState *us) {
     // if not encountered previously, update file location / key
     file_info_id = us->dso_hdr.get_or_insert_file_info(dso);
     if (file_info_id <= k_file_info_error) {
-      // unable to acces file: add available info from dso
+      // unable to access file: add available info from dso
       add_dso_frame(us, dso, pc, "pc");
       // We could stop here or attempt to continue in the dwarf unwinding
       // sometimes frame pointer lets us go further -> So we continue
@@ -156,15 +156,15 @@ DDRes add_symbol(Dwfl_Frame *dwfl_frame, UnwindState *us) {
   // This means we need access to the module information.
   // Now that we have loaded the module, we can check if we are an activation
   // frame
-  bool isactivation = false;
+  bool is_activation = false;
 
-  if (!dwfl_frame_pc(dwfl_frame, &pc, &isactivation)) {
+  if (!dwfl_frame_pc(dwfl_frame, &pc, &is_activation)) {
     LG_DBG("Failure to compute frame PC: %s (depth#%lu)", dwfl_errmsg(-1),
            us->output.locs.size());
     add_error_frame(nullptr, us, pc, SymbolErrors::dwfl_frame);
     return ddres_init(); // invalid pc : do not add frame
   }
-  if (!isactivation) {
+  if (!is_activation) {
     --pc;
   }
   us->current_ip = pc;
@@ -180,7 +180,7 @@ DDRes add_symbol(Dwfl_Frame *dwfl_frame, UnwindState *us) {
 int frame_cb(Dwfl_Frame *dwfl_frame, void *arg) {
   auto *us = static_cast<UnwindState *>(arg);
 #ifdef DEBUG
-  LG_NFO("Beging depth %lu", us->output.locs.size());
+  LG_NFO("Begin depth %lu", us->output.locs.size());
 #endif
   int const dwfl_error_value = dwfl_errno();
   if (dwfl_error_value) {

--- a/src/unwind_dwfl.cc
+++ b/src/unwind_dwfl.cc
@@ -105,7 +105,7 @@ DDRes add_symbol(Dwfl_Frame *dwfl_frame, UnwindState *us) {
     }
     const Dso &dso = find_res.first->second;
     std::string_view jitdump_path = {};
-    if (dso::has_runtime_symbols(dso._type)) {
+    if (has_runtime_symbols(dso._type)) {
       if (pid_mapping._jitdump_addr) {
         DsoHdr::DsoFindRes const find_mapping = DsoHdr::dso_find_closest(
             pid_mapping._map, pid_mapping._jitdump_addr);

--- a/test/ddprof_module_lib-ut.cc
+++ b/test/ddprof_module_lib-ut.cc
@@ -17,7 +17,7 @@ Mapping mapping(Offset_t offset, uint32_t prot = PROT_EXEC | PROT_READ) {
 }
 
 TEST(ddprof_module_lib, empty) {
-  auto res = find_match({}, {});
+  auto res = find_match({}, {}, true);
   ASSERT_EQ(res.load_segment, nullptr);
   ASSERT_EQ(res.mapping, nullptr);
   ASSERT_FALSE(res.is_ambiguous);
@@ -25,7 +25,7 @@ TEST(ddprof_module_lib, empty) {
 
 TEST(ddprof_module_lib, empty_segments) {
   Mapping mappings[] = {mapping(0)};
-  auto res = find_match(mappings, {});
+  auto res = find_match(mappings, {}, true);
   ASSERT_EQ(res.load_segment, nullptr);
   ASSERT_EQ(res.mapping, nullptr);
   ASSERT_FALSE(res.is_ambiguous);
@@ -33,7 +33,7 @@ TEST(ddprof_module_lib, empty_segments) {
 
 TEST(ddprof_module_lib, empty_mappings) {
   Segment segments[] = {segment(0x128)};
-  auto res = find_match({}, segments);
+  auto res = find_match({}, segments, true);
   ASSERT_EQ(res.load_segment, nullptr);
   ASSERT_EQ(res.mapping, nullptr);
   ASSERT_FALSE(res.is_ambiguous);
@@ -42,7 +42,7 @@ TEST(ddprof_module_lib, empty_mappings) {
 TEST(ddprof_module_lib, simple) {
   Mapping mappings[] = {mapping(0)};
   Segment segments[] = {segment(0x128)};
-  auto res = find_match(mappings, segments);
+  auto res = find_match(mappings, segments, true);
   ASSERT_EQ(res.load_segment, &segments[0]);
   ASSERT_EQ(res.mapping, &mappings[0]);
   ASSERT_FALSE(res.is_ambiguous);
@@ -51,7 +51,7 @@ TEST(ddprof_module_lib, simple) {
 TEST(ddprof_module_lib, simple2) {
   Mapping mappings[] = {mapping(0)};
   Segment segments[] = {segment(0, PROT_EXEC)};
-  auto res = find_match(mappings, segments);
+  auto res = find_match(mappings, segments, true);
   ASSERT_EQ(res.load_segment, nullptr);
   ASSERT_EQ(res.mapping, nullptr);
   ASSERT_FALSE(res.is_ambiguous);
@@ -60,7 +60,7 @@ TEST(ddprof_module_lib, simple2) {
 TEST(ddprof_module_lib, ambiguous) {
   Mapping mappings[] = {mapping(0)};
   Segment segments[] = {segment(0x128), segment(0x201)};
-  auto res = find_match(mappings, segments);
+  auto res = find_match(mappings, segments, true);
   ASSERT_EQ(res.load_segment, &segments[0]);
   ASSERT_EQ(res.mapping, &mappings[0]);
   ASSERT_TRUE(res.is_ambiguous);
@@ -70,7 +70,7 @@ TEST(ddprof_module_lib, complex) {
   Mapping mappings[] = {mapping(0x1000), mapping(0x5000)};
   Segment segments[] = {segment(0x1100, PROT_EXEC), segment(0x1200),
                         segment(0x5128), segment(0x5457)};
-  auto res = find_match(mappings, segments);
+  auto res = find_match(mappings, segments, true);
   ASSERT_EQ(res.load_segment, &segments[1]);
   ASSERT_EQ(res.mapping, &mappings[0]);
   ASSERT_TRUE(res.is_ambiguous);
@@ -81,7 +81,7 @@ TEST(ddprof_module_lib, libcoreclr) {
                         mapping(0x5d9000)};
   Segment segments[] = {segment(0x000000, PROT_EXEC),
                         segment(0x6b7ec0, PROT_READ)};
-  auto res = find_match(mappings, segments);
+  auto res = find_match(mappings, segments, true);
   ASSERT_FALSE(res.is_ambiguous);
 }
 

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -223,6 +223,10 @@ static const char *const s_jsa_line = "0x800000000-0x800001fff rw-p 00000000 00:
 static const char *const s_dd_profiling = "0x800000000-0x800001fff rw-p 00000000 00:00 0                          /tmp/libdd_profiling.so.1234";
 static const char *const s_dotnet_line = "7fbd4f1e4000-7fbd4f1ec000 r--s 00000000 ca:01 140372                     /usr/share/dotnet/shared/Microsoft.NETCore.App/6.0.5/System.Runtime.dll";
 static const char *const s_jitdump_line = "7b5242e44000-7b5242e45000 r-xp 00000000 fd:06 22295230                   /home/r1viollet/.debug/jit/llvm-IR-jit-20230131-981d92/jit-3237589.dump";
+
+static const char *const s_empty_file_line = "7f9b650b1000-7f9b650b4000 rw-p 00000000 00:00 0                 \n";
+static const char *const s_bad_line = "7b5242e44000-7b5242e45000 r-xp  00000000 fd:06";
+
 // clang-format on
 
 TEST(DSOTest, dso_from_procline) {
@@ -300,10 +304,20 @@ TEST(DSOTest, dso_from_procline) {
         DsoHdr::dso_from_procline(3237589, const_cast<char *>(s_jitdump_line));
     EXPECT_EQ(jitdump_dso._type, DsoType::kJITDump);
   }
-  { // jitdump with a name different from PID (for wholehost)
+  { // jitdump with a name different from PID (for whole host)
     Dso jitdump_dso =
         DsoHdr::dso_from_procline(12, const_cast<char *>(s_jitdump_line));
     EXPECT_EQ(jitdump_dso._type, DsoType::kJITDump);
+  }
+  {
+    // empty file proc line
+    Dso dso = DsoHdr::dso_from_procline(12, const_cast<char *>(s_empty_file_line));
+    EXPECT_EQ(dso._type, DsoType::kAnon);
+  }
+  {
+    // bad proc line
+    Dso dso = DsoHdr::dso_from_procline(12, const_cast<char *>(s_bad_line));
+    EXPECT_EQ(dso._pid, -1);
   }
 }
 

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -372,7 +372,7 @@ TEST(DSOTest, mmap_into_backpop) {
   for (auto &el : pid_mapping._map) {
     Dso &dso = el.second;
     // emulate an insert of big size
-    if (dso._filename.find("c++") != std::string::npos && dso._pgoff == 0) {
+    if (dso._filename.find("c++") != std::string::npos && dso._offset == 0) {
       Dso copy(dso);
       copy._end = copy._start + 0x388FFF;
       found = true;
@@ -381,7 +381,7 @@ TEST(DSOTest, mmap_into_backpop) {
   }
   EXPECT_TRUE(found);
   dso_hdr.pid_backpopulate(my_pid, nb_elts);
-  // TODO: To be discussed - should we erase overlaping or not
+  // TODO: To be discussed - should we erase overlapping or not
 }
 
 TEST(DSOTest, insert_jitdump) {

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -229,49 +229,49 @@ static const char *const s_bad_line = "7b5242e44000-7b5242e45000 r-xp  00000000 
 
 // clang-format on
 
-TEST(DSOTest, dso_from_procline) {
+TEST(DSOTest, dso_from_proc_line) {
   LogHandle handle;
   Dso no_exec =
-      DsoHdr::dso_from_procline(10, const_cast<char *>(s_line_noexec));
+      DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_line_noexec));
   EXPECT_EQ(no_exec._type, DsoType::kStandard);
   EXPECT_EQ(no_exec._prot, PROT_READ);
   EXPECT_EQ(no_exec._pid, 10);
   Dso standard_dso =
-      DsoHdr::dso_from_procline(10, const_cast<char *>(s_exec_line));
+      DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_exec_line));
   { // standard
     EXPECT_EQ(standard_dso._type, DsoType::kStandard);
   }
   { // vdso
     Dso vdso_dso =
-        DsoHdr::dso_from_procline(10, const_cast<char *>(s_vdso_lib));
+        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_vdso_lib));
     EXPECT_EQ(vdso_dso._type, DsoType::kVdso);
   }
   { // stack
     Dso stack_dso =
-        DsoHdr::dso_from_procline(10, const_cast<char *>(s_stack_line));
+        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_stack_line));
     EXPECT_EQ(stack_dso._type, DsoType::kStack);
   }
   { // inode
     Dso inode_dso =
-        DsoHdr::dso_from_procline(10, const_cast<char *>(s_inode_line));
+        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_inode_line));
     EXPECT_EQ(inode_dso._type, DsoType::kAnon);
   }
   {
     // jsa
-    Dso jsa_dso = DsoHdr::dso_from_procline(10, const_cast<char *>(s_jsa_line));
+    Dso jsa_dso = DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_jsa_line));
     EXPECT_EQ(jsa_dso._type, DsoType::kRuntime);
   }
   {
     // dotnet dll
     Dso dll_dso =
-        DsoHdr::dso_from_procline(10, const_cast<char *>(s_dotnet_line));
+        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_dotnet_line));
     EXPECT_EQ(dll_dso._type, DsoType::kRuntime);
   }
   DsoHdr dso_hdr;
   {
     // check that we don't overlap between lines that end on same byte
     Dso standard_dso_2 =
-        DsoHdr::dso_from_procline(10, const_cast<char *>(s_exec_line2));
+        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_exec_line2));
     EXPECT_EQ(standard_dso._type, DsoType::kStandard);
     dso_hdr.insert_erase_overlap(std::move(standard_dso_2));
     dso_hdr.insert_erase_overlap(std::move(standard_dso));
@@ -280,7 +280,7 @@ TEST(DSOTest, dso_from_procline) {
   {
     // check that we erase everything if we have an overlap
     Dso standard_dso_3 =
-        DsoHdr::dso_from_procline(10, const_cast<char *>(s_exec_line3));
+        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_exec_line3));
     EXPECT_EQ(standard_dso._type, DsoType::kStandard);
     dso_hdr.insert_erase_overlap(std::move(standard_dso_3));
     EXPECT_EQ(dso_hdr.get_nb_dso(), 1);
@@ -288,7 +288,7 @@ TEST(DSOTest, dso_from_procline) {
   {
     // check that we still match element number 3
     Dso standard_dso_4 =
-        DsoHdr::dso_from_procline(10, const_cast<char *>(s_exec_line4));
+        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_exec_line4));
     ProcessAddress_t end_4 = standard_dso_4._end;
     DsoFindRes findres =
         dso_hdr.insert_erase_overlap(std::move(standard_dso_4));
@@ -296,27 +296,27 @@ TEST(DSOTest, dso_from_procline) {
   }
   {
     Dso dd_profiling_dso =
-        DsoHdr::dso_from_procline(10, const_cast<char *>(s_dd_profiling));
+        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_dd_profiling));
     EXPECT_EQ(dd_profiling_dso._type, DsoType::kDDProfiling);
   }
   {
     Dso jitdump_dso =
-        DsoHdr::dso_from_procline(3237589, const_cast<char *>(s_jitdump_line));
+        DsoHdr::dso_from_proc_line(3237589, const_cast<char *>(s_jitdump_line));
     EXPECT_EQ(jitdump_dso._type, DsoType::kJITDump);
   }
   { // jitdump with a name different from PID (for whole host)
     Dso jitdump_dso =
-        DsoHdr::dso_from_procline(12, const_cast<char *>(s_jitdump_line));
+        DsoHdr::dso_from_proc_line(12, const_cast<char *>(s_jitdump_line));
     EXPECT_EQ(jitdump_dso._type, DsoType::kJITDump);
   }
   {
     // empty file proc line
-    Dso dso = DsoHdr::dso_from_procline(12, const_cast<char *>(s_empty_file_line));
+    Dso dso = DsoHdr::dso_from_proc_line(12, const_cast<char *>(s_empty_file_line));
     EXPECT_EQ(dso._type, DsoType::kAnon);
   }
   {
     // bad proc line
-    Dso dso = DsoHdr::dso_from_procline(12, const_cast<char *>(s_bad_line));
+    Dso dso = DsoHdr::dso_from_proc_line(12, const_cast<char *>(s_bad_line));
     EXPECT_EQ(dso._pid, -1);
   }
 }
@@ -405,7 +405,7 @@ TEST(DSOTest, insert_jitdump) {
   // pid from dso line (important for the jitdump name)
   pid_t test_pid = 3237589;
   Dso jitdump_dso =
-      DsoHdr::dso_from_procline(test_pid, const_cast<char *>(s_jitdump_line));
+      DsoHdr::dso_from_proc_line(test_pid, const_cast<char *>(s_jitdump_line));
   EXPECT_EQ(jitdump_dso._type, DsoType::kJITDump);
   ProcessAddress_t start = jitdump_dso._start;
   DsoHdr::PidMapping &pid_mapping = dso_hdr._pid_map[test_pid];

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -62,7 +62,7 @@ Dso build_dso_file_10_2500() {
 
 void fill_mock_hdr(DsoHdr &dso_hdr) {
   auto insert_res = dso_hdr.insert_erase_overlap(build_dso_5_1500());
-  EXPECT_TRUE(insert_res.first->second._type == dso::kStandard);
+  EXPECT_TRUE(insert_res.first->second._type == DsoType::kStandard);
   EXPECT_TRUE(insert_res.second);
 
   insert_res = dso_hdr.insert_erase_overlap(build_dso_10_1000());
@@ -78,7 +78,7 @@ void fill_mock_hdr(DsoHdr &dso_hdr) {
 
   insert_res = dso_hdr.insert_erase_overlap(build_dso_10_1500());
   EXPECT_TRUE(insert_res.second);
-  EXPECT_TRUE(insert_res.first->second._type == dso::kAnon);
+  EXPECT_TRUE(insert_res.first->second._type == DsoType::kAnon);
 }
 
 TEST(DSOTest, is_within) {
@@ -201,9 +201,9 @@ TEST(DSOTest, insert_erase_overlap) {
 
 TEST(DSOTest, path_type) {
   Dso vdso_dso = build_dso_vdso();
-  EXPECT_TRUE(vdso_dso._type == dso::kVdso);
+  EXPECT_TRUE(vdso_dso._type == DsoType::kVdso);
   Dso syscall_dso = build_dso_vsyscall();
-  EXPECT_TRUE(syscall_dso._type == dso::kVsysCall);
+  EXPECT_TRUE(syscall_dso._type == DsoType::kVsysCall);
 }
 
 // clang-format off
@@ -229,46 +229,46 @@ TEST(DSOTest, dso_from_procline) {
   LogHandle handle;
   Dso no_exec =
       DsoHdr::dso_from_procline(10, const_cast<char *>(s_line_noexec));
-  EXPECT_EQ(no_exec._type, dso::kStandard);
+  EXPECT_EQ(no_exec._type, DsoType::kStandard);
   EXPECT_EQ(no_exec._prot, PROT_READ);
   EXPECT_EQ(no_exec._pid, 10);
   Dso standard_dso =
       DsoHdr::dso_from_procline(10, const_cast<char *>(s_exec_line));
   { // standard
-    EXPECT_EQ(standard_dso._type, dso::kStandard);
+    EXPECT_EQ(standard_dso._type, DsoType::kStandard);
   }
   { // vdso
     Dso vdso_dso =
         DsoHdr::dso_from_procline(10, const_cast<char *>(s_vdso_lib));
-    EXPECT_EQ(vdso_dso._type, dso::kVdso);
+    EXPECT_EQ(vdso_dso._type, DsoType::kVdso);
   }
   { // stack
     Dso stack_dso =
         DsoHdr::dso_from_procline(10, const_cast<char *>(s_stack_line));
-    EXPECT_EQ(stack_dso._type, dso::kStack);
+    EXPECT_EQ(stack_dso._type, DsoType::kStack);
   }
   { // inode
     Dso inode_dso =
         DsoHdr::dso_from_procline(10, const_cast<char *>(s_inode_line));
-    EXPECT_EQ(inode_dso._type, dso::kAnon);
+    EXPECT_EQ(inode_dso._type, DsoType::kAnon);
   }
   {
     // jsa
     Dso jsa_dso = DsoHdr::dso_from_procline(10, const_cast<char *>(s_jsa_line));
-    EXPECT_EQ(jsa_dso._type, dso::kRuntime);
+    EXPECT_EQ(jsa_dso._type, DsoType::kRuntime);
   }
   {
     // dotnet dll
     Dso dll_dso =
         DsoHdr::dso_from_procline(10, const_cast<char *>(s_dotnet_line));
-    EXPECT_EQ(dll_dso._type, dso::kRuntime);
+    EXPECT_EQ(dll_dso._type, DsoType::kRuntime);
   }
   DsoHdr dso_hdr;
   {
     // check that we don't overlap between lines that end on same byte
     Dso standard_dso_2 =
         DsoHdr::dso_from_procline(10, const_cast<char *>(s_exec_line2));
-    EXPECT_EQ(standard_dso._type, dso::kStandard);
+    EXPECT_EQ(standard_dso._type, DsoType::kStandard);
     dso_hdr.insert_erase_overlap(std::move(standard_dso_2));
     dso_hdr.insert_erase_overlap(std::move(standard_dso));
     EXPECT_EQ(dso_hdr.get_nb_dso(), 2);
@@ -277,7 +277,7 @@ TEST(DSOTest, dso_from_procline) {
     // check that we erase everything if we have an overlap
     Dso standard_dso_3 =
         DsoHdr::dso_from_procline(10, const_cast<char *>(s_exec_line3));
-    EXPECT_EQ(standard_dso._type, dso::kStandard);
+    EXPECT_EQ(standard_dso._type, DsoType::kStandard);
     dso_hdr.insert_erase_overlap(std::move(standard_dso_3));
     EXPECT_EQ(dso_hdr.get_nb_dso(), 1);
   }
@@ -293,17 +293,17 @@ TEST(DSOTest, dso_from_procline) {
   {
     Dso dd_profiling_dso =
         DsoHdr::dso_from_procline(10, const_cast<char *>(s_dd_profiling));
-    EXPECT_EQ(dd_profiling_dso._type, dso::kDDProfiling);
+    EXPECT_EQ(dd_profiling_dso._type, DsoType::kDDProfiling);
   }
   {
     Dso jitdump_dso =
         DsoHdr::dso_from_procline(3237589, const_cast<char *>(s_jitdump_line));
-    EXPECT_EQ(jitdump_dso._type, dso::kJITDump);
+    EXPECT_EQ(jitdump_dso._type, DsoType::kJITDump);
   }
   { // jitdump with a name different from PID (for wholehost)
     Dso jitdump_dso =
         DsoHdr::dso_from_procline(12, const_cast<char *>(s_jitdump_line));
-    EXPECT_EQ(jitdump_dso._type, dso::kJITDump);
+    EXPECT_EQ(jitdump_dso._type, DsoType::kJITDump);
   }
 }
 
@@ -391,7 +391,7 @@ TEST(DSOTest, insert_jitdump) {
   pid_t test_pid = 3237589;
   Dso jitdump_dso =
       DsoHdr::dso_from_procline(test_pid, const_cast<char *>(s_jitdump_line));
-  EXPECT_EQ(jitdump_dso._type, dso::kJITDump);
+  EXPECT_EQ(jitdump_dso._type, DsoType::kJITDump);
   ProcessAddress_t start = jitdump_dso._start;
   DsoHdr::PidMapping &pid_mapping = dso_hdr._pid_map[test_pid];
   dso_hdr.insert_erase_overlap(pid_mapping, std::move(jitdump_dso));

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -231,47 +231,40 @@ static const char *const s_bad_line = "7b5242e44000-7b5242e45000 r-xp  00000000 
 
 TEST(DSOTest, dso_from_proc_line) {
   LogHandle handle;
-  Dso no_exec =
-      DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_line_noexec));
+  Dso no_exec = DsoHdr::dso_from_proc_line(10, s_line_noexec);
   EXPECT_EQ(no_exec._type, DsoType::kStandard);
   EXPECT_EQ(no_exec._prot, PROT_READ);
   EXPECT_EQ(no_exec._pid, 10);
-  Dso standard_dso =
-      DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_exec_line));
+  Dso standard_dso = DsoHdr::dso_from_proc_line(10, s_exec_line);
   { // standard
     EXPECT_EQ(standard_dso._type, DsoType::kStandard);
   }
   { // vdso
-    Dso vdso_dso =
-        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_vdso_lib));
+    Dso vdso_dso = DsoHdr::dso_from_proc_line(10, s_vdso_lib);
     EXPECT_EQ(vdso_dso._type, DsoType::kVdso);
   }
   { // stack
-    Dso stack_dso =
-        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_stack_line));
+    Dso stack_dso = DsoHdr::dso_from_proc_line(10, s_stack_line);
     EXPECT_EQ(stack_dso._type, DsoType::kStack);
   }
   { // inode
-    Dso inode_dso =
-        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_inode_line));
+    Dso inode_dso = DsoHdr::dso_from_proc_line(10, s_inode_line);
     EXPECT_EQ(inode_dso._type, DsoType::kAnon);
   }
   {
     // jsa
-    Dso jsa_dso = DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_jsa_line));
+    Dso jsa_dso = DsoHdr::dso_from_proc_line(10, s_jsa_line);
     EXPECT_EQ(jsa_dso._type, DsoType::kRuntime);
   }
   {
     // dotnet dll
-    Dso dll_dso =
-        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_dotnet_line));
+    Dso dll_dso = DsoHdr::dso_from_proc_line(10, s_dotnet_line);
     EXPECT_EQ(dll_dso._type, DsoType::kRuntime);
   }
   DsoHdr dso_hdr;
   {
     // check that we don't overlap between lines that end on same byte
-    Dso standard_dso_2 =
-        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_exec_line2));
+    Dso standard_dso_2 = DsoHdr::dso_from_proc_line(10, s_exec_line2);
     EXPECT_EQ(standard_dso._type, DsoType::kStandard);
     dso_hdr.insert_erase_overlap(std::move(standard_dso_2));
     dso_hdr.insert_erase_overlap(std::move(standard_dso));
@@ -279,44 +272,39 @@ TEST(DSOTest, dso_from_proc_line) {
   }
   {
     // check that we erase everything if we have an overlap
-    Dso standard_dso_3 =
-        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_exec_line3));
+    Dso standard_dso_3 = DsoHdr::dso_from_proc_line(10, s_exec_line3);
     EXPECT_EQ(standard_dso._type, DsoType::kStandard);
     dso_hdr.insert_erase_overlap(std::move(standard_dso_3));
     EXPECT_EQ(dso_hdr.get_nb_dso(), 1);
   }
   {
     // check that we still match element number 3
-    Dso standard_dso_4 =
-        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_exec_line4));
+    Dso standard_dso_4 = DsoHdr::dso_from_proc_line(10, s_exec_line4);
     ProcessAddress_t end_4 = standard_dso_4._end;
     DsoFindRes findres =
         dso_hdr.insert_erase_overlap(std::move(standard_dso_4));
     EXPECT_EQ(findres.first->second._end, end_4);
   }
   {
-    Dso dd_profiling_dso =
-        DsoHdr::dso_from_proc_line(10, const_cast<char *>(s_dd_profiling));
+    Dso dd_profiling_dso = DsoHdr::dso_from_proc_line(10, s_dd_profiling);
     EXPECT_EQ(dd_profiling_dso._type, DsoType::kDDProfiling);
   }
   {
-    Dso jitdump_dso =
-        DsoHdr::dso_from_proc_line(3237589, const_cast<char *>(s_jitdump_line));
+    Dso jitdump_dso = DsoHdr::dso_from_proc_line(3237589, s_jitdump_line);
     EXPECT_EQ(jitdump_dso._type, DsoType::kJITDump);
   }
   { // jitdump with a name different from PID (for whole host)
-    Dso jitdump_dso =
-        DsoHdr::dso_from_proc_line(12, const_cast<char *>(s_jitdump_line));
+    Dso jitdump_dso = DsoHdr::dso_from_proc_line(12, s_jitdump_line);
     EXPECT_EQ(jitdump_dso._type, DsoType::kJITDump);
   }
   {
     // empty file proc line
-    Dso dso = DsoHdr::dso_from_proc_line(12, const_cast<char *>(s_empty_file_line));
+    Dso dso = DsoHdr::dso_from_proc_line(12, s_empty_file_line);
     EXPECT_EQ(dso._type, DsoType::kAnon);
   }
   {
     // bad proc line
-    Dso dso = DsoHdr::dso_from_proc_line(12, const_cast<char *>(s_bad_line));
+    Dso dso = DsoHdr::dso_from_proc_line(12, s_bad_line);
     EXPECT_EQ(dso._pid, -1);
   }
 }
@@ -404,8 +392,7 @@ TEST(DSOTest, insert_jitdump) {
   DsoHdr dso_hdr;
   // pid from dso line (important for the jitdump name)
   pid_t test_pid = 3237589;
-  Dso jitdump_dso =
-      DsoHdr::dso_from_proc_line(test_pid, const_cast<char *>(s_jitdump_line));
+  Dso jitdump_dso = DsoHdr::dso_from_proc_line(test_pid, s_jitdump_line);
   EXPECT_EQ(jitdump_dso._type, DsoType::kJITDump);
   ProcessAddress_t start = jitdump_dso._start;
   DsoHdr::PidMapping &pid_mapping = dso_hdr._pid_map[test_pid];

--- a/test/dwfl_module-ut.cc
+++ b/test/dwfl_module-ut.cc
@@ -57,7 +57,7 @@ TEST(DwflModule, inconsistency_test) {
 
     for (auto it = dso_map.begin(); it != dso_map.end(); ++it) {
       Dso &dso = it->second;
-      if (!dso::has_relevant_path(dso._type) || !dso.is_executable()) {
+      if (!has_relevant_path(dso._type) || !dso.is_executable()) {
         continue; // skip non exec / non standard (anon/vdso...)
       }
 
@@ -98,7 +98,7 @@ TEST(DwflModule, inconsistency_test) {
       EXPECT_EQ(ddprof_mod->_status, DDProfMod::kUnknown);
     }
   }
-  int nb_fds_end = cound_fds(my_pid);
+  int nb_fds_end = count_fds(my_pid);
   printf("-- End open file descriptors: %d\n", nb_fds_end);
   EXPECT_EQ(nb_fds_start, nb_fds_end);
 }
@@ -128,7 +128,7 @@ TEST(DwflModule, short_lived) {
 
     for (auto it = dso_map.begin(); it != dso_map.end(); ++it) {
       Dso &dso = it->second;
-      if (!dso::has_relevant_path(dso._type) || !dso.is_executable()) {
+      if (!has_relevant_path(dso._type) || !dso.is_executable()) {
         continue; // skip non exec / non standard (anon/vdso...)
       }
 
@@ -164,7 +164,7 @@ TEST(DwflModule, short_lived) {
 
     for (auto it = dso_map.begin(); it != dso_map.end(); ++it) {
       Dso &dso = it->second;
-      if (!dso::has_relevant_path(dso._type) || !dso.is_executable()) {
+      if (!has_relevant_path(dso._type) || !dso.is_executable()) {
         continue; // skip non exec / non standard (anon/vdso...)
       }
 

--- a/test/dwfl_module-ut.cc
+++ b/test/dwfl_module-ut.cc
@@ -30,7 +30,7 @@ namespace ddprof {
 
 namespace fs = std::filesystem;
 
-int cound_fds(pid_t pid) {
+int count_fds(pid_t pid) {
   std::string proc_dir = "/proc/" + std::to_string(pid) + "/fd";
   int fd_count = 0;
   for ([[maybe_unused]] const auto &entry : fs::directory_iterator(proc_dir)) {
@@ -41,7 +41,7 @@ int cound_fds(pid_t pid) {
 
 TEST(DwflModule, inconsistency_test) {
   pid_t my_pid = getpid();
-  int nb_fds_start = cound_fds(my_pid);
+  int nb_fds_start = count_fds(my_pid);
   printf("-- Start open file descriptors: %d\n", nb_fds_start);
   LogHandle handle;
   // Load DSOs from our unit test
@@ -76,17 +76,17 @@ TEST(DwflModule, inconsistency_test) {
       if (find_res.first == it) {
         Symbol symbol;
         GElf_Sym elf_sym;
-        Offset_t lbiais;
-        EXPECT_TRUE(symbol_get_from_dwfl(ddprof_mod->_mod, ip, symbol, elf_sym,
-                                         lbiais));
+        Offset_t bias;
+        EXPECT_TRUE(
+            symbol_get_from_dwfl(ddprof_mod->_mod, ip, symbol, elf_sym, bias));
         EXPECT_EQ("ddprof::DwflModule_inconsistency_test_Test::TestBody()",
                   symbol._demangle_name);
-        EXPECT_EQ(lbiais, ddprof_mod->_sym_bias);
+        EXPECT_EQ(bias, ddprof_mod->_sym_bias);
         FileAddress_t elf_addr = ip - ddprof_mod->_sym_bias;
         FileAddress_t start_sym, end_sym = {};
         EXPECT_TRUE(compute_elf_range(elf_addr, elf_sym, start_sym, end_sym));
-        printf("Start --> 0x%lx - end %lx - lbiais 0x%lx <--\n", start_sym,
-               end_sym, lbiais);
+        printf("Start --> 0x%lx - end %lx - bias 0x%lx <--\n", start_sym,
+               end_sym, bias);
         EXPECT_GE(elf_addr, start_sym);
         EXPECT_LE(elf_addr, end_sym);
 


### PR DESCRIPTION
# What does this PR do?

*  Use first LOAD segment for bias computation if available
    If all mappings are available (ie. they come from proc maps), then  use the first LOAD segment (executable or not) to compute the bias.
    This will ensure that bias computation is possible even for processes that punch holes into existing mappings  (eg.dotnet).

Other changes:
*  Fix typos and improve some naming
*  Use an enum class for DsoType and remove dso namespace
* Add DsoOrigin to Dso class
    DsoOrigin indicates if Dso information was obtained from a perf mmap event or from parsing proc maps.
*Only adjust Dso end if smaller
* Improve mapping insertion
    When a new mapping is inserted, if it intersects other mappings, keep  the remaining parts of the existing mappings if mapped file is the same or if new mapping is anonymous and it truncates the end of an existing  mapping.
* Avoid throwing exception if parsing of a proc map line fails
    Also explicits why expected return value of sscanf does not match number of specifiers.
* Rename dso_from_procline to dso_from_proc_line
* Improve const-correctness of dso_from_proc_line