### PR TITLE
Remove some dependencies on ddprof::Parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,6 @@ set(DD_PROFILING_SOURCES
     src/lib/saveregisters.cc
     src/lib/symbol_overrides.cc
     src/logger.cc
-    src/logger_setup.cc
     src/perf.cc
     src/perf_clock.cc
     src/perf_ringbuffer.cc
@@ -253,8 +252,6 @@ if(BUILD_UNIVERSAL_DDPROF)
     target_compile_definitions(dd_profiling-embedded PRIVATE DDPROF_MISSING_FSTAT)
   endif()
 endif()
-
-target_link_libraries(dd_profiling-embedded PRIVATE DDProf::Parser)
 
 # Fix for link error in sanitizeddebug build mode with gcc:
 # ~~~
@@ -343,7 +340,7 @@ target_include_directories(dd_profiling-static PUBLIC ${CMAKE_SOURCE_DIR}/includ
                                                       ${CMAKE_SOURCE_DIR}/include)
 set_target_properties(dd_profiling-static
                       PROPERTIES PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/lib/dd_profiling.h")
-target_link_libraries(dd_profiling-static PRIVATE DDProf::Parser ddprof_exe_object)
+target_link_libraries(dd_profiling-static PRIVATE ddprof_exe_object)
 target_link_libraries(dd_profiling-static PUBLIC dl pthread rt)
 
 if(USE_LOADER)
@@ -359,7 +356,7 @@ else()
   # Without loader, libdd_profiling.so is basically the same as libdd_profiling-embedded.so plus an
   # embedded ddprof executable.
   add_library(dd_profiling-shared SHARED ${DD_PROFILING_SOURCES} src/lib/lib_embedded_data.c)
-  target_link_libraries(dd_profiling-shared PRIVATE DDProf::Parser ddprof_exe_object)
+  target_link_libraries(dd_profiling-shared PRIVATE ddprof_exe_object)
   target_compile_definitions(dd_profiling-shared PRIVATE DDPROF_EMBEDDED_EXE_DATA)
 
   # Fix for link error in sanitizeddebug build mode with gcc:

--- a/include/ddprof_cmdline.hpp
+++ b/include/ddprof_cmdline.hpp
@@ -5,15 +5,10 @@
 
 #pragma once
 
-#include "ddprof_defs.hpp"
-
 #include <cstddef>
 #include <cstdint>
-#include <vector>
 
 namespace ddprof {
-
-struct PerfWatcher;
 
 /**************************** Cmdline Helpers *********************************/
 // Helper functions for processing commandline arguments.
@@ -31,9 +26,5 @@ int arg_which(const char *str, char const *const *set, int sz_set);
 bool arg_inset(const char *str, char const *const *set, int sz_set);
 
 bool arg_yesno(const char *str, int mode);
-
-bool watchers_from_str(
-    const char *str, std::vector<PerfWatcher> &watchers,
-    uint32_t stack_sample_size = k_default_perf_stack_sample_size);
 
 } // namespace ddprof

--- a/include/ddprof_cmdline_watcher.hpp
+++ b/include/ddprof_cmdline_watcher.hpp
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#pragma once
+
+#include "ddprof_defs.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace ddprof {
+
+struct PerfWatcher;
+
+bool watchers_from_str(
+    const char *str, std::vector<PerfWatcher> &watchers,
+    uint32_t stack_sample_size = k_default_perf_stack_sample_size);
+
+} // namespace ddprof

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -15,6 +15,7 @@
 #include "CLI/CLI11.hpp"
 #include "constants.hpp"
 #include "ddprof_cmdline.hpp"
+#include "ddprof_cmdline_watcher.hpp"
 #include "ddprof_defs.hpp"
 #include "ddres.hpp"
 #include "logger.hpp"

--- a/src/ddprof_cmdline.cc
+++ b/src/ddprof_cmdline.cc
@@ -7,103 +7,8 @@
 
 #include <cassert>
 #include <strings.h>
-#include <utility>
-
-#include "event_config.hpp"
-#include "perf_watcher.hpp"
-#include "tracepoint_config.hpp"
 
 namespace ddprof {
-
-namespace {
-bool watcher_from_config(EventConf *conf, PerfWatcher *watcher) {
-  constexpr int64_t kIgnoredWatcherID = -1L;
-
-  // If there's no eventname, then this configuration is invalid
-  if (conf->eventname.empty()) {
-    return false;
-  }
-
-  // The watcher is templated; either from an existing Profiling template,
-  // keyed on the eventname, or it uses the generic template for Tracepoints
-  const PerfWatcher *tmp_watcher = ewatcher_from_str(conf->eventname.c_str());
-  if (tmp_watcher) {
-    *watcher = *tmp_watcher;
-    conf->id = kIgnoredWatcherID; // matched, so invalidate Tracepoint checks
-  } else if (!conf->groupname.empty()) {
-    // If the event doesn't match an ewatcher, it is only valid if a group was
-    // also provided (splitting events on ':' is the responsibility of the
-    // parser)
-    const auto *tmp_tracepoint_watcher = tracepoint_default_watcher();
-    if (!tmp_tracepoint_watcher) {
-      return false;
-    }
-    *watcher = *tmp_tracepoint_watcher;
-  } else {
-    return false;
-  }
-
-  if (conf->id != kIgnoredWatcherID) {
-    // The most likely thing to be invalid is the selection of the tracepoint
-    // from the trace events system.  If the conf has a nonzero number for the
-    // id we assume the user has privileged information and knows what they
-    // want. Else, we use the group/event combination to extract that id from
-    // the tracefs filesystem in the canonical way.
-    int64_t tracepoint_id = 0;
-    if (conf->id > 0) {
-      tracepoint_id = conf->id;
-    } else {
-      tracepoint_id = tracepoint_get_id(conf->eventname, conf->groupname);
-    }
-    // At this point we needed to find a valid tracepoint id
-    if (tracepoint_id == kIgnoredWatcherID) {
-      return false;
-    }
-    watcher->config = tracepoint_id;
-  }
-
-  // Configure the sampling strategy.  If no valid conf, use template default
-  if (conf->cadence != 0) {
-    if (conf->cad_type == EventConfCadenceType::kPeriod) {
-      watcher->sample_period = conf->cadence;
-    } else if (conf->cad_type == EventConfCadenceType::kFrequency) {
-      watcher->sample_frequency = conf->cadence;
-      watcher->options.is_freq = true;
-    }
-  }
-
-  // Configure value source
-  if (conf->value_source == EventConfValueSource::kRaw) {
-    watcher->value_source = EventConfValueSource::kRaw;
-    watcher->sample_type |= PERF_SAMPLE_RAW;
-    watcher->raw_off = conf->raw_offset;
-    if (conf->raw_size > 0) {
-      watcher->raw_sz = conf->raw_size;
-    } else {
-      watcher->raw_sz = sizeof(uint64_t); // default raw entry
-    }
-  } else if (conf->value_source == EventConfValueSource::kRegister) {
-    watcher->regno = conf->register_num;
-    watcher->value_source = EventConfValueSource::kRegister;
-  }
-
-  if (conf->value_scale != 0.0) {
-    watcher->value_scale = conf->value_scale;
-  }
-  watcher->aggregation_mode = conf->mode;
-  watcher->tracepoint_event = conf->eventname;
-  watcher->tracepoint_group = conf->groupname;
-  watcher->tracepoint_label = conf->label;
-  watcher->options.stack_sample_size = conf->stack_sample_size;
-  // Allocation watcher, has an extra field to ensure we capture address
-
-  if (watcher->config == kDDPROF_COUNT_ALLOCATIONS) {
-    watcher->sample_type |= PERF_SAMPLE_ADDR;
-  }
-
-  return true;
-}
-} // namespace
 
 int arg_which(const char *str, char const *const *set, int sz_set) {
   if (!str || !set) {
@@ -128,28 +33,6 @@ bool arg_yesno(const char *str, int mode) {
   assert(0 == mode || 1 == mode);
   char const *const *set = (!mode) ? no_set : yes_set;
   return arg_which(str, set, sizeOfPatterns) != -1;
-}
-
-// If this returns false, then the passed watcher should be regarded as invalid
-bool watchers_from_str(const char *str, std::vector<PerfWatcher> &watchers,
-                       uint32_t stack_sample_size) {
-  std::vector<EventConf> configs;
-  const EventConf template_conf{
-      .mode = EventAggregationMode::kSum,
-      .stack_sample_size = stack_sample_size,
-  };
-  if (EventConf_parse(str, template_conf, configs) != 0) {
-    return false;
-  }
-
-  for (auto &conf : configs) {
-    PerfWatcher watcher;
-    if (!watcher_from_config(&conf, &watcher)) {
-      return false;
-    }
-    watchers.push_back(std::move(watcher));
-  }
-  return true;
 }
 
 } // namespace ddprof

--- a/src/ddprof_cmdline_watcher.cc
+++ b/src/ddprof_cmdline_watcher.cc
@@ -1,0 +1,128 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include "ddprof_cmdline_watcher.hpp"
+
+#include <cassert>
+#include <strings.h>
+#include <utility>
+
+#include "event_config.hpp"
+#include "perf_watcher.hpp"
+#include "tracepoint_config.hpp"
+
+namespace ddprof {
+namespace {
+bool watcher_from_config(EventConf *conf, PerfWatcher *watcher) {
+  constexpr int64_t kIgnoredWatcherID = -1L;
+
+  // If there's no eventname, then this configuration is invalid
+  if (conf->eventname.empty()) {
+    return false;
+  }
+
+  // The watcher is templated; either from an existing Profiling template,
+  // keyed on the eventname, or it uses the generic template for Tracepoints
+  const PerfWatcher *tmp_watcher = ewatcher_from_str(conf->eventname.c_str());
+  if (tmp_watcher) {
+    *watcher = *tmp_watcher;
+    conf->id = kIgnoredWatcherID; // matched, so invalidate Tracepoint checks
+  } else if (!conf->groupname.empty()) {
+    // If the event doesn't match an ewatcher, it is only valid if a group was
+    // also provided (splitting events on ':' is the responsibility of the
+    // parser)
+    const auto *tmp_tracepoint_watcher = tracepoint_default_watcher();
+    if (!tmp_tracepoint_watcher) {
+      return false;
+    }
+    *watcher = *tmp_tracepoint_watcher;
+  } else {
+    return false;
+  }
+
+  if (conf->id != kIgnoredWatcherID) {
+    // The most likely thing to be invalid is the selection of the tracepoint
+    // from the trace events system.  If the conf has a nonzero number for the
+    // id we assume the user has privileged information and knows what they
+    // want. Else, we use the group/event combination to extract that id from
+    // the tracefs filesystem in the canonical way.
+    int64_t tracepoint_id = 0;
+    if (conf->id > 0) {
+      tracepoint_id = conf->id;
+    } else {
+      tracepoint_id = tracepoint_get_id(conf->eventname, conf->groupname);
+    }
+    // At this point we needed to find a valid tracepoint id
+    if (tracepoint_id == kIgnoredWatcherID) {
+      return false;
+    }
+    watcher->config = tracepoint_id;
+  }
+
+  // Configure the sampling strategy.  If no valid conf, use template default
+  if (conf->cadence != 0) {
+    if (conf->cad_type == EventConfCadenceType::kPeriod) {
+      watcher->sample_period = conf->cadence;
+    } else if (conf->cad_type == EventConfCadenceType::kFrequency) {
+      watcher->sample_frequency = conf->cadence;
+      watcher->options.is_freq = true;
+    }
+  }
+
+  // Configure value source
+  if (conf->value_source == EventConfValueSource::kRaw) {
+    watcher->value_source = EventConfValueSource::kRaw;
+    watcher->sample_type |= PERF_SAMPLE_RAW;
+    watcher->raw_off = conf->raw_offset;
+    if (conf->raw_size > 0) {
+      watcher->raw_sz = conf->raw_size;
+    } else {
+      watcher->raw_sz = sizeof(uint64_t); // default raw entry
+    }
+  } else if (conf->value_source == EventConfValueSource::kRegister) {
+    watcher->regno = conf->register_num;
+    watcher->value_source = EventConfValueSource::kRegister;
+  }
+
+  if (conf->value_scale != 0.0) {
+    watcher->value_scale = conf->value_scale;
+  }
+  watcher->aggregation_mode = conf->mode;
+  watcher->tracepoint_event = conf->eventname;
+  watcher->tracepoint_group = conf->groupname;
+  watcher->tracepoint_label = conf->label;
+  watcher->options.stack_sample_size = conf->stack_sample_size;
+  // Allocation watcher, has an extra field to ensure we capture address
+
+  if (watcher->config == kDDPROF_COUNT_ALLOCATIONS) {
+    watcher->sample_type |= PERF_SAMPLE_ADDR;
+  }
+
+  return true;
+}
+} // namespace
+// If this returns false, then the passed watcher should be regarded as invalid
+bool watchers_from_str(const char *str, std::vector<PerfWatcher> &watchers,
+                       uint32_t stack_sample_size) {
+  std::vector<EventConf> configs;
+  const EventConf template_conf{
+      .mode = EventAggregationMode::kSum,
+      .stack_sample_size = stack_sample_size,
+  };
+  if (EventConf_parse(str, template_conf, configs) != 0) {
+    return false;
+  }
+
+  for (auto &conf : configs) {
+    PerfWatcher watcher;
+    if (!watcher_from_config(&conf, &watcher)) {
+      return false;
+    }
+    watchers.push_back(std::move(watcher));
+  }
+  return true;
+}
+
+} // namespace ddprof

--- a/src/presets.cc
+++ b/src/presets.cc
@@ -5,7 +5,7 @@
 
 #include "presets.hpp"
 
-#include "ddprof_cmdline.hpp"
+#include "ddprof_cmdline_watcher.hpp"
 #include "ddres.hpp"
 
 #include <algorithm>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,8 +92,9 @@ endfunction()
 # Definition of unit tests
 add_compile_definitions("UNIT_TEST_DATA=\"${CMAKE_CURRENT_SOURCE_DIR}/data\"")
 
-add_unit_test(ddprofcmdline-ut ../src/ddprof_cmdline.cc ../src/perf_watcher.cc
-              ../src/tracepoint_config.cc ddprofcmdline-ut.cc LIBRARIES DDProf::Parser)
+add_unit_test(
+  ddprofcmdline-ut ../src/ddprof_cmdline.cc ../src/ddprof_cmdline_watcher.cc ../src/perf_watcher.cc
+  ../src/tracepoint_config.cc ddprofcmdline-ut.cc LIBRARIES DDProf::Parser)
 
 add_unit_test(logger-ut logger-ut.cc)
 
@@ -130,8 +131,9 @@ add_unit_test(procutils-ut ../src/procutils.cc procutils-ut.cc DEFINITIONS MYNAM
 
 add_unit_test(
   ddprof_context-ut
-  ../src/ddprof_cmdline.cc
   ../src/ddprof_cli.cc
+  ../src/ddprof_cmdline.cc
+  ../src/ddprof_cmdline_watcher.cc
   ../src/ddprof_context_lib.cc
   ../src/ddprof_cpumask.cc
   ../src/logger_setup.cc
@@ -142,14 +144,11 @@ add_unit_test(
   LIBRARIES DDProf::Parser CLI11
   DEFINITIONS MYNAME="ddprof_context-ut")
 
-add_unit_test(
-  perf_ringbuffer-ut ../src/perf.cc ../src/perf_watcher.cc ../src/perf_ringbuffer.cc
-  ../src/tracepoint_config.cc perf_ringbuffer-ut.cc DEFINITIONS MYNAME="perf_ringbuffer-ut")
+add_unit_test(perf_ringbuffer-ut ../src/perf.cc ../src/perf_watcher.cc ../src/perf_ringbuffer.cc
+              perf_ringbuffer-ut.cc DEFINITIONS MYNAME="perf_ringbuffer-ut")
 
 add_unit_test(
   pevent-ut
-  ../src/ddprof_cmdline.cc
-  ../src/tracepoint_config.cc
   ../src/pevent_lib.cc
   ../src/user_override.cc
   ../src/perf.cc
@@ -158,24 +157,17 @@ add_unit_test(
   ../src/ringbuffer_utils.cc
   ../src/sys_utils.cc
   pevent-ut.cc
-  LIBRARIES DDProf::Parser
   DEFINITIONS MYNAME="pevent-ut")
 
 add_unit_test(
-  ddprof_pprof-ut ddprof_pprof-ut.cc ../src/ddprof_cmdline.cc ../src/pprof/ddprof_pprof.cc
+  ddprof_pprof-ut ddprof_pprof-ut.cc ../src/ddprof_cmdline_watcher.cc ../src/pprof/ddprof_pprof.cc
   ../src/perf_watcher.cc ../src/tracepoint_config.cc
   LIBRARIES Datadog::Profiling DDProf::Parser
   DEFINITIONS MYNAME="ddprof_pprof-ut")
 
 add_unit_test(
-  ddprof_exporter-ut
-  ../src/exporter/ddprof_exporter.cc
-  ../src/ddprof_cmdline.cc
-  ../src/tracepoint_config.cc
-  ../src/pprof/ddprof_pprof.cc
-  ../src/perf_watcher.cc
-  ../src/tags.cc
-  ddprof_exporter-ut.cc
+  ddprof_exporter-ut ../src/exporter/ddprof_exporter.cc ../src/pprof/ddprof_pprof.cc
+  ../src/perf_watcher.cc ../src/tags.cc ddprof_exporter-ut.cc
   LIBRARIES Datadog::Profiling DDProf::Parser
   DEFINITIONS MYNAME="ddprof_exporter-ut")
 
@@ -271,7 +263,6 @@ set(ALLOCATION_TRACKER_UT_SRCS
     ../src/container_id.cc
     ../src/common_mapinfo_lookup.cc
     ../src/common_symbol_lookup.cc
-    ../src/ddprof_cmdline.cc
     ../src/ddprof_process.cc
     ../src/ddprof_stats.cc
     ../src/dso.cc
@@ -302,7 +293,6 @@ set(ALLOCATION_TRACKER_UT_SRCS
     ../src/signal_helper.cc
     ../src/statsd.cc
     ../src/sys_utils.cc
-    ../src/tracepoint_config.cc
     ../src/tsc_clock.cc
     ../src/user_override.cc
     ../src/unwind.cc
@@ -312,13 +302,13 @@ set(ALLOCATION_TRACKER_UT_SRCS
 
 add_unit_test(
   allocation_tracker-ut ${ALLOCATION_TRACKER_UT_SRCS}
-  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle DDProf::Parser dl rt
+  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle dl rt
   DEFINITIONS ${DDPROF_DEFINITION_LIST} KMAX_TRACKED_ALLOCATIONS=16384)
 
 if(TARGET jemalloc::jemalloc_shared)
   add_unit_test(
     allocation_tracker_jemalloc-ut ${ALLOCATION_TRACKER_UT_SRCS}
-    LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle DDProf::Parser dl rt jemalloc::jemalloc_shared
+    LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle dl rt jemalloc::jemalloc_shared
     DEFINITIONS ${DDPROF_DEFINITION_LIST} KMAX_TRACKED_ALLOCATIONS=16384 USE_JEMALLOC=1)
 endif()
 
@@ -327,16 +317,13 @@ add_unit_test(sys_utils-ut sys_utils-ut.cc ../src/sys_utils.cc)
 add_unit_test(
   ringbuffer-ut
   ringbuffer-ut.cc
-  ../src/ddprof_cmdline.cc
-  ../src/tracepoint_config.cc
   ../src/perf.cc
   ../src/perf_ringbuffer.cc
   ../src/perf_watcher.cc
   ../src/pevent_lib.cc
   ../src/ringbuffer_utils.cc
   ../src/sys_utils.cc
-  ../src/user_override.cc
-  LIBRARIES DDProf::Parser)
+  ../src/user_override.cc)
 
 add_unit_test(timer-ut timer-ut.cc ../src/tsc_clock.cc ../src/perf.cc)
 
@@ -370,6 +357,7 @@ add_unit_test(
   ../src/ddprof_cli.cc
   ../src/version.cc
   ../src/ddprof_cmdline.cc
+  ../src/ddprof_cmdline_watcher.cc
   ../src/perf_watcher.cc
   ../src/tracepoint_config.cc
   LIBRARIES DDProf::Parser CLI11)
@@ -381,7 +369,7 @@ add_unit_test(address_bitset-ut address_bitset-ut.cc ../src/lib/address_bitset.c
 add_unit_test(lib_logger-ut ./lib_logger-ut.cc)
 
 add_benchmark(savecontext-bench savecontext-bench.cc ../src/lib/pthread_fixes.cc
-              ../src/lib/savecontext.cc ../src/lib/saveregisters.cc)
+              ../src/lib/savecontext.cc ../src/lib/saveregisters.cc LIBRARIES llvm-demangle)
 
 add_benchmark(timer-bench timer-bench.cc ../src/tsc_clock.cc ../src/perf.cc ../src/perf_clock.cc
               ../src/perf_ringbuffer.cc)
@@ -413,7 +401,7 @@ add_benchmark(
   ../src/tsc_clock.cc
   ../src/user_override.cc
   ../src/sys_utils.cc
-  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle DDProf::Parser
+  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle
   DEFINITIONS ${DDPROF_DEFINITION_LIST} KMAX_TRACKED_ALLOCATIONS=16384)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "SanitizedDebug")

--- a/test/ddprof_pprof-ut.cc
+++ b/test/ddprof_pprof-ut.cc
@@ -7,6 +7,7 @@
 
 #include "ddog_profiling_utils.hpp"
 #include "ddprof_cmdline.hpp"
+#include "ddprof_cmdline_watcher.hpp"
 #include "loghandle.hpp"
 #include "pevent_lib_mocks.hpp"
 #include "symbol_hdr.hpp"

--- a/test/ddprofcmdline-ut.cc
+++ b/test/ddprofcmdline-ut.cc
@@ -4,6 +4,7 @@
 // Datadog, Inc.
 
 #include "ddprof_cmdline.hpp"
+#include "ddprof_cmdline_watcher.hpp"
 #include "perf_archmap.hpp"
 #include "perf_watcher.hpp"
 


### PR DESCRIPTION
Split ddprof_cmdline into 2 files
This allows to removing dependency on ddprof::Parser for profiling lib and some unit tests.