### PR TITLE
Add function_ref

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,6 @@ set(DD_PROFILING_SOURCES
     src/lib/saveregisters.cc
     src/lib/symbol_overrides.cc
     src/logger.cc
-    src/logger_setup.cc
     src/perf.cc
     src/perf_clock.cc
     src/perf_ringbuffer.cc
@@ -253,8 +252,6 @@ if(BUILD_UNIVERSAL_DDPROF)
     target_compile_definitions(dd_profiling-embedded PRIVATE DDPROF_MISSING_FSTAT)
   endif()
 endif()
-
-target_link_libraries(dd_profiling-embedded PRIVATE DDProf::Parser)
 
 # Fix for link error in sanitizeddebug build mode with gcc:
 # ~~~
@@ -343,7 +340,7 @@ target_include_directories(dd_profiling-static PUBLIC ${CMAKE_SOURCE_DIR}/includ
                                                       ${CMAKE_SOURCE_DIR}/include)
 set_target_properties(dd_profiling-static
                       PROPERTIES PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/lib/dd_profiling.h")
-target_link_libraries(dd_profiling-static PRIVATE DDProf::Parser ddprof_exe_object)
+target_link_libraries(dd_profiling-static PRIVATE ddprof_exe_object)
 target_link_libraries(dd_profiling-static PUBLIC dl pthread rt)
 
 if(USE_LOADER)
@@ -359,7 +356,7 @@ else()
   # Without loader, libdd_profiling.so is basically the same as libdd_profiling-embedded.so plus an
   # embedded ddprof executable.
   add_library(dd_profiling-shared SHARED ${DD_PROFILING_SOURCES} src/lib/lib_embedded_data.c)
-  target_link_libraries(dd_profiling-shared PRIVATE DDProf::Parser ddprof_exe_object)
+  target_link_libraries(dd_profiling-shared PRIVATE ddprof_exe_object)
   target_compile_definitions(dd_profiling-shared PRIVATE DDPROF_EMBEDDED_EXE_DATA)
 
   # Fix for link error in sanitizeddebug build mode with gcc:

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -6,3 +6,4 @@ libunwind,"https://github.com/libunwind/libunwind",MIT License
 llvm-demangle,"https://github.com/llvm/llvm-project",Apache-2.0,llvm-project
 dpdk/lib/eal,"https://github.com/DPDK/dpdk",BSD-3-Clause
 CLI11,"https://github.com/CLIUtils/CLI11",BSD-3-Clause
+nontype_functional,"https://github.com/zhihaoy/nontype_functional",BSD-2-Clause,Zhihao Yuan

--- a/include/ddprof_cmdline.hpp
+++ b/include/ddprof_cmdline.hpp
@@ -5,15 +5,10 @@
 
 #pragma once
 
-#include "ddprof_defs.hpp"
-
 #include <cstddef>
 #include <cstdint>
-#include <vector>
 
 namespace ddprof {
-
-struct PerfWatcher;
 
 /**************************** Cmdline Helpers *********************************/
 // Helper functions for processing commandline arguments.
@@ -31,9 +26,5 @@ int arg_which(const char *str, char const *const *set, int sz_set);
 bool arg_inset(const char *str, char const *const *set, int sz_set);
 
 bool arg_yesno(const char *str, int mode);
-
-bool watchers_from_str(
-    const char *str, std::vector<PerfWatcher> &watchers,
-    uint32_t stack_sample_size = k_default_perf_stack_sample_size);
 
 } // namespace ddprof

--- a/include/ddprof_cmdline_watcher.hpp
+++ b/include/ddprof_cmdline_watcher.hpp
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#pragma once
+
+#include "ddprof_defs.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace ddprof {
+
+struct PerfWatcher;
+
+bool watchers_from_str(
+    const char *str, std::vector<PerfWatcher> &watchers,
+    uint32_t stack_sample_size = k_default_perf_stack_sample_size);
+
+} // namespace ddprof

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -15,6 +15,7 @@
 #include "CLI/CLI11.hpp"
 #include "constants.hpp"
 #include "ddprof_cmdline.hpp"
+#include "ddprof_cmdline_watcher.hpp"
 #include "ddprof_defs.hpp"
 #include "ddres.hpp"
 #include "logger.hpp"

--- a/src/ddprof_cmdline.cc
+++ b/src/ddprof_cmdline.cc
@@ -7,103 +7,8 @@
 
 #include <cassert>
 #include <strings.h>
-#include <utility>
-
-#include "event_config.hpp"
-#include "perf_watcher.hpp"
-#include "tracepoint_config.hpp"
 
 namespace ddprof {
-
-namespace {
-bool watcher_from_config(EventConf *conf, PerfWatcher *watcher) {
-  constexpr int64_t kIgnoredWatcherID = -1L;
-
-  // If there's no eventname, then this configuration is invalid
-  if (conf->eventname.empty()) {
-    return false;
-  }
-
-  // The watcher is templated; either from an existing Profiling template,
-  // keyed on the eventname, or it uses the generic template for Tracepoints
-  const PerfWatcher *tmp_watcher = ewatcher_from_str(conf->eventname.c_str());
-  if (tmp_watcher) {
-    *watcher = *tmp_watcher;
-    conf->id = kIgnoredWatcherID; // matched, so invalidate Tracepoint checks
-  } else if (!conf->groupname.empty()) {
-    // If the event doesn't match an ewatcher, it is only valid if a group was
-    // also provided (splitting events on ':' is the responsibility of the
-    // parser)
-    const auto *tmp_tracepoint_watcher = tracepoint_default_watcher();
-    if (!tmp_tracepoint_watcher) {
-      return false;
-    }
-    *watcher = *tmp_tracepoint_watcher;
-  } else {
-    return false;
-  }
-
-  if (conf->id != kIgnoredWatcherID) {
-    // The most likely thing to be invalid is the selection of the tracepoint
-    // from the trace events system.  If the conf has a nonzero number for the
-    // id we assume the user has privileged information and knows what they
-    // want. Else, we use the group/event combination to extract that id from
-    // the tracefs filesystem in the canonical way.
-    int64_t tracepoint_id = 0;
-    if (conf->id > 0) {
-      tracepoint_id = conf->id;
-    } else {
-      tracepoint_id = tracepoint_get_id(conf->eventname, conf->groupname);
-    }
-    // At this point we needed to find a valid tracepoint id
-    if (tracepoint_id == kIgnoredWatcherID) {
-      return false;
-    }
-    watcher->config = tracepoint_id;
-  }
-
-  // Configure the sampling strategy.  If no valid conf, use template default
-  if (conf->cadence != 0) {
-    if (conf->cad_type == EventConfCadenceType::kPeriod) {
-      watcher->sample_period = conf->cadence;
-    } else if (conf->cad_type == EventConfCadenceType::kFrequency) {
-      watcher->sample_frequency = conf->cadence;
-      watcher->options.is_freq = true;
-    }
-  }
-
-  // Configure value source
-  if (conf->value_source == EventConfValueSource::kRaw) {
-    watcher->value_source = EventConfValueSource::kRaw;
-    watcher->sample_type |= PERF_SAMPLE_RAW;
-    watcher->raw_off = conf->raw_offset;
-    if (conf->raw_size > 0) {
-      watcher->raw_sz = conf->raw_size;
-    } else {
-      watcher->raw_sz = sizeof(uint64_t); // default raw entry
-    }
-  } else if (conf->value_source == EventConfValueSource::kRegister) {
-    watcher->regno = conf->register_num;
-    watcher->value_source = EventConfValueSource::kRegister;
-  }
-
-  if (conf->value_scale != 0.0) {
-    watcher->value_scale = conf->value_scale;
-  }
-  watcher->aggregation_mode = conf->mode;
-  watcher->tracepoint_event = conf->eventname;
-  watcher->tracepoint_group = conf->groupname;
-  watcher->tracepoint_label = conf->label;
-  watcher->options.stack_sample_size = conf->stack_sample_size;
-  // Allocation watcher, has an extra field to ensure we capture address
-
-  if (watcher->config == kDDPROF_COUNT_ALLOCATIONS) {
-    watcher->sample_type |= PERF_SAMPLE_ADDR;
-  }
-
-  return true;
-}
-} // namespace
 
 int arg_which(const char *str, char const *const *set, int sz_set) {
   if (!str || !set) {
@@ -128,28 +33,6 @@ bool arg_yesno(const char *str, int mode) {
   assert(0 == mode || 1 == mode);
   char const *const *set = (!mode) ? no_set : yes_set;
   return arg_which(str, set, sizeOfPatterns) != -1;
-}
-
-// If this returns false, then the passed watcher should be regarded as invalid
-bool watchers_from_str(const char *str, std::vector<PerfWatcher> &watchers,
-                       uint32_t stack_sample_size) {
-  std::vector<EventConf> configs;
-  const EventConf template_conf{
-      .mode = EventAggregationMode::kSum,
-      .stack_sample_size = stack_sample_size,
-  };
-  if (EventConf_parse(str, template_conf, configs) != 0) {
-    return false;
-  }
-
-  for (auto &conf : configs) {
-    PerfWatcher watcher;
-    if (!watcher_from_config(&conf, &watcher)) {
-      return false;
-    }
-    watchers.push_back(std::move(watcher));
-  }
-  return true;
 }
 
 } // namespace ddprof

--- a/src/ddprof_cmdline_watcher.cc
+++ b/src/ddprof_cmdline_watcher.cc
@@ -1,0 +1,128 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include "ddprof_cmdline_watcher.hpp"
+
+#include <cassert>
+#include <strings.h>
+#include <utility>
+
+#include "event_config.hpp"
+#include "perf_watcher.hpp"
+#include "tracepoint_config.hpp"
+
+namespace ddprof {
+namespace {
+bool watcher_from_config(EventConf *conf, PerfWatcher *watcher) {
+  constexpr int64_t kIgnoredWatcherID = -1L;
+
+  // If there's no eventname, then this configuration is invalid
+  if (conf->eventname.empty()) {
+    return false;
+  }
+
+  // The watcher is templated; either from an existing Profiling template,
+  // keyed on the eventname, or it uses the generic template for Tracepoints
+  const PerfWatcher *tmp_watcher = ewatcher_from_str(conf->eventname.c_str());
+  if (tmp_watcher) {
+    *watcher = *tmp_watcher;
+    conf->id = kIgnoredWatcherID; // matched, so invalidate Tracepoint checks
+  } else if (!conf->groupname.empty()) {
+    // If the event doesn't match an ewatcher, it is only valid if a group was
+    // also provided (splitting events on ':' is the responsibility of the
+    // parser)
+    const auto *tmp_tracepoint_watcher = tracepoint_default_watcher();
+    if (!tmp_tracepoint_watcher) {
+      return false;
+    }
+    *watcher = *tmp_tracepoint_watcher;
+  } else {
+    return false;
+  }
+
+  if (conf->id != kIgnoredWatcherID) {
+    // The most likely thing to be invalid is the selection of the tracepoint
+    // from the trace events system.  If the conf has a nonzero number for the
+    // id we assume the user has privileged information and knows what they
+    // want. Else, we use the group/event combination to extract that id from
+    // the tracefs filesystem in the canonical way.
+    int64_t tracepoint_id = 0;
+    if (conf->id > 0) {
+      tracepoint_id = conf->id;
+    } else {
+      tracepoint_id = tracepoint_get_id(conf->eventname, conf->groupname);
+    }
+    // At this point we needed to find a valid tracepoint id
+    if (tracepoint_id == kIgnoredWatcherID) {
+      return false;
+    }
+    watcher->config = tracepoint_id;
+  }
+
+  // Configure the sampling strategy.  If no valid conf, use template default
+  if (conf->cadence != 0) {
+    if (conf->cad_type == EventConfCadenceType::kPeriod) {
+      watcher->sample_period = conf->cadence;
+    } else if (conf->cad_type == EventConfCadenceType::kFrequency) {
+      watcher->sample_frequency = conf->cadence;
+      watcher->options.is_freq = true;
+    }
+  }
+
+  // Configure value source
+  if (conf->value_source == EventConfValueSource::kRaw) {
+    watcher->value_source = EventConfValueSource::kRaw;
+    watcher->sample_type |= PERF_SAMPLE_RAW;
+    watcher->raw_off = conf->raw_offset;
+    if (conf->raw_size > 0) {
+      watcher->raw_sz = conf->raw_size;
+    } else {
+      watcher->raw_sz = sizeof(uint64_t); // default raw entry
+    }
+  } else if (conf->value_source == EventConfValueSource::kRegister) {
+    watcher->regno = conf->register_num;
+    watcher->value_source = EventConfValueSource::kRegister;
+  }
+
+  if (conf->value_scale != 0.0) {
+    watcher->value_scale = conf->value_scale;
+  }
+  watcher->aggregation_mode = conf->mode;
+  watcher->tracepoint_event = conf->eventname;
+  watcher->tracepoint_group = conf->groupname;
+  watcher->tracepoint_label = conf->label;
+  watcher->options.stack_sample_size = conf->stack_sample_size;
+  // Allocation watcher, has an extra field to ensure we capture address
+
+  if (watcher->config == kDDPROF_COUNT_ALLOCATIONS) {
+    watcher->sample_type |= PERF_SAMPLE_ADDR;
+  }
+
+  return true;
+}
+} // namespace
+// If this returns false, then the passed watcher should be regarded as invalid
+bool watchers_from_str(const char *str, std::vector<PerfWatcher> &watchers,
+                       uint32_t stack_sample_size) {
+  std::vector<EventConf> configs;
+  const EventConf template_conf{
+      .mode = EventAggregationMode::kSum,
+      .stack_sample_size = stack_sample_size,
+  };
+  if (EventConf_parse(str, template_conf, configs) != 0) {
+    return false;
+  }
+
+  for (auto &conf : configs) {
+    PerfWatcher watcher;
+    if (!watcher_from_config(&conf, &watcher)) {
+      return false;
+    }
+    watchers.push_back(std::move(watcher));
+  }
+  return true;
+}
+
+} // namespace ddprof

--- a/src/presets.cc
+++ b/src/presets.cc
@@ -5,7 +5,7 @@
 
 #include "presets.hpp"
 
-#include "ddprof_cmdline.hpp"
+#include "ddprof_cmdline_watcher.hpp"
 #include "ddres.hpp"
 
 #include <algorithm>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,8 +92,9 @@ endfunction()
 # Definition of unit tests
 add_compile_definitions("UNIT_TEST_DATA=\"${CMAKE_CURRENT_SOURCE_DIR}/data\"")
 
-add_unit_test(ddprofcmdline-ut ../src/ddprof_cmdline.cc ../src/perf_watcher.cc
-              ../src/tracepoint_config.cc ddprofcmdline-ut.cc LIBRARIES DDProf::Parser)
+add_unit_test(
+  ddprofcmdline-ut ../src/ddprof_cmdline.cc ../src/ddprof_cmdline_watcher.cc ../src/perf_watcher.cc
+  ../src/tracepoint_config.cc ddprofcmdline-ut.cc LIBRARIES DDProf::Parser)
 
 add_unit_test(logger-ut logger-ut.cc)
 
@@ -130,8 +131,9 @@ add_unit_test(procutils-ut ../src/procutils.cc procutils-ut.cc DEFINITIONS MYNAM
 
 add_unit_test(
   ddprof_context-ut
-  ../src/ddprof_cmdline.cc
   ../src/ddprof_cli.cc
+  ../src/ddprof_cmdline.cc
+  ../src/ddprof_cmdline_watcher.cc
   ../src/ddprof_context_lib.cc
   ../src/ddprof_cpumask.cc
   ../src/logger_setup.cc
@@ -142,14 +144,11 @@ add_unit_test(
   LIBRARIES DDProf::Parser CLI11
   DEFINITIONS MYNAME="ddprof_context-ut")
 
-add_unit_test(
-  perf_ringbuffer-ut ../src/perf.cc ../src/perf_watcher.cc ../src/perf_ringbuffer.cc
-  ../src/tracepoint_config.cc perf_ringbuffer-ut.cc DEFINITIONS MYNAME="perf_ringbuffer-ut")
+add_unit_test(perf_ringbuffer-ut ../src/perf.cc ../src/perf_watcher.cc ../src/perf_ringbuffer.cc
+              perf_ringbuffer-ut.cc DEFINITIONS MYNAME="perf_ringbuffer-ut")
 
 add_unit_test(
   pevent-ut
-  ../src/ddprof_cmdline.cc
-  ../src/tracepoint_config.cc
   ../src/pevent_lib.cc
   ../src/user_override.cc
   ../src/perf.cc
@@ -158,24 +157,17 @@ add_unit_test(
   ../src/ringbuffer_utils.cc
   ../src/sys_utils.cc
   pevent-ut.cc
-  LIBRARIES DDProf::Parser
   DEFINITIONS MYNAME="pevent-ut")
 
 add_unit_test(
-  ddprof_pprof-ut ddprof_pprof-ut.cc ../src/ddprof_cmdline.cc ../src/pprof/ddprof_pprof.cc
+  ddprof_pprof-ut ddprof_pprof-ut.cc ../src/ddprof_cmdline_watcher.cc ../src/pprof/ddprof_pprof.cc
   ../src/perf_watcher.cc ../src/tracepoint_config.cc
   LIBRARIES Datadog::Profiling DDProf::Parser
   DEFINITIONS MYNAME="ddprof_pprof-ut")
 
 add_unit_test(
-  ddprof_exporter-ut
-  ../src/exporter/ddprof_exporter.cc
-  ../src/ddprof_cmdline.cc
-  ../src/tracepoint_config.cc
-  ../src/pprof/ddprof_pprof.cc
-  ../src/perf_watcher.cc
-  ../src/tags.cc
-  ddprof_exporter-ut.cc
+  ddprof_exporter-ut ../src/exporter/ddprof_exporter.cc ../src/pprof/ddprof_pprof.cc
+  ../src/perf_watcher.cc ../src/tags.cc ddprof_exporter-ut.cc
   LIBRARIES Datadog::Profiling DDProf::Parser
   DEFINITIONS MYNAME="ddprof_exporter-ut")
 
@@ -271,7 +263,6 @@ set(ALLOCATION_TRACKER_UT_SRCS
     ../src/container_id.cc
     ../src/common_mapinfo_lookup.cc
     ../src/common_symbol_lookup.cc
-    ../src/ddprof_cmdline.cc
     ../src/ddprof_process.cc
     ../src/ddprof_stats.cc
     ../src/dso.cc
@@ -302,7 +293,6 @@ set(ALLOCATION_TRACKER_UT_SRCS
     ../src/signal_helper.cc
     ../src/statsd.cc
     ../src/sys_utils.cc
-    ../src/tracepoint_config.cc
     ../src/tsc_clock.cc
     ../src/user_override.cc
     ../src/unwind.cc
@@ -312,13 +302,13 @@ set(ALLOCATION_TRACKER_UT_SRCS
 
 add_unit_test(
   allocation_tracker-ut ${ALLOCATION_TRACKER_UT_SRCS}
-  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle DDProf::Parser dl rt
+  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle dl rt
   DEFINITIONS ${DDPROF_DEFINITION_LIST} KMAX_TRACKED_ALLOCATIONS=16384)
 
 if(TARGET jemalloc::jemalloc_shared)
   add_unit_test(
     allocation_tracker_jemalloc-ut ${ALLOCATION_TRACKER_UT_SRCS}
-    LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle DDProf::Parser dl rt jemalloc::jemalloc_shared
+    LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle dl rt jemalloc::jemalloc_shared
     DEFINITIONS ${DDPROF_DEFINITION_LIST} KMAX_TRACKED_ALLOCATIONS=16384 USE_JEMALLOC=1)
 endif()
 
@@ -327,16 +317,13 @@ add_unit_test(sys_utils-ut sys_utils-ut.cc ../src/sys_utils.cc)
 add_unit_test(
   ringbuffer-ut
   ringbuffer-ut.cc
-  ../src/ddprof_cmdline.cc
-  ../src/tracepoint_config.cc
   ../src/perf.cc
   ../src/perf_ringbuffer.cc
   ../src/perf_watcher.cc
   ../src/pevent_lib.cc
   ../src/ringbuffer_utils.cc
   ../src/sys_utils.cc
-  ../src/user_override.cc
-  LIBRARIES DDProf::Parser)
+  ../src/user_override.cc)
 
 add_unit_test(timer-ut timer-ut.cc ../src/tsc_clock.cc ../src/perf.cc)
 
@@ -370,6 +357,7 @@ add_unit_test(
   ../src/ddprof_cli.cc
   ../src/version.cc
   ../src/ddprof_cmdline.cc
+  ../src/ddprof_cmdline_watcher.cc
   ../src/perf_watcher.cc
   ../src/tracepoint_config.cc
   LIBRARIES DDProf::Parser CLI11)
@@ -381,7 +369,7 @@ add_unit_test(address_bitset-ut address_bitset-ut.cc ../src/lib/address_bitset.c
 add_unit_test(lib_logger-ut ./lib_logger-ut.cc)
 
 add_benchmark(savecontext-bench savecontext-bench.cc ../src/lib/pthread_fixes.cc
-              ../src/lib/savecontext.cc ../src/lib/saveregisters.cc)
+              ../src/lib/savecontext.cc ../src/lib/saveregisters.cc LIBRARIES llvm-demangle)
 
 add_benchmark(timer-bench timer-bench.cc ../src/tsc_clock.cc ../src/perf.cc ../src/perf_clock.cc
               ../src/perf_ringbuffer.cc)
@@ -413,7 +401,7 @@ add_benchmark(
   ../src/tsc_clock.cc
   ../src/user_override.cc
   ../src/sys_utils.cc
-  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle DDProf::Parser
+  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle
   DEFINITIONS ${DDPROF_DEFINITION_LIST} KMAX_TRACKED_ALLOCATIONS=16384)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "SanitizedDebug")

--- a/test/ddprof_pprof-ut.cc
+++ b/test/ddprof_pprof-ut.cc
@@ -7,6 +7,7 @@
 
 #include "ddog_profiling_utils.hpp"
 #include "ddprof_cmdline.hpp"
+#include "ddprof_cmdline_watcher.hpp"
 #include "loghandle.hpp"
 #include "pevent_lib_mocks.hpp"
 #include "symbol_hdr.hpp"

--- a/test/ddprofcmdline-ut.cc
+++ b/test/ddprofcmdline-ut.cc
@@ -4,6 +4,7 @@
 // Datadog, Inc.
 
 #include "ddprof_cmdline.hpp"
+#include "ddprof_cmdline_watcher.hpp"
 #include "perf_archmap.hpp"
 #include "perf_watcher.hpp"
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(CLI)
 add_subdirectory(llvm)
+add_subdirectory(nontype_functional)

--- a/third_party/nontype_functional/CMakeLists.txt
+++ b/third_party/nontype_functional/CMakeLists.txt
@@ -1,0 +1,77 @@
+﻿cmake_minimum_required(VERSION 3.15)
+
+get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(is_multi_config)
+    set(CMAKE_CONFIGURATION_TYPES Debug RelWithDebInfo CACHE STRING
+        "Semicolon separated list of supported configuration types")
+    mark_as_advanced(CMAKE_CONFIGURATION_TYPES)
+elseif(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CXX_FLAGS)
+    message(WARNING "No CMAKE_BUILD_TYPE is selected")
+endif()
+
+project(nontype_functional VERSION 1.0.1 LANGUAGES CXX)
+
+if(NOT DEFINED PROJECT_IS_TOP_LEVEL)
+    if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+        set(PROJECT_IS_TOP_LEVEL TRUE)
+    else()
+        set(PROJECT_IS_TOP_LEVEL FALSE)
+    endif()
+endif()
+
+include(CTest)
+include(CMakePackageConfigHelpers)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+
+if(MSVC)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/W3>)
+    string(REPLACE "/GR" "/GR-" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+else()
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wall>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wconversion>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wsign-conversion>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wsign-compare>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>)
+endif()
+
+add_library(nontype_functional INTERFACE)
+add_library(std23::nontype_functional ALIAS nontype_functional)
+target_sources(nontype_functional INTERFACE
+ "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/std23/function_ref.h>"
+ "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/std23/function.h>"
+ "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/std23/move_only_function.h>"
+ "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/std23/__functional_base.h>"
+ "$<INSTALL_INTERFACE:include/std23/function_ref.h>"
+ "$<INSTALL_INTERFACE:include/std23/function.h>"
+ "$<INSTALL_INTERFACE:include/std23/move_only_function.h>"
+ "$<INSTALL_INTERFACE:include/std23/__functional_base.h>"
+)
+target_include_directories(nontype_functional
+    INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+              $<INSTALL_INTERFACE:include>
+)
+target_compile_features(nontype_functional INTERFACE cxx_std_20)
+
+if(PROJECT_IS_TOP_LEVEL)
+    set(_version_filename "nontype_functional-config-version.cmake")
+    write_basic_package_version_file(
+        ${_version_filename}
+        COMPATIBILITY SameMajorVersion
+    )
+    install(TARGETS nontype_functional
+            EXPORT nontype_functional-config)
+    install(EXPORT nontype_functional-config
+            NAMESPACE std23::
+            DESTINATION lib/cmake/${PROJECT_NAME})
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${_version_filename}"
+            DESTINATION lib/cmake/${PROJECT_NAME})
+    install(FILES "$<TARGET_PROPERTY:nontype_functional,INTERFACE_SOURCES>"
+            DESTINATION include/std23)
+endif()
+
+if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+    add_subdirectory("tests")
+endif()

--- a/third_party/nontype_functional/LICENSE
+++ b/third_party/nontype_functional/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2022, Zhihao Yuan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/nontype_functional/include/std23/__functional_base.h
+++ b/third_party/nontype_functional/include/std23/__functional_base.h
@@ -1,0 +1,227 @@
+#ifndef INCLUDE_STD23____FUNCTIONAL__BASE
+#define INCLUDE_STD23____FUNCTIONAL__BASE
+
+#include <functional>
+#include <utility>
+
+namespace std23
+{
+
+template<auto V> struct nontype_t // freestanding
+{
+    explicit nontype_t() = default;
+};
+
+template<auto V> inline constexpr nontype_t<V> nontype{}; // freestanding
+
+using std::in_place_type;
+using std::in_place_type_t;
+using std::initializer_list;
+using std::nullptr_t;
+
+template<class R, class F, class... Args>
+requires std::is_invocable_r_v<R, F, Args...>
+constexpr R invoke_r(F &&f, Args &&...args) // freestanding
+    noexcept(std::is_nothrow_invocable_r_v<R, F, Args...>)
+{
+    if constexpr (std::is_void_v<R>)
+        std::invoke(std::forward<F>(f), std::forward<Args>(args)...);
+    else
+        return std::invoke(std::forward<F>(f), std::forward<Args>(args)...);
+}
+
+// See also: https://www.agner.org/optimize/calling_conventions.pdf
+template<class T>
+inline constexpr auto _select_param_type = []
+{
+    if constexpr (std::is_trivially_copyable_v<T>)
+        return std::type_identity<T>();
+    else
+        return std::add_rvalue_reference<T>();
+};
+
+template<class T>
+using _param_t = std::invoke_result_t<decltype(_select_param_type<T>)>::type;
+
+template<class T, class Self>
+inline constexpr bool _is_not_self =
+    not std::is_same_v<std::remove_cvref_t<T>, Self>;
+
+template<class T, template<class> class>
+inline constexpr bool _looks_nullable_to_impl = std::is_member_pointer_v<T>;
+
+template<class F, template<class> class Self>
+inline constexpr bool _looks_nullable_to_impl<F *, Self> =
+    std::is_function_v<F>;
+
+template<class... S, template<class...> class Self>
+inline constexpr bool _looks_nullable_to_impl<Self<S...>, Self> = true;
+
+template<class S, template<class> class Self>
+inline constexpr bool _looks_nullable_to =
+    _looks_nullable_to_impl<std::remove_cvref_t<S>, Self>;
+
+template<class T> inline constexpr bool _is_not_nontype_t = true;
+template<auto f> inline constexpr bool _is_not_nontype_t<nontype_t<f>> = false;
+
+template<class T> struct _adapt_signature;
+
+template<class F> requires std::is_function_v<F>
+struct _adapt_signature<F *>
+{
+    using type = F;
+};
+
+template<class Fp> using _adapt_signature_t = _adapt_signature<Fp>::type;
+
+template<class S> struct _not_qualifying_this
+{};
+
+template<class R, class... Args> struct _not_qualifying_this<R(Args...)>
+{
+    using type = R(Args...);
+};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) noexcept>
+{
+    using type = R(Args...) noexcept;
+};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) const> : _not_qualifying_this<R(Args...)>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) volatile>
+    : _not_qualifying_this<R(Args...)>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) const volatile>
+    : _not_qualifying_this<R(Args...)>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) &> : _not_qualifying_this<R(Args...)>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) const &>
+    : _not_qualifying_this<R(Args...)>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) volatile &>
+    : _not_qualifying_this<R(Args...)>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) const volatile &>
+    : _not_qualifying_this<R(Args...)>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) &&> : _not_qualifying_this<R(Args...)>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) const &&>
+    : _not_qualifying_this<R(Args...)>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) volatile &&>
+    : _not_qualifying_this<R(Args...)>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) const volatile &&>
+    : _not_qualifying_this<R(Args...)>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) const noexcept>
+    : _not_qualifying_this<R(Args...) noexcept>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) volatile noexcept>
+    : _not_qualifying_this<R(Args...) noexcept>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) const volatile noexcept>
+    : _not_qualifying_this<R(Args...) noexcept>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) & noexcept>
+    : _not_qualifying_this<R(Args...) noexcept>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) const & noexcept>
+    : _not_qualifying_this<R(Args...) noexcept>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) volatile & noexcept>
+    : _not_qualifying_this<R(Args...) noexcept>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) const volatile & noexcept>
+    : _not_qualifying_this<R(Args...) noexcept>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) && noexcept>
+    : _not_qualifying_this<R(Args...) noexcept>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) const && noexcept>
+    : _not_qualifying_this<R(Args...) noexcept>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) volatile && noexcept>
+    : _not_qualifying_this<R(Args...) noexcept>
+{};
+
+template<class R, class... Args>
+struct _not_qualifying_this<R(Args...) const volatile && noexcept>
+    : _not_qualifying_this<R(Args...) noexcept>
+{};
+
+template<class F, class T> struct _drop_first_arg_to_invoke;
+
+template<class T, class R, class G, class... Args>
+struct _drop_first_arg_to_invoke<R (*)(G, Args...), T>
+{
+    using type = R(Args...);
+};
+
+template<class T, class R, class G, class... Args>
+struct _drop_first_arg_to_invoke<R (*)(G, Args...) noexcept, T>
+{
+    using type = R(Args...) noexcept;
+};
+
+template<class T, class M, class G> requires std::is_object_v<M>
+struct _drop_first_arg_to_invoke<M G::*, T>
+{
+    using type = std::invoke_result_t<M G::*, T>();
+};
+
+template<class T, class M, class G> requires std::is_function_v<M>
+struct _drop_first_arg_to_invoke<M G::*, T> : _not_qualifying_this<M>
+{};
+
+template<class F, class T>
+using _drop_first_arg_to_invoke_t = _drop_first_arg_to_invoke<F, T>::type;
+
+} // namespace std23
+
+#endif

