### PR TITLE
Remove unreachable return

### DIFF
--- a/src/lib/savecontext.cc
+++ b/src/lib/savecontext.cc
@@ -71,7 +71,6 @@ size_t save_context(std::span<const std::byte> stack_bounds,
   return save_stack(stack_bounds,
                     reinterpret_cast<const std::byte *>(regs[REGNAME(SP)]),
                     buffer);
-  return 0;
 }
 
 } // namespace ddprof


### PR DESCRIPTION
Remove unreachable return.

# What does this PR do?

Removes an unreachable return.

# Motivation

Returns should be reachable.  A return which is unreachable cannot be reached, so it can be confusing when people try to reach it.

# Additional Notes

When a return is unreachable, nobody can reach it.

# How to test the change?

There is NO WAY to test this change, do not try.