### PR TITLE
Add timestamp to allocation using PerfClock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,7 @@ set(DD_PROFILING_SOURCES
     src/logger.cc
     src/logger_setup.cc
     src/perf.cc
+    src/perf_clock.cc
     src/perf_ringbuffer.cc
     src/perf_watcher.cc
     src/pevent_lib.cc
@@ -222,6 +223,7 @@ set(DD_PROFILING_SOURCES
     src/signal_helper.cc
     src/sys_utils.cc
     src/tracepoint_config.cc
+    src/tsc_clock.cc
     src/user_override.cc)
 
 if(BUILD_UNIVERSAL_DDPROF)

--- a/include/mpscringbuffer.hpp
+++ b/include/mpscringbuffer.hpp
@@ -86,6 +86,11 @@ struct MPSCRingBufferMetaDataPage {
   alignas(hardware_destructive_interference_size) uint64_t writer_pos;
   alignas(hardware_destructive_interference_size) uint64_t reader_pos;
   alignas(hardware_destructive_interference_size) SpinLock spinlock;
+  uint64_t time_zero;
+  uint32_t time_mult;
+  uint16_t time_shift;
+  uint8_t perf_clock_source;
+  bool tsc_available;
 };
 
 } // namespace ddprof

--- a/include/perf_clock.hpp
+++ b/include/perf_clock.hpp
@@ -32,7 +32,11 @@ public:
 
   static time_point now() noexcept { return time_point{_clock_func()}; }
 
-  static PerfClockSource determine_perf_clock_source();
+  // Determine which perf clock source to use
+  static PerfClockSource init() noexcept;
+
+  static void init(PerfClockSource clock_source) noexcept;
+
   static PerfClockSource perf_clock_source() { return _clock_source; }
 
   // Reset PerfClock to its initial state (just return 0)

--- a/include/perf_ringbuffer.hpp
+++ b/include/perf_ringbuffer.hpp
@@ -23,7 +23,14 @@ struct RingBuffer {
 
   uint64_t *writer_pos;
   uint64_t *reader_pos;
+
+  // only used for MPSCRingBuffer
   SpinLock *spinlock;
+  uint64_t time_zero;
+  uint32_t time_mult;
+  uint16_t time_shift;
+  uint8_t perf_clock_source;
+  bool tsc_available;
 };
 
 bool rb_init(RingBuffer *rb, void *base, size_t size, RingBufferType type);

--- a/include/tsc_clock.hpp
+++ b/include/tsc_clock.hpp
@@ -39,7 +39,13 @@ public:
   using Cycles = uint64_t;
 
   enum class State { kUninitialized, kUnavailable, kOK };
-  enum class CalibrationMethod { kAuto, kPerf, kCpuArch, kClockMonotonicRaw };
+  enum class CalibrationMethod {
+    kAuto,
+    kPerf,
+    kCpuArch,
+    kClockMonotonicRaw,
+    kManual
+  };
 
   struct CalibrationParams {
     time_point offset;
@@ -53,16 +59,14 @@ public:
     CalibrationMethod method;
   };
 
-  static DDRes init(CalibrationMethod method = CalibrationMethod::kAuto);
-  static CalibrationMethod get_calibration_method() noexcept {
-    return _calibration.method;
-  }
+  static DDRes
+  init(CalibrationMethod method = CalibrationMethod::kAuto) noexcept;
+  static void init(CalibrationParams params) noexcept;
 
   static Cycles cycles_now() noexcept { return read_tsc(); }
   static time_point now() noexcept {
     return cycles_to_time_point(cycles_now());
   }
