### PR TITLE
Minor alpine local compilation fix - patch file read permissions

### DIFF
--- a/app/base-env-alpine/Dockerfile
+++ b/app/base-env-alpine/Dockerfile
@@ -107,6 +107,7 @@ RUN mkdir /patch
 ADD ./app/base-env-alpine/*.patch /patch/
 ADD ./app/base-env-alpine/error.h /patch/
 ADD ./app/base-env-alpine/libintl.h /patch/
+RUN chmod 644 /patch/*
 
 # jemalloc
 RUN VERSION="5.3.0" \


### PR DESCRIPTION
# What does this PR do?

As we build the docker file as root, the patch files are not always readable when we run the dockerfile as a non root user.

# Motivation

Enable local compilation of alpine binaries

# Additional Notes

N/A

# How to test the change?

N/A
