### PR TITLE
Tracepoints - add a check for debug fs using pid 1

### DIFF
--- a/src/exporter/ddprof_exporter.cc
+++ b/src/exporter/ddprof_exporter.cc
@@ -52,7 +52,7 @@ DDRes create_pprof_file(ddog_Timespec start, const char *dbg_pprof_prefix,
   strftime(time_start, std::size(time_start), "%Y%m%dT%H%M%SZ", tm_start);
 
   char filename[PATH_MAX];
-  snprintf(filename, std::size(filename), "%s%s.pprof", dbg_pprof_prefix,
+  snprintf(filename, std::size(filename), "%s%s.pprof.lz4", dbg_pprof_prefix,
            time_start);
   LG_NTC("[EXPORTER] Writing pprof to file %s", filename);
   constexpr int read_write_user_only = 0600;

--- a/src/tracepoint_config.cc
+++ b/src/tracepoint_config.cc
@@ -23,6 +23,8 @@ int64_t tracepoint_get_id(std::string_view global_name,
     fs_path = "/sys/kernel/tracing/events";
   } else if (stat("/sys/kernel/debug/tracing/events", &sb) == 0) {
     fs_path = "/sys/kernel/debug/tracing/events";
+  } else if (stat("/proc/1/root/sys/kernel/debug/tracing/events", &sb) == 0) {
+    fs_path = "/proc/1/root/sys/kernel/debug/tracing/events";
   } else {
     return -1; // Neither debugfs nor tracefs is available.
   }


### PR DESCRIPTION

# What does this PR do?

- Tracepoints - add a check for debug fs using pid 1
- Minor fix on pprof naming - Add lz4 suffix

# Motivation

When using tracepoints on full host, this allows us to find the tracepoint IDs.
When capturing pprofs, the lack of extension was misleading.

# Additional Notes

N.A.

# How to test the change?

TBD