### PR TITLE
Log TSC calibration method

### DIFF
--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -283,7 +283,13 @@ int start_profiler_internal(std::unique_ptr<DDProfContext> ctx,
   // Now, we are the profiler process
   exit_on_return = true;
 
-  init_tsc();
+  if (IsDDResOK(init_tsc())) {
+    LG_NTC(
+        "Successfully calibrated TSC from %s",
+        tsc_calibration_method_to_string(get_tsc_calibration_method()).c_str());
+  } else {
+    LG_WRN("Failed to initialize TSC");
+  }
 
   if (CPU_COUNT(&ctx->params.cpu_affinity) > 0) {
     LG_DBG("Setting affinity to 0x%s",

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -215,18 +215,22 @@ DDRes init_tsc(TscCalibrationMethod method) {
   if ((method == TscCalibrationMethod::kAuto ||
        method == TscCalibrationMethod::kPerf) &&
       !init_from_perf(g_tsc_conversion)) {
+    g_tsc_conversion.calibration_method = TscCalibrationMethod::kPerf;
     return {};
   }
   uint64_t tsc_hz = 0;
 
   if (method == TscCalibrationMethod::kAuto ||
       method == TscCalibrationMethod::kCpuArch) {
+    g_tsc_conversion.calibration_method = TscCalibrationMethod::kCpuArch;
     tsc_hz = get_tsc_freq_arch();
   }
 
   if (!tsc_hz &&
       (method == TscCalibrationMethod::kAuto ||
        method == TscCalibrationMethod::kClockMonotonicRaw)) {
+    g_tsc_conversion.calibration_method =
+        TscCalibrationMethod::kClockMonotonicRaw;
     tsc_hz = estimate_tsc_freq();
   }
 


### PR DESCRIPTION
# What does this PR do?

Add a log message (notice level) with the calibration method used for TSC.

# Motivation

I was surprised to see that clock_monotonic_raw was used on DD workspaces instead of perf.