--- a/third_party/nontype_functional/include/std23/function.h
+++ b/third_party/nontype_functional/include/std23/function.h
@@ -1,0 +1,395 @@
+#ifndef INCLUDE_STD23_FUNCTION
+#define INCLUDE_STD23_FUNCTION
+
+#include "__functional_base.h"
+
+#include <cstdarg>
+#include <memory>
+#include <new>
+
+namespace std23
+{
+
+template<class Sig> struct _opt_fn_sig;
+
+template<class R, class... Args> struct _opt_fn_sig<R(Args...)>
+{
+    using function_type = R(Args...);
+    static constexpr bool is_variadic = false;
+
+    template<class... T>
+    static constexpr bool is_invocable_using =
+        std::is_invocable_r_v<R, T..., Args...>;
+};
+
+template<class R, class... Args> struct _opt_fn_sig<R(Args......)>
+{
+    using function_type = R(Args...);
+    static constexpr bool is_variadic = true;
+
+    template<class... T>
+    static constexpr bool is_invocable_using =
+        std::is_invocable_r_v<R, T..., Args..., va_list>;
+};
+
+template<class R, class... Args> struct _copyable_function
+{
+    struct lvalue_callable
+    {
+        virtual R operator()(Args...) const = 0;
+        virtual constexpr ~lvalue_callable() = default;
+
+        void copy_into(std::byte *storage) const { copy_into_(storage); }
+        void move_into(std::byte *storage) noexcept { move_into_(storage); }
+
+      protected:
+        virtual void copy_into_(void *) const = 0;
+        virtual void move_into_(void *) noexcept = 0;
+    };
+
+    template<class Self> struct empty_object : lvalue_callable
+    {
+        void copy_into_(void *location) const override
+        {
+            ::new (location) Self;
+        }
+
+        void move_into_(void *location) noexcept override
+        {
+            ::new (location) Self;
+        }
+    };
+
+    struct constructible_lvalue : lvalue_callable
+    {
+        [[noreturn]] R operator()(Args...) const override
+        {
+#if defined(_MSC_VER)
+            __assume(0);
+#else
+            __builtin_unreachable();
+#endif
+        }
+    };
+
+    template<class T, class Self> class stored_object : constructible_lvalue
+    {
+        std::conditional_t<std::is_pointer_v<T>, T, std::unique_ptr<T>> p_;
+
+      public:
+        template<class F>
+        explicit stored_object(F &&f)
+            requires(_is_not_self<F, stored_object> and
+                     not std::is_pointer_v<T>)
+            : p_(std::make_unique<T>(std::forward<F>(f)))
+        {}
+
+        explicit stored_object(T p) noexcept requires std::is_pointer_v<T>
+        : p_(p)
+        {}
+
+      protected:
+        decltype(auto) get() const
+        {
+            if constexpr (std::is_pointer_v<T>)
+                return p_;
+            else
+                return *p_;
+        }
+
+        void copy_into_(void *location) const override
+        {
+            ::new (location) Self(get());
+        }
+
+        void move_into_(void *location) noexcept override
+        {
+            ::new (location) Self(std::move(*this));
+        }
+    };
+
+    template<class T, class Self>
+    class stored_object<T &, Self> : constructible_lvalue
+    {
+        T &target_;
+
+      public:
+        explicit stored_object(T &target) noexcept : target_(target) {}
+
+      protected:
+        decltype(auto) get() const { return target_; }
+
+        void copy_into_(void *location) const override
+        {
+            ::new (location) Self(*this);
+        }
+
+        void move_into_(void *location) noexcept override
+        {
+            ::new (location) Self(*this);
+        }
+    };
+
+    struct empty_target_object final : empty_object<empty_target_object>
+    {
+        [[noreturn]] R operator()(Args...) const override
+        {
+            throw std::bad_function_call{};
+        }
+    };
+
+    template<auto f>
+    struct unbound_target_object final : empty_object<unbound_target_object<f>>
+    {
+        R operator()(Args... args) const override
+        {
+            return std23::invoke_r<R>(f, static_cast<Args>(args)...);
+        }
+    };
+
+    template<class T>
+    class target_object final : stored_object<T, target_object<T>>
+    {
+        using base = stored_object<T, target_object<T>>;
+
+      public:
+        template<class F>
+        explicit target_object(F &&f) noexcept(
+            std::is_nothrow_constructible_v<base, F>)
+            requires _is_not_self<F, target_object>
+            : base(std::forward<F>(f))
+        {}
+
+        R operator()(Args... args) const override
+        {
+            return std23::invoke_r<R>(this->get(), static_cast<Args>(args)...);
+        }
+    };
+
+    template<auto f, class T>
+    class bound_target_object final
+        : stored_object<T, bound_target_object<f, T>>
+    {
+        using base = stored_object<T, bound_target_object<f, T>>;
+
+      public:
+        template<class U>
+        explicit bound_target_object(U &&obj) noexcept(
+            std::is_nothrow_constructible_v<base, U>)
+            requires _is_not_self<U, bound_target_object>
+            : base(std::forward<U>(obj))
+        {}
+
+        R operator()(Args... args) const override
+        {
+            return std23::invoke_r<R>(f, this->get(),
+                                      static_cast<Args>(args)...);
+        }
+    };
+};
+
+template<class S, class = typename _opt_fn_sig<S>::function_type>
+class function;
+
+template<class S, class R, class... Args> class function<S, R(Args...)>
+{
+    using signature = _opt_fn_sig<S>;
+
+    template<class... T>
+    static constexpr bool is_invocable_using =
+        signature::template is_invocable_using<T...>;
+
+    template<class T> using lvalue = std::decay_t<T> &;
+
+    using copyable_function =
+        std::conditional_t<signature::is_variadic,
+                           _copyable_function<R, _param_t<Args>..., va_list &>,
+                           _copyable_function<R, _param_t<Args>...>>;
+
+    using lvalue_callable = copyable_function::lvalue_callable;
+    using empty_target_object = copyable_function::empty_target_object;
+
+    struct typical_target_object : lvalue_callable
+    {
+        union
+        {
+            void (*fp)() = nullptr;
+            void *p;
+        };
+    };
+
+    template<class F>
+    using target_object_for =
+        copyable_function::template target_object<std::unwrap_ref_decay_t<F>>;
+
+    template<auto f>
+    using unbound_target_object =
+        copyable_function::template unbound_target_object<f>;
+
+    template<auto f, class T>
+    using bound_target_object_for =
+        copyable_function::template bound_target_object<
+            f, std::unwrap_ref_decay_t<T>>;
+
+    template<class F, class FD = std::decay_t<F>>
+    static bool constexpr is_viable_initializer =
+        std::is_copy_constructible_v<FD> and std::is_constructible_v<FD, F>;
+
+    alignas(typical_target_object)
+        std::byte storage_[sizeof(typical_target_object)];
+
+    auto storage_location() noexcept -> void * { return &storage_; }
+
+    auto target() noexcept
+    {
+        return std::launder(reinterpret_cast<lvalue_callable *>(&storage_));
+    }
+
+    auto target() const noexcept
+    {
+        return std::launder(
+            reinterpret_cast<lvalue_callable const *>(&storage_));
+    }
+
+  public:
+    using result_type = R;
+
+    function() noexcept { ::new (storage_location()) empty_target_object; }
+    function(nullptr_t) noexcept : function() {}
+
+    template<class F>
+    function(F &&f) noexcept(
+        std::is_nothrow_constructible_v<target_object_for<F>, F>)
+        requires _is_not_self<F, function> and is_invocable_using<lvalue<F>> and
+                 is_viable_initializer<F>
+    {
+        using T = target_object_for<F>;
+        static_assert(sizeof(T) <= sizeof(storage_));
+
+        if constexpr (_looks_nullable_to<F, function>)
+        {
+            if (f == nullptr)
+            {
+                std::construct_at(this);
+                return;
+            }
+        }
+
+        ::new (storage_location()) T(std::forward<F>(f));
+    }
+
+    template<auto f>
+    function(nontype_t<f>) noexcept requires is_invocable_using<decltype(f)>
+    {
+        ::new (storage_location()) unbound_target_object<f>;
+    }
+
+    template<auto f, class U>
+    function(nontype_t<f>, U &&obj) noexcept(
+        std::is_nothrow_constructible_v<bound_target_object_for<f, U>, U>)
+        requires is_invocable_using<decltype(f), lvalue<U>> and
+                 is_viable_initializer<U>
+    {
+        using T = bound_target_object_for<f, U>;
+        static_assert(sizeof(T) <= sizeof(storage_));
+
+        ::new (storage_location()) T(std::forward<U>(obj));
+    }
+
+    function(function const &other) { other.target()->copy_into(storage_); }
+    function(function &&other) noexcept { other.target()->move_into(storage_); }
+
+    function &operator=(function const &other)
+    {
+        if (&other != this)
+        {
+            auto tmp = other;
+            swap(tmp);
+        }
+
+        return *this;
+    }
+
+    function &operator=(function &&other) noexcept
+    {
+        if (&other != this)
+        {
+            std::destroy_at(this);
+            return *std::construct_at(this, std::move(other));
+        }
+        else
+            return *this;
+    }
+
+    void swap(function &other) noexcept { std::swap<function>(*this, other); }
+    friend void swap(function &lhs, function &rhs) noexcept { lhs.swap(rhs); }
+
+    ~function() { std::destroy_at(target()); }
+
+    explicit operator bool() const noexcept
+    {
+        constexpr empty_target_object null;
+        return __builtin_memcmp(storage_, &null, sizeof(void *)) != 0;
+    }
+
+    friend bool operator==(function const &f, nullptr_t) noexcept { return !f; }
+
+    R operator()(Args... args) const requires(!signature::is_variadic)
+    {
+        return (*target())(std::forward<Args>(args)...);
+    }
+
+#if defined(__GNUC__) && (!defined(__clang__) || defined(__INTELLISENSE__))
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-value"
+#endif
+
+    R operator()(Args... args...) const
+        requires(signature::is_variadic and sizeof...(Args) != 0)
+    {
+        struct raii
+        {
+            va_list data;
+            ~raii() { va_end(data); }
+        } va;
+        va_start(va.data, (args, ...));
+        return (*target())(std::forward<Args>(args)..., va.data);
+    }
+
+#if defined(__GNUC__) && (!defined(__clang__) || defined(__INTELLISENSE__))
+#pragma GCC diagnostic pop
+#endif
+};
+
+template<class S> struct _strip_noexcept;
+
+template<class R, class... Args> struct _strip_noexcept<R(Args...)>
+{
+    using type = R(Args...);
+};
+
+template<class R, class... Args> struct _strip_noexcept<R(Args...) noexcept>
+{
+    using type = R(Args...);
+};
+
+template<class S> using _strip_noexcept_t = _strip_noexcept<S>::type;
+
+template<class F> requires std::is_function_v<F>
+function(F *) -> function<_strip_noexcept_t<F>>;
+
+template<class T>
+function(T) -> function<_strip_noexcept_t<
+    _drop_first_arg_to_invoke_t<decltype(&T::operator()), void>>>;
+
+template<auto V>
+function(nontype_t<V>)
+    -> function<_strip_noexcept_t<_adapt_signature_t<decltype(V)>>>;
+
+template<auto V, class T>
+function(nontype_t<V>, T)
+    -> function<_strip_noexcept_t<_drop_first_arg_to_invoke_t<decltype(V), T>>>;
+
+} // namespace std23
+
+#endif

