### PR TITLE
Reduce size of allocation events

### DIFF
--- a/include/lib/allocation_event.hpp
+++ b/include/lib/allocation_event.hpp
@@ -26,8 +26,8 @@ struct AllocationEvent {
 // An extra field is added after the end to communicate the dyn_size
 //  uint64_t dyn_size_stack;
 
-inline size_t sizeof_allocation_event(uint32_t stack_sample_user) {
-  // (Size of the event) + + sizeof(dyn_size field)
-  return sizeof(AllocationEvent) + stack_sample_user + sizeof(uint64_t);
+inline size_t sizeof_allocation_event(uint32_t stack_size) {
+  // (Size of the event) + stack_size + sizeof(dyn_size field)
+  return sizeof(AllocationEvent) + stack_size + sizeof(uint64_t);
 }
 } // namespace ddprof

--- a/src/lib/savecontext.cc
+++ b/src/lib/savecontext.cc
@@ -48,7 +48,7 @@ save_stack(std::span<const std::byte> stack_bounds, const std::byte *stack_ptr,
       stack_ptr >= to_address(stack_bounds.end())) {
     return 0;
   }
-  // take the min of current stack size and requested stack sample size~
+  // take the min of current stack size and requested stack sample size
   int64_t const saved_stack_size =
       std::min(static_cast<intptr_t>(buffer.size()),
                to_address(stack_bounds.end()) - stack_ptr);
@@ -56,12 +56,13 @@ save_stack(std::span<const std::byte> stack_bounds, const std::byte *stack_ptr,
   if (saved_stack_size <= 0) {
     return 0;
   }
-  // Use memmove to stay on the safe side on case caller put `buffer` on the
+  // Use memmove to stay on the safe side in case caller has put `buffer` on the
   // stack
   memmove(buffer.data(), stack_ptr, saved_stack_size);
   return saved_stack_size;
 }
 } // namespace
+
 size_t save_context(std::span<const std::byte> stack_bounds,
                     std::span<uint64_t, k_perf_register_count> regs,
                     std::span<std::byte> buffer) {

--- a/test/allocation_tracker-ut.cc
+++ b/test/allocation_tracker-ut.cc
@@ -4,6 +4,7 @@
 // Datadog, Inc.
 #include "allocation_tracker.hpp"
 
+#include "allocation_event.hpp"
 #include "ddprof_perf_event.hpp"
 #include "defer.hpp"
 #include "ipc.hpp"
@@ -118,6 +119,9 @@ TEST(allocation_tracker, start_stop) {
     ASSERT_EQ(sample->addr, 0xdeadbeef);
     ASSERT_GE(sample->time, before.time_since_epoch().count());
     ASSERT_LE(sample->time, after.time_since_epoch().count());
+
+    // check that the stack was not truncated due to a too small kStackMargin
+    ASSERT_LT(sample->dyn_size_stack, hdr->size - sizeof_allocation_event(0));
 
     UnwindState state;
     unwind_init_sample(&state, sample->regs, sample->pid, sample->size_stack,


### PR DESCRIPTION
# What does this PR do?

Instead of using fixed sized allocation events, estimate the required stack size (with some margin) before calling reserve on ring buffer.