-  static State state() noexcept { return _calibration.state; }
   static const Calibration &calibration() noexcept { return _calibration; }
 
   static duration cycles_to_duration(Cycles cycles) noexcept {
@@ -94,6 +98,8 @@ inline std::string to_string(TscClock::CalibrationMethod method) {
     return "perf";
   case TscClock::CalibrationMethod::kAuto:
     return "Auto";
+  case TscClock::CalibrationMethod::kManual:
+    return "Manual";
   default:
     break;
   }

--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -305,7 +305,7 @@ int start_profiler_internal(std::unique_ptr<DDProfContext> ctx,
     return -1;
   }
 
-  ctx->perf_clock_source = PerfClock::determine_perf_clock_source();
+  ctx->perf_clock_source = PerfClock::init();
 
   if (CPU_COUNT(&ctx->params.cpu_affinity) > 0) {
     LG_DBG("Setting affinity to 0x%s",

--- a/src/perf_ringbuffer.cc
+++ b/src/perf_ringbuffer.cc
@@ -22,6 +22,8 @@ bool rb_init(RingBuffer *rb, void *base, size_t size,
   rb->data_size = size - rb->meta_size;
   rb->mask = get_mask_from_size(size);
   rb->type = ring_buffer_type;
+  rb->spinlock = nullptr;
+
   switch (ring_buffer_type) {
   case RingBufferType::kPerfRingBuffer: {
     auto *meta = reinterpret_cast<perf_event_mmap_page *>(rb->base);
@@ -34,6 +36,11 @@ bool rb_init(RingBuffer *rb, void *base, size_t size,
     rb->reader_pos = &meta->reader_pos;
     rb->writer_pos = &meta->writer_pos;
     rb->spinlock = &meta->spinlock;
+    rb->perf_clock_source = meta->perf_clock_source;
+    rb->time_mult = meta->time_mult;
+    rb->time_shift = meta->time_shift;
+    rb->time_zero = meta->time_zero;
+    rb->tsc_available = meta->tsc_available;
     break;
   }
   default:

--- a/src/tsc_clock.cc
+++ b/src/tsc_clock.cc
@@ -215,7 +215,13 @@ bool TscClock::init_from_perf(Calibration &calibration) {
   return true;
 }
 
-DDRes TscClock::init(CalibrationMethod method) {
+void TscClock::init(CalibrationParams params) noexcept {
+  _calibration.params = params;
+  _calibration.method = CalibrationMethod::kManual;
+  _calibration.state = State::kOK;
+}
+
+DDRes TscClock::init(CalibrationMethod method) noexcept {
   if ((method == CalibrationMethod::kAuto ||
        method == CalibrationMethod::kPerf) &&
       init_from_perf(_calibration)) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -287,6 +287,7 @@ set(ALLOCATION_TRACKER_UT_SRCS
     ../src/failed_assumption.cc
     ../src/pevent_lib.cc
     ../src/perf.cc
+    ../src/perf_clock.cc
     ../src/perf_ringbuffer.cc
     ../src/perf_watcher.cc
     ../src/ringbuffer_utils.cc
@@ -302,6 +303,7 @@ set(ALLOCATION_TRACKER_UT_SRCS
     ../src/statsd.cc
     ../src/sys_utils.cc
     ../src/tracepoint_config.cc
+    ../src/tsc_clock.cc
     ../src/user_override.cc
     ../src/unwind.cc
     ../src/unwind_dwfl.cc
@@ -406,7 +408,9 @@ add_benchmark(
   ../src/lib/pthread_fixes.cc
   ../src/lib/savecontext.cc
   ../src/lib/saveregisters.cc
+  ../src/perf_clock.cc
   ../src/procutils.cc
+  ../src/tsc_clock.cc
   ../src/user_override.cc
   ../src/sys_utils.cc
   LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle DDProf::Parser

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -365,7 +365,7 @@ TEST(DSOTest, backpopulate_with_perf_clock) {
                                                    old_timestamp));
   }
   // Init perf clock
-  PerfClock::determine_perf_clock_source();
+  PerfClock::init();
   {
     DsoHdr dso_hdr;
     auto old_timestamp = PerfClock::now();

--- a/test/timer-bench.cc
+++ b/test/timer-bench.cc
@@ -75,7 +75,7 @@ BENCHMARK(BM_times);
 
 static void BM_perf_clock(benchmark::State &state) {
   ddprof::LogHandle log_handle;
-  ddprof::PerfClock::determine_perf_clock_source();
+  ddprof::PerfClock::init();
   for (auto _ : state) {
     auto t = ddprof::PerfClock::now();
     benchmark::DoNotOptimize(t);


### PR DESCRIPTION
# What does this PR do?

Add timestamp information to allocation events using perf clock.=

Perf clock parameters are transferred to the library through metadata page.