--- a/third_party/nontype_functional/include/std23/function_ref.h
+++ b/third_party/nontype_functional/include/std23/function_ref.h
@@ -1,0 +1,216 @@
+#ifndef INCLUDE_STD23_FUNCTION__REF
+#define INCLUDE_STD23_FUNCTION__REF
+
+#include "__functional_base.h"
+
+#include <cassert>
+
+namespace std23
+{
+
+template<class Sig> struct _qual_fn_sig;
+
+template<class R, class... Args> struct _qual_fn_sig<R(Args...)>
+{
+    using function = R(Args...);
+    static constexpr bool is_noexcept = false;
+
+    template<class... T>
+    static constexpr bool is_invocable_using =
+        std::is_invocable_r_v<R, T..., Args...>;
+
+    template<class T> using cv = T;
+};
+
+template<class R, class... Args> struct _qual_fn_sig<R(Args...) noexcept>
+{
+    using function = R(Args...);
+    static constexpr bool is_noexcept = true;
+
+    template<class... T>
+    static constexpr bool is_invocable_using =
+        std::is_nothrow_invocable_r_v<R, T..., Args...>;
+
+    template<class T> using cv = T;
+};
+
+template<class R, class... Args>
+struct _qual_fn_sig<R(Args...) const> : _qual_fn_sig<R(Args...)>
+{
+    template<class T> using cv = T const;
+};
+
+template<class R, class... Args>
+struct _qual_fn_sig<R(Args...) const noexcept>
+    : _qual_fn_sig<R(Args...) noexcept>
+{
+    template<class T> using cv = T const;
+};
+
+struct _function_ref_base
+{
+    union storage
+    {
+        void *p_ = nullptr;
+        void const *cp_;
+        void (*fp_)();
+
+        constexpr storage() noexcept = default;
+
+        template<class T> requires std::is_object_v<T>
+        constexpr explicit storage(T *p) noexcept : p_(p)
+        {}
+
+        template<class T> requires std::is_object_v<T>
+        constexpr explicit storage(T const *p) noexcept : cp_(p)
+        {}
+
+        template<class T> requires std::is_function_v<T>
+        constexpr explicit storage(T *p) noexcept
+            : fp_(reinterpret_cast<decltype(fp_)>(p))
+        {}
+    };
+
+    template<class T> constexpr static auto get(storage obj)
+    {
+        if constexpr (std::is_const_v<T>)
+            return static_cast<T *>(obj.cp_);
+        else if constexpr (std::is_object_v<T>)
+            return static_cast<T *>(obj.p_);
+        else
+            return reinterpret_cast<T *>(obj.fp_);
+    }
+};
+
+template<class Sig, class = typename _qual_fn_sig<Sig>::function>
+class function_ref; // freestanding
+
+template<class Sig, class R, class... Args>
+class function_ref<Sig, R(Args...)> // freestanding
+    : _function_ref_base
+{
+    using signature = _qual_fn_sig<Sig>;
+
+    template<class T> using cv = signature::template cv<T>;
+    template<class T> using cvref = cv<T> &;
+    static constexpr bool noex = signature::is_noexcept;
+
+    template<class... T>
+    static constexpr bool is_invocable_using =
+        signature::template is_invocable_using<T...>;
+
+    typedef R fwd_t(storage, _param_t<Args>...) noexcept(noex);
+    fwd_t *fptr_ = nullptr;
+    storage obj_;
+
+  public:
+    template<class F>
+    function_ref(F *f) noexcept
+        requires std::is_function_v<F> and is_invocable_using<F>
+        : fptr_(
+              [](storage fn_, _param_t<Args>... args) noexcept(noex) -> R
+              {
+                  if constexpr (std::is_void_v<R>)
+                      get<F>(fn_)(static_cast<decltype(args)>(args)...);
+                  else
+                      return get<F>(fn_)(static_cast<decltype(args)>(args)...);
+              }),
+          obj_(f)
+    {
+        assert(f != nullptr && "must reference a function");
+    }
+
+    template<class F, class T = std::remove_reference_t<F>>
+    constexpr function_ref(F &&f) noexcept
+        requires(_is_not_self<F, function_ref> and
+                 not std::is_member_pointer_v<T> and
+                 is_invocable_using<cvref<T>>)
+        : fptr_(
+              [](storage fn_, _param_t<Args>... args) noexcept(noex) -> R
+              {
+                  cvref<T> obj = *get<T>(fn_);
+                  if constexpr (std::is_void_v<R>)
+                      obj(static_cast<decltype(args)>(args)...);
+                  else
+                      return obj(static_cast<decltype(args)>(args)...);
+              }),
+          obj_(std::addressof(f))
+    {}
+
+    template<class T>
+    function_ref &operator=(T)
+        requires(_is_not_self<T, function_ref> and not std::is_pointer_v<T> and
+                 _is_not_nontype_t<T>)
+        = delete;
+
+    template<auto f>
+    constexpr function_ref(nontype_t<f>) noexcept
+        requires is_invocable_using<decltype(f)>
+        : fptr_(
+              [](storage, _param_t<Args>... args) noexcept(noex) -> R {
+                  return std23::invoke_r<R>(
+                      f, static_cast<decltype(args)>(args)...);
+              })
+    {
+        using F = decltype(f);
+        if constexpr (std::is_pointer_v<F> or std::is_member_pointer_v<F>)
+            static_assert(f != nullptr, "NTTP callable must be usable");
+    }
+
+    template<auto f, class U, class T = std::remove_reference_t<U>>
+    constexpr function_ref(nontype_t<f>, U &&obj) noexcept
+        requires(not std::is_rvalue_reference_v<U &&> and
+                 is_invocable_using<decltype(f), cvref<T>>)
+        : fptr_(
+              [](storage this_, _param_t<Args>... args) noexcept(noex) -> R
+              {
+                  cvref<T> obj = *get<T>(this_);
+                  return std23::invoke_r<R>(
+                      f, obj, static_cast<decltype(args)>(args)...);
+              }),
+          obj_(std::addressof(obj))
+    {
+        using F = decltype(f);
+        if constexpr (std::is_pointer_v<F> or std::is_member_pointer_v<F>)
+            static_assert(f != nullptr, "NTTP callable must be usable");
+    }
+
+    template<auto f, class T>
+    constexpr function_ref(nontype_t<f>, cv<T> *obj) noexcept
+        requires is_invocable_using<decltype(f), decltype(obj)>
+        : fptr_(
+              [](storage this_, _param_t<Args>... args) noexcept(noex) -> R
+              {
+                  return std23::invoke_r<R>(
+                      f, get<cv<T>>(this_),
+                      static_cast<decltype(args)>(args)...);
+              }),
+          obj_(obj)
+    {
+        using F = decltype(f);
+        if constexpr (std::is_pointer_v<F> or std::is_member_pointer_v<F>)
+            static_assert(f != nullptr, "NTTP callable must be usable");
+
+        if constexpr (std::is_member_pointer_v<F>)
+            assert(obj != nullptr && "must reference an object");
+    }
+
+    constexpr R operator()(Args... args) const noexcept(noex)
+    {
+        return fptr_(obj_, std::forward<Args>(args)...);
+    }
+};
+
+template<class F> requires std::is_function_v<F>
+function_ref(F *) -> function_ref<F>;
+
+template<auto V>
+function_ref(nontype_t<V>) -> function_ref<_adapt_signature_t<decltype(V)>>;
+
+template<auto V, class T>
+function_ref(nontype_t<V>, T &&)
+    -> function_ref<_drop_first_arg_to_invoke_t<decltype(V), T &>>;
+
+} // namespace std23
+
+#endif

--- a/third_party/nontype_functional/include/std23/function_ref.h
+++ b/third_party/nontype_functional/include/std23/function_ref.h
@@ -164,9 +164,9 @@ class function_ref<Sig, R(Args...)> // freestanding
         : fptr_(
               [](storage this_, _param_t<Args>... args) noexcept(noex) -> R
               {
-                  cvref<T> obj = *get<T>(this_);
+                  cvref<T> obj2 = *get<T>(this_);
                   return std23::invoke_r<R>(
-                      f, obj, static_cast<decltype(args)>(args)...);
+                      f, obj2, static_cast<decltype(args)>(args)...);
               }),
           obj_(std::addressof(obj))
     {

--- a/third_party/nontype_functional/include/std23/move_only_function.h
+++ b/third_party/nontype_functional/include/std23/move_only_function.h
@@ -1,0 +1,517 @@
+#ifndef INCLUDE_STD23_MOVE__ONLY__FUNCTION
+#define INCLUDE_STD23_MOVE__ONLY__FUNCTION
+
+#include "__functional_base.h"
+
+#include <memory>
+#include <new>
+#include <utility>
+
+namespace std23
+{
+
+template<class Sig> struct _cv_fn_sig
+{};
+
+template<class R, class... Args> struct _cv_fn_sig<R(Args...)>
+{
+    using function = R(Args...);
+    template<class T> using cv = T;
+};
+
+template<class R, class... Args> struct _cv_fn_sig<R(Args...) const>
+{
+    using function = R(Args...);
+    template<class T> using cv = T const;
+};
+
+template<class Sig> struct _ref_quals_fn_sig : _cv_fn_sig<Sig>
+{
+    template<class T> using ref = T;
+};
+
+template<class R, class... Args>
+struct _ref_quals_fn_sig<R(Args...) &> : _cv_fn_sig<R(Args...)>
+{
+    template<class T> using ref = T &;
+};
+
+template<class R, class... Args>
+struct _ref_quals_fn_sig<R(Args...) const &> : _cv_fn_sig<R(Args...) const>
+{
+    template<class T> using ref = T &;
+};
+
+template<class R, class... Args>
+struct _ref_quals_fn_sig<R(Args...) &&> : _cv_fn_sig<R(Args...)>
+{
+    template<class T> using ref = T &&;
+};
+
+template<class R, class... Args>
+struct _ref_quals_fn_sig<R(Args...) const &&> : _cv_fn_sig<R(Args...) const>
+{
+    template<class T> using ref = T &&;
+};
+
+template<bool V> struct _noex_traits
+{
+    static constexpr bool is_noexcept = V;
+};
+
+template<class Sig>
+struct _full_fn_sig : _ref_quals_fn_sig<Sig>, _noex_traits<false>
+{};
+
+template<class R, class... Args>
+struct _full_fn_sig<R(Args...) noexcept> : _ref_quals_fn_sig<R(Args...)>,
+                                           _noex_traits<true>
+{};
+
+template<class R, class... Args>
+struct _full_fn_sig<R(Args...) & noexcept> : _ref_quals_fn_sig<R(Args...) &>,
+                                             _noex_traits<true>
+{};
+
+template<class R, class... Args>
+struct _full_fn_sig<R(Args...) && noexcept> : _ref_quals_fn_sig<R(Args...) &&>,
+                                              _noex_traits<true>
+{};
+
+template<class R, class... Args>
+struct _full_fn_sig<R(Args...) const noexcept>
+    : _ref_quals_fn_sig<R(Args...) const>, _noex_traits<true>
+{};
+
+template<class R, class... Args>
+struct _full_fn_sig<R(Args...) const & noexcept>
+    : _ref_quals_fn_sig<R(Args...) const &>, _noex_traits<true>
+{};
+
+template<class R, class... Args>
+struct _full_fn_sig<R(Args...) const && noexcept>
+    : _ref_quals_fn_sig<R(Args...) const &&>, _noex_traits<true>
+{};
+
+constexpr inline struct
+{
+    constexpr auto operator()(auto &&rhs) const
+    {
+        return new auto(decltype(rhs)(rhs));
+    }
+
+    constexpr auto operator()(auto *rhs) const noexcept { return rhs; }
+
+    template<class T>
+    constexpr auto operator()(std::reference_wrapper<T> rhs) const noexcept
+    {
+        return std::addressof(rhs.get());
+    }
+
+} _take_reference;
+
+template<class T>
+constexpr auto _build_reference = [](auto &&...args)
+{ return new T(decltype(args)(args)...); };
+
+template<class T>
+constexpr auto _build_reference<T *> = [](auto &&...args) noexcept -> T *
+{ return {decltype(args)(args)...}; };
+
+template<class T>
+constexpr auto _build_reference<std::reference_wrapper<T>> =
+    [](auto &rhs) noexcept { return std::addressof(rhs); };
+
+struct _move_only_pointer
+{
+    union value_type
+    {
+        void *p_ = nullptr;
+        void const *cp_;
+        void (*fp_)();
+    } val;
+
+    _move_only_pointer() = default;
+    _move_only_pointer(_move_only_pointer const &) = delete;
+    _move_only_pointer &operator=(_move_only_pointer const &) = delete;
+
+    constexpr _move_only_pointer(_move_only_pointer &&other) noexcept
+        : val(std::exchange(other.val, {}))
+    {}
+
+    template<class T> requires std::is_object_v<T>
+    constexpr explicit _move_only_pointer(T *p) noexcept : val{.p_ = p}
+    {}
+
+    template<class T> requires std::is_object_v<T>
+    constexpr explicit _move_only_pointer(T const *p) noexcept : val{.cp_ = p}
+    {}
+
+    template<class T> requires std::is_function_v<T>
+    constexpr explicit _move_only_pointer(T *p) noexcept
+        : val{.fp_ = reinterpret_cast<decltype(val.fp_)>(p)}
+    {}
+
+    template<class T> requires std::is_object_v<T>
+    constexpr _move_only_pointer &operator=(T *p) noexcept
+    {
+        val.p_ = p;
+        return *this;
+    }
+
+    template<class T> requires std::is_object_v<T>
+    constexpr _move_only_pointer &operator=(T const *p) noexcept
+    {
+        val.cp_ = p;
+        return *this;
+    }
+
+    template<class T> requires std::is_function_v<T>
+    constexpr _move_only_pointer &operator=(T *p) noexcept
+    {
+        val.fp_ = reinterpret_cast<decltype(val.fp_)>(p);
+        return *this;
+    }
+
+    constexpr _move_only_pointer &operator=(_move_only_pointer &&other) noexcept
+    {
+        val = std::exchange(other.val, {});
+        return *this;
+    }
+};
+
+template<bool noex, class R, class... Args> struct _callable_trait
+{
+    using handle = _move_only_pointer::value_type;
+
+    typedef auto call_t(handle, Args...) noexcept(noex) -> R;
+    typedef void destroy_t(handle) noexcept;
+
+    struct vtable
+    {
+        call_t *call = 0;
+        destroy_t *destroy = [](handle) noexcept {};
+    };
+
+    static inline constinit vtable const abstract_base;
+
+    template<class T> constexpr static auto get(handle val)
+    {
+        if constexpr (std::is_const_v<T>)
+            return static_cast<T *>(val.cp_);
+        else if constexpr (std::is_object_v<T>)
+            return static_cast<T *>(val.p_);
+        else
+            return reinterpret_cast<T *>(val.fp_);
+    }
+
+    // See also: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71954
+    template<class T, template<class> class quals>
+    static inline constinit vtable const callable_target{
+        .call = [](handle this_, Args... args) noexcept(noex) -> R
+        {
+            if constexpr (std::is_lvalue_reference_v<T> or std::is_pointer_v<T>)
+            {
+                using Tp = std::remove_reference_t<std::remove_pointer_t<T>>;
+                return std23::invoke_r<R>(*get<Tp>(this_),
+                                          static_cast<Args>(args)...);
+            }
+            else
+            {
+                using Fp = quals<T>::type;
+                return std23::invoke_r<R>(static_cast<Fp>(*get<T>(this_)),
+                                          static_cast<Args>(args)...);
+            }
+        },
+        .destroy =
+            [](handle this_) noexcept
+        {
+            if constexpr (not std::is_lvalue_reference_v<T> and
+                          not std::is_pointer_v<T>)
+                delete get<T>(this_);
+        },
+    };
+
+    template<auto f>
+    static inline constinit vtable const unbound_callable_target{
+        .call = [](handle, Args... args) noexcept(noex) -> R
+        { return std23::invoke_r<R>(f, static_cast<Args>(args)...); },
+    };
+
+    template<auto f, class T, template<class> class quals>
+    static inline constinit vtable const bound_callable_target{
+        .call = [](handle this_, Args... args) noexcept(noex) -> R
+        {
+            if constexpr (std::is_pointer_v<T>)
+            {
+                using Tp = std::remove_pointer_t<T>;
+                return std23::invoke_r<R>(f, get<Tp>(this_),
+                                          static_cast<Args>(args)...);
+            }
+            else if constexpr (std::is_lvalue_reference_v<T>)
+            {
+                using Tp = std::remove_reference_t<T>;
+                return std23::invoke_r<R>(f, *get<Tp>(this_),
+                                          static_cast<Args>(args)...);
+            }
+            else
+            {
+                using Fp = quals<T>::type;
+                return std23::invoke_r<R>(f, static_cast<Fp>(*get<T>(this_)),
+                                          static_cast<Args>(args)...);
+            }
+        },
+        .destroy =
+            [](handle this_) noexcept
+        {
+            if constexpr (not std::is_lvalue_reference_v<T> and
+                          not std::is_pointer_v<T>)
+                delete get<T>(this_);
+        },
+    };
+
+    template<auto f, class T>
+    static inline constinit vtable const boxed_callable_target{
+        .call = [](handle this_, Args... args) noexcept(noex) -> R {
+            return std23::invoke_r<R>(f, get<T>(this_),
+                                      static_cast<Args>(args)...);
+        },
+        .destroy =
+            [](handle this_) noexcept
+        {
+            using D = std::unique_ptr<T>::deleter_type;
+            static_assert(std::is_trivially_default_constructible_v<D>);
+            if (auto p = get<T>(this_))
+                D()(p);
+        },
+    };
+};
+
+template<class T, template<class...> class Primary>
+inline constexpr bool _is_specialization_of = false;
+
+template<template<class...> class Primary, class... Args>
+inline constexpr bool _is_specialization_of<Primary<Args...>, Primary> = true;
+
+template<class T, template<class...> class Primary>
+inline constexpr bool _does_not_specialize =
+    not _is_specialization_of<std::remove_cvref_t<T>, Primary>;
+
+template<class S, class = typename _full_fn_sig<S>::function>
+class move_only_function;
+
+template<class S, class R, class... Args>
+class move_only_function<S, R(Args...)>
+{
+    using signature = _full_fn_sig<S>;
+
+    template<class T> using cv = signature::template cv<T>;
+    template<class T> using ref = signature::template ref<T>;
+
+    static constexpr bool noex = signature::is_noexcept;
+    static constexpr bool is_const = std::is_same_v<cv<void>, void const>;
+    static constexpr bool is_lvalue_only = std::is_same_v<ref<int>, int &>;
+    static constexpr bool is_rvalue_only = std::is_same_v<ref<int>, int &&>;
+
+    template<class T> using cvref = ref<cv<T>>;
+    template<class T>
+    struct inv_quals_f
+        : std::conditional<is_lvalue_only or is_rvalue_only, cvref<T>, cv<T> &>
+    {};
+    template<class T> using inv_quals = inv_quals_f<T>::type;
+
+    template<class... T>
+    static constexpr bool is_invocable_using =
+        std::conditional_t<noex, std::is_nothrow_invocable_r<R, T..., Args...>,
+                           std::is_invocable_r<R, T..., Args...>>::value;
+
+    template<class VT>
+    static constexpr bool is_callable_from =
+        is_invocable_using<cvref<VT>> and is_invocable_using<inv_quals<VT>>;
+
+    template<auto f, class VT>
+    static constexpr bool is_callable_as_if_from =
+        is_invocable_using<decltype(f), inv_quals<VT>>;
+
+    using trait = _callable_trait<noex, R, _param_t<Args>...>;
+    using vtable = trait::vtable;
+
+    std::reference_wrapper<vtable const> vtbl_ = trait::abstract_base;
+    _move_only_pointer obj_;
+
+  public:
+    using result_type = R;
+
+    move_only_function() = default;
+    move_only_function(nullptr_t) noexcept : move_only_function() {}
+
+    template<class F, class VT = std::decay_t<F>>
+    move_only_function(F &&f) noexcept(
+        std::is_nothrow_invocable_v<decltype(_take_reference), F>)
+        requires _is_not_self<F, move_only_function> and
+                 _does_not_specialize<F, in_place_type_t> and
+                 is_callable_from<VT> and std::is_constructible_v<VT, F>
+    {
+        if constexpr (_looks_nullable_to<F, move_only_function>)
+        {
+            if (f == nullptr)
+                return;
+        }
+
+        vtbl_ = trait::template callable_target<std::unwrap_ref_decay_t<F>,
+                                                inv_quals_f>;
+        obj_ = _take_reference(std::forward<F>(f));
+    }
+
+    template<auto f>
+    move_only_function(nontype_t<f>) noexcept
+        requires is_invocable_using<decltype(f)>
+        : vtbl_(trait::template unbound_callable_target<f>)
+    {}
+
+    template<auto f, class T, class VT = std::decay_t<T>>
+    move_only_function(nontype_t<f>, T &&x) noexcept(
+        std::is_nothrow_invocable_v<decltype(_take_reference), T>)
+        requires is_callable_as_if_from<f, VT> and
+                     std::is_constructible_v<VT, T>
+        : vtbl_(trait::template bound_callable_target<
+                f, std::unwrap_ref_decay_t<T>, inv_quals_f>),
+          obj_(_take_reference(std::forward<T>(x)))
+    {}
+
+    template<class M, class C, M C::*f, class T>
+    move_only_function(nontype_t<f>, std::unique_ptr<T> &&x) noexcept
+        requires std::is_base_of_v<C, T> and is_callable_as_if_from<f, T *>
+        : vtbl_(trait::template boxed_callable_target<f, T>), obj_(x.release())
+    {}
+
+    template<class T, class... Inits>
+    explicit move_only_function(in_place_type_t<T>, Inits &&...inits) noexcept(
+        std::is_nothrow_invocable_v<decltype(_build_reference<T>), Inits...>)
+        requires is_callable_from<T> and std::is_constructible_v<T, Inits...>
+        : vtbl_(trait::template callable_target<std::unwrap_reference_t<T>,
+                                                inv_quals_f>),
+          obj_(_build_reference<T>(std::forward<Inits>(inits)...))
+    {
+        static_assert(std::is_same_v<std::decay_t<T>, T>);
+    }
+
+    template<class T, class U, class... Inits>
+    explicit move_only_function(in_place_type_t<T>, initializer_list<U> ilist,
+                                Inits &&...inits) noexcept( //
+        std::is_nothrow_invocable_v<decltype(_build_reference<T>),
+                                    decltype((ilist)), Inits...>)
+        requires is_callable_from<T> and
+                     std::is_constructible_v<T, decltype((ilist)), Inits...>
+        : vtbl_(trait::template callable_target<std::unwrap_reference_t<T>,
+                                                inv_quals_f>),
+          obj_(_build_reference<T>(ilist, std::forward<Inits>(inits)...))
+    {
+        static_assert(std::is_same_v<std::decay_t<T>, T>);
+    }
+
+    template<auto f, class T, class... Inits>
+    explicit move_only_function(nontype_t<f>, in_place_type_t<T>,
+                                Inits &&...inits) noexcept( //
+        std::is_nothrow_invocable_v<decltype(_build_reference<T>), Inits...>)
+        requires is_callable_as_if_from<f, T> and
+                     std::is_constructible_v<T, Inits...>
+        : vtbl_(trait::template bound_callable_target<
+                f, std::unwrap_reference_t<T>, inv_quals_f>),
+          obj_(_build_reference<T>(std::forward<Inits>(inits)...))
+    {
+        static_assert(std::is_same_v<std::decay_t<T>, T>);
+    }
+
+    template<class M, class C, M C::*f, class T, class... Inits>
+    explicit move_only_function(nontype_t<f> t,
+                                in_place_type_t<std::unique_ptr<T>>,
+                                Inits &&...inits) noexcept( //
+        std::is_nothrow_constructible_v<std::unique_ptr<T>, Inits...>)
+        requires std::is_base_of_v<C, T> and is_callable_as_if_from<f, T *> and
+                 std::is_constructible_v<std::unique_ptr<T>,
+                                         Inits...>
+        : move_only_function(t,
+                             std::unique_ptr<T>(std::forward<Inits>(inits)...))
+    {}
+
+    template<auto f, class T, class U, class... Inits>
+    explicit move_only_function(nontype_t<f>, in_place_type_t<T>,
+                                initializer_list<U> ilist,
+                                Inits &&...inits) noexcept( //
+        std::is_nothrow_invocable_v<decltype(_build_reference<T>),
+                                    decltype((ilist)), Inits...>)
+        requires is_callable_as_if_from<f, T> and
+                     std::is_constructible_v<T, decltype((ilist)), Inits...>
+        : vtbl_(trait::template bound_callable_target<
+                f, std::unwrap_reference_t<T>, inv_quals_f>),
+          obj_(_build_reference<T>(ilist, std::forward<Inits>(inits)...))
+    {
+        static_assert(std::is_same_v<std::decay_t<T>, T>);
+    }
+
+    move_only_function(move_only_function &&) = default;
+    move_only_function &operator=(move_only_function &&) = default;
+
+    void swap(move_only_function &other) noexcept
+    {
+        std::swap<move_only_function>(*this, other);
+    }
+
+    friend void swap(move_only_function &lhs, move_only_function &rhs) noexcept
+    {
+        lhs.swap(rhs);
+    }
+
+    ~move_only_function() { vtbl_.get().destroy(obj_.val); }
+
+    explicit operator bool() const noexcept
+    {
+        return &vtbl_.get() != &trait::abstract_base;
+    }
+
+    friend bool operator==(move_only_function const &f, nullptr_t) noexcept
+    {
+        return !f;
+    }
+
+    R operator()(Args... args) noexcept(noex)
+        requires(!is_const and !is_lvalue_only and !is_rvalue_only)
+    {
+        return vtbl_.get().call(obj_.val, std::forward<Args>(args)...);
+    }
+
+    R operator()(Args... args) const noexcept(noex)
+        requires(is_const and !is_lvalue_only and !is_rvalue_only)
+    {
+        return vtbl_.get().call(obj_.val, std::forward<Args>(args)...);
+    }
+
+    R operator()(Args... args) &noexcept(noex)
+        requires(!is_const and is_lvalue_only and !is_rvalue_only)
+    {
+        return vtbl_.get().call(obj_.val, std::forward<Args>(args)...);
+    }
+
+    R operator()(Args... args) const &noexcept(noex)
+        requires(is_const and is_lvalue_only and !is_rvalue_only)
+    {
+        return vtbl_.get().call(obj_.val, std::forward<Args>(args)...);
+    }
+
+    R operator()(Args... args) &&noexcept(noex)
+        requires(!is_const and !is_lvalue_only and is_rvalue_only)
+    {
+        return vtbl_.get().call(obj_.val, std::forward<Args>(args)...);
+    }
+
+    R operator()(Args... args) const &&noexcept(noex)
+        requires(is_const and !is_lvalue_only and is_rvalue_only)
+    {
+        return vtbl_.get().call(obj_.val, std::forward<Args>(args)...);
+    }
+};
+
+} // namespace std23
+
+#endif


### PR DESCRIPTION
# Based on PR #336

Add https://github.com/zhihaoy/nontype_functional as third party, this provides a [function_ref](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0792r10.html) implementation (non-owning cheap alternative to `std::function`).

