### PR TITLE
Make allocation profiling work after exec

### DIFF
--- a/docs/Design.md
+++ b/docs/Design.md
@@ -8,3 +8,51 @@ Overview of the `ddprof` architecture
 `ddprof` runs in a separate process and processes events through shared ring buffers.
 
 ![wrapper_architecture.png](wrapper_architecture.png)
+
+## IPC communication
+
+Library communicates with profiler through a unix socket.
+Socket creation is the responsibility of the profiler.
+By default ddprof creates an random abstract socket, that does not exist on
+the filesystem: "\0/tmp/ddprof-<pid>-<random_string>.sock" but unix socket
+path can be overridden with profiler --socket input option.
+Profiler worker process accepts and handles connections on this socket in a
+separate thread and sends ring buffer information upon request.
+
+Overview of the communication process (wrapper mode):
+ * Profiler starts, set `DD_PROFILING_NATIVE_LIB_SOCKET` env variable with
+   socket path and daemonizes.
+ * Target process starts and blocks on intermediate process termination
+ * Profiler creates socket and listen on it, and then unblock target
+   process by killing intermediate process.
+ * Profiler forks into worker process and worker process starts accepting
+   connections.
+ * Library get socket path from `DD_PROFILING_NATIVE_LIB_SOCKET`, connects
+   to it, retrieve ring buffer information and closes connection.
+ * Exec'd processes from target process inherit
+ `DD_PROFILING_NATIVE_LIB_SOCKET`
+   env variable and connect to profiler in the same manner.
+Overview of the communication process (library mode):
+ * Library starts, checks if `DD_PROFILING_NATIVE_LIB_SOCKET` is set.
+ * If `DD_PROFILING_NATIVE_LIB_SOCKET` is set:
+   * Library connects to socket, retrieve ring buffer information and
+     closes connection.
+ * Otherwise:
+   * Library daemonizes into the profiler.
+   * Profiler blocks on intermediate process termination.
+   * Library unblocks profiler by killing intermediate process.
+   * Library blocks on reading socket path from pipe created during
+    daemonization.
+   * Profiler starts, creates socket and listen on socket.
+   * Profiler creates socket, listen on it and then sends socket path to
+     library through pipe created during daemonization.
+     Pipe allows library to retrieve socket path from profiler and to
+     ensure that library tries to connect to socket after it has been
+     created by profiler.
+   * Library connects to socket, retrieve ring buffer information and
+     closes connection.
+   * Library sets environment variable `DD_PROFILING_NATIVE_LIB_SOCKET`
+     with socket path so that socket is used by future exec'd processes.
+   * Exec'd processes from target process inherit
+     `DD_PROFILING_NATIVE_LIB_SOCKET` env variable and connect to profiler
+     in the same manner as in wrapper mod

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -48,6 +48,10 @@ DDPROF_CONSTREXPR const char *k_profiler_lib_env_variable =
 DDPROF_CONSTREXPR const char *k_startup_wait_ms_env_variable =
     "DD_PROFILING_NATIVE_STARTUP_WAIT_MS";
 
+// Env variable to disable allocation profiling of of exec'd processes
+DDPROF_CONSTREXPR const char *k_allocation_profiling_follow_execs =
+    "DD_PROFILING_NATIVE_ALLOCATION_PROFILING_FOLLOW_EXECS";
+
 DDPROF_CONSTREXPR const char *k_libdd_profiling_name = "libdd_profiling.so";
 
 DDPROF_CONSTREXPR const char *k_libdd_profiling_embedded_name =

--- a/include/daemonize.hpp
+++ b/include/daemonize.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "unique_fd.hpp"
+
 #include <sys/types.h>
 
 namespace ddprof {
@@ -16,6 +18,8 @@ struct DaemonizeResult {
       temp_pid; // -1 on failure, 0 for initial process, > 0 for daemon process
   pid_t parent_pid; // pid of process initiating daemonize
   pid_t daemon_pid; // pid of daemon process
+  UniqueFd
+      pipe_fd; // pipe to communicate from daemon process to initial process
 };
 
 // Daemonization function

--- a/include/ddprof_cli.hpp
+++ b/include/ddprof_cli.hpp
@@ -67,7 +67,8 @@ public:
   bool show_samples{false};
   bool fault_info{true};
   bool help_extended{false};
-  int socket{-1};
+  std::string socket_path;
+  int pipefd_to_library{-1};
   bool continue_exec{false};
   bool timeline{false};
 

--- a/include/ddprof_cmdline.hpp
+++ b/include/ddprof_cmdline.hpp
@@ -5,26 +5,15 @@
 
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
+#include <span>
+#include <string_view>
 
 namespace ddprof {
 
-/**************************** Cmdline Helpers *********************************/
-// Helper functions for processing commandline arguments.
-//
-// Note that `arg_yesno(,1)` is not the same as `!arg(,0)` or vice-versa.  This
-// is mostly because a parameter whose default value is true needs to check
-// very specifically for disablement, but the failover is to retain enable
-//
-// That said, it might be better to be more correct and only accept input of
-// the specified form, returning error otherwise.
+/// Returns index to element that matches str (case insensitive), otherwise -1
+int arg_which(std::string_view str, std::span<const std::string_view> str_set);
 
-/// Returns index to element that compars to str, otherwise -1
-int arg_which(const char *str, char const *const *set, int sz_set);
-
-bool arg_inset(const char *str, char const *const *set, int sz_set);
-
-bool arg_yesno(const char *str, int mode);
+bool arg_yes(std::string_view str);
+bool arg_no(std::string_view str);
 
 } // namespace ddprof

--- a/include/ddprof_context.hpp
+++ b/include/ddprof_context.hpp
@@ -28,7 +28,8 @@ struct DDProfContext {
     pid_t pid{0}; // ! only use for perf attach (can be -1 in global mode)
     uint32_t worker_period{}; // exports between worker refreshes
     int dd_profiling_fd{-1};  // opened file descriptor to our internal lib
-    ddprof::UniqueFd sockfd;
+    std::string socket_path;
+    UniqueFd pipefd_to_library;
     bool show_samples{false};
     bool timeline{false};
     cpu_set_t cpu_affinity{};
@@ -39,6 +40,7 @@ struct DDProfContext {
     std::chrono::milliseconds loaded_libs_check_interval{0};
   } params;
 
+  ddprof::UniqueFd socket_fd;
   PerfClockSource perf_clock_source{PerfClockSource::kNoClock};
   std::vector<PerfWatcher> watchers;
   ExporterInput exp_input;

--- a/include/defer.hpp
+++ b/include/defer.hpp
@@ -22,6 +22,12 @@ template <class F> ddprof::scope_exit<F> make_defer(F &&f) {
   return ddprof::scope_exit<F>{std::forward<F>(f)};
 }
 
+// Allows to execute a deferred operation early (before scope end)
+template <typename F> void exec_defer(ddprof::scope_exit<F> &&scope_object) {
+  const ddprof::scope_exit<F> local{std::move(scope_object)};
+  (void)local;
+}
+
 #define DEFER_(LINE) zz_defer##LINE
 #define DEFER(LINE) DEFER_(LINE)
 #define defer                                                                  \

--- a/include/ipc.hpp
+++ b/include/ipc.hpp
@@ -80,13 +80,12 @@ struct RingBufferInfo {
 };
 
 struct ReplyMessage {
-  enum { kLiveCallgraph = 0 };
+  enum { kLiveSum = 0x1 };
   // reply with the request flags from the request
   uint32_t request = 0;
   // profiler pid
   int32_t pid = -1;
   int64_t allocation_profiling_rate = 0;
-  // RingBufferInfo is returned if request & kRingBuffer
   // cppcheck-suppress unusedStructMember
   RingBufferInfo ring_buffer;
   uint32_t initial_loaded_libs_check_delay_ms = 0;

--- a/include/prng.hpp
+++ b/include/prng.hpp
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#pragma once
+
+#include <cstdint>
+#include <random>
+#include <string>
+
+namespace ddprof {
+// The "xoshiro256** 1.0" generator.
+// C++ port by Arthur O'Dwyer (2021).
+// https://quuxplusone.github.io/blog/2021/11/23/xoshiro/ Based on the C version
+// by David Blackman and Sebastiano Vigna (2018),
+// https://prng.di.unimi.it/xoshiro256starstar.c
+
+// NOLINTBEGIN(readability-magic-numbers)
+class xoshiro256ss {
+  uint64_t s[4]{};
+
+  static constexpr uint64_t splitmix64(uint64_t &x) {
+    uint64_t z = (x += 0x9e3779b97f4a7c15UL);
+    z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9UL;
+    z = (z ^ (z >> 27)) * 0x94d049bb133111ebUL;
+    return z ^ (z >> 31);
+  }
+
+  static constexpr uint64_t rotl(uint64_t x, int k) {
+    return (x << k) | (x >> (64 - k));
+  }
+
+public:
+  constexpr explicit xoshiro256ss() : xoshiro256ss(0) {}
+
+  constexpr explicit xoshiro256ss(uint64_t seed) {
+    s[0] = splitmix64(seed);
+    s[1] = splitmix64(seed);
+    s[2] = splitmix64(seed);
+    s[3] = splitmix64(seed);
+  }
+
+  using result_type = uint64_t;
+  static constexpr uint64_t min() { return 0; }
+  static constexpr uint64_t max() { return static_cast<uint64_t>(-1); }
+
+  constexpr uint64_t operator()() {
+    const uint64_t result = rotl(s[1] * 5, 7) * 9;
+    const uint64_t t = s[1] << 17;
+    s[2] ^= s[0];
+    s[3] ^= s[1];
+    s[1] ^= s[2];
+    s[0] ^= s[3];
+    s[2] ^= t;
+    s[3] = rotl(s[3], 45);
+    return result;
+  }
+};
+// NOLINTEND(readability-magic-numbers)
+
+inline constexpr char charset[] = "0123456789"
+                                  "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                  "abcdefghijklmnopqrstuvwxyz";
+
+template <typename TRandomGenerator>
+std::string generate_random_string(TRandomGenerator &engine,
+                                   std::size_t length) {
+  // NOLINTNEXTLINE(misc-const-correctness)
+  std::uniform_int_distribution<std::size_t> distribution(0,
+                                                          sizeof(charset) - 2);
+  std::string result;
+  result.reserve(length);
+  for (std::size_t i = 0; i < length; ++i) {
+    result.push_back(charset[distribution(engine)]);
+  }
+  return result;
+}
+
+} // namespace ddprof

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -297,9 +297,13 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
       app.add_flag("--help_extended", help_extended, "Show extended options")
           ->group(""));
   extended_options.push_back(
-      app.add_option("--socket", socket,
-                     "Profiler's IPC socket, as a file descriptor")
+      app.add_option("--socket", socket_path, "Profiler socket path")
           ->envname("DD_PROFILING_NATIVE_SOCKET")
+          ->group(""));
+  extended_options.push_back(
+      app.add_option("--pipefd", pipefd_to_library,
+                     "Pipe file descriptor to communicate with library that "
+                     "spawned the profiler")
           ->group(""));
   extended_options.push_back(
       app.add_option("--stack_sample_size", default_stack_sample_size,

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -297,7 +297,9 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
       app.add_flag("--help_extended", help_extended, "Show extended options")
           ->group(""));
   extended_options.push_back(
-      app.add_option("--socket", socket_path, "Profiler socket path")
+      app.add_option(
+             "--socket", socket_path,
+             "Override the automatically created socket with a specific path")
           ->envname("DD_PROFILING_NATIVE_SOCKET")
           ->group(""));
   extended_options.push_back(

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -421,7 +421,13 @@ void DDProfCLI::print() const {
     PRINT_NFO("  - global: %s", global ? "true" : "false");
   }
   if (!command_line.empty()) {
-    PRINT_NFO("  - command line(wrapper mode): %s", command_line[0].c_str());
+    std::string command_line_str = "[" + command_line[0];
+    std::for_each(std::next(command_line.begin()), command_line.end(),
+                  [&command_line_str](const std::string &el) {
+                    command_line_str += ", " + el;
+                  });
+    command_line_str += "]";
+    PRINT_NFO("  - command line(wrapper mode): %s", command_line_str.c_str());
   }
   PRINT_NFO("  - upload_period: %lds",
             std::chrono::seconds{upload_period}.count());

--- a/src/lib/dd_profiling.cc
+++ b/src/lib/dd_profiling.cc
@@ -202,7 +202,7 @@ struct ProfilerAutoStart {
     bool autostart = false;
     const char *autostart_env =
         g_state.getenv(k_profiler_auto_start_env_variable);
-    if ((autostart_env && arg_yesno(autostart_env, 1)) || is_preloaded()) {
+    if ((autostart_env && arg_yes(autostart_env)) || is_preloaded()) {
       // if library is preloaded, autostart profiling since there is no way
       // otherwise to start profiling
       autostart = true;

--- a/src/lib/dd_profiling.cc
+++ b/src/lib/dd_profiling.cc
@@ -345,7 +345,7 @@ int ddprof_start_profiling_internal() {
         info.allocation_profiling_rate = -info.allocation_profiling_rate;
       }
 
-      if (info.allocation_flags & (1 << ReplyMessage::kLiveCallgraph)) {
+      if (info.allocation_flags & ReplyMessage::kLiveSum) {
         // tracking deallocations to allow a live view
         flags |= AllocationTracker::kTrackDeallocations;
       }

--- a/src/lib/dd_profiling.cc
+++ b/src/lib/dd_profiling.cc
@@ -292,53 +292,6 @@ int ddprof_start_profiling_internal() {
     return -1;
   }
 
-  // Library communicates with profiler through a unix socket.
-  // Socket creation is the responsibility of the profiler.
-  // By default ddprof creates an random abstract socket, that does not exist on
-  // the filesystem: "\0/tmp/ddprof-<pid>-<random_string>.sock" but unix socket
-  // path can be overridden with profiler --socket input option.
-  // Profiler worker process accepts and handles connections on this socket in a
-  // separate thread and sends ring buffer information upon request.
-  //
-  // Overview of the communication process (wrapper mode):
-  //  * Profiler starts, set `DD_PROFILING_NATIVE_LIB_SOCKET` env variable with
-  //    socket path and daemonizes.
-  //  * Target process starts and blocks on intermediate process termination
-  //  * Profiler creates socket and listen on it, and then unblock target
-  //    process by killing intermediate process.
-  //  * Profiler forks into worker process and worker process starts accepting
-  //    connections.
-  //  * Library get socket path from `DD_PROFILING_NATIVE_LIB_SOCKET`, connects
-  //    to it, retrieve ring buffer information and closes connection.
-  //  * Exec'd processes from target process inherit
-  //  DD_PROFILING_NATIVE_LIB_SOCKET
-  //    env variable and connect to profiler in the same manner.
-  //
-  // Overview of the communication process (library mode):
-  //  * Library starts, checks if `DD_PROFILING_NATIVE_LIB_SOCKET` is set.
-  //  * If `DD_PROFILING_NATIVE_LIB_SOCKET` is set:
-  //    * Library connects to socket, retrieve ring buffer information and
-  //      closes connection.
-  //  * Otherwise:
-  //    * Library daemonizes into the profiler.
-  //    * Profiler blocks on intermediate process termination.
-  //    * Library unblocks profiler by killing intermediate process.
-  //    * Library blocks on reading socket path from pipe created during
-  //     daemonization.
-  //    * Profiler starts, creates socket and listen on socket.
-  //    * Profiler creates socket, listen on it and then sends socket path to
-  //      library through pipe created during daemonization.
-  //      Pipe allows library to retrieve socket path from profiler and to
-  //      ensure that library tries to connect to socket after it has been
-  //      created by profiler.
-  //    * Library connects to socket, retrieve ring buffer information and
-  //      closes connection.
-  //    * Library sets environment variable `DD_PROFILING_NATIVE_LIB_SOCKET`
-  //      with socket path so that socket is used by future exec'd processes.
-  //    * Exec'd processes from target process inherit
-  //      `DD_PROFILING_NATIVE_LIB_SOCKET` env variable and connect to profiler
-  //      in the same manner as in wrapper mode.
-
   auto socket_path = get_ddprof_socket_path();
   pid_t const target_pid = getpid();
 

--- a/src/logger_setup.cc
+++ b/src/logger_setup.cc
@@ -9,15 +9,16 @@
 #include "logger.hpp"
 
 #include <array>
+#include <string_view>
 
 namespace ddprof {
 
 void setup_logger(const char *log_mode, const char *log_level) {
   // Process logging mode
-  char const *logpattern[] = {"stdout", "stderr", "syslog", "disabled"};
-  int const idx_log_mode = log_mode
-      ? arg_which(log_mode, logpattern, std::size(logpattern))
-      : 0; // default to stdout
+  const std::string_view logpattern[] = {"stdout", "stderr", "syslog",
+                                         "disabled"};
+  int const idx_log_mode =
+      log_mode ? arg_which(log_mode, logpattern) : 0; // default to stdout
   switch (idx_log_mode) {
   case 0:
     LOG_open(LOG_STDOUT, "");
@@ -37,9 +38,9 @@ void setup_logger(const char *log_mode, const char *log_level) {
   }
 
   // Process logging level
-  char const *loglpattern[] = {"debug", "informational", "notice", "warn",
-                               "error"};
-  switch (arg_which(log_level, loglpattern, std::size(loglpattern))) {
+  const std::string_view loglpattern[] = {"debug", "informational", "notice",
+                                          "warn", "error"};
+  switch (log_level ? arg_which(log_level, loglpattern) : -1) {
   case 0:
     LOG_setlevel(LL_DEBUG);
     break;

--- a/src/perf_mainloop.cc
+++ b/src/perf_mainloop.cc
@@ -142,7 +142,7 @@ ReplyMessage create_reply_message(const DDProfContext &ctx) {
 
       if (ctx.watchers[alloc_watcher_idx].aggregation_mode ==
           EventAggregationMode::kLiveSum) {
-        reply.allocation_flags |= (1 << ReplyMessage::kLiveCallgraph);
+        reply.allocation_flags |= ReplyMessage::kLiveSum;
       }
     }
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -374,6 +374,8 @@ add_benchmark(savecontext-bench savecontext-bench.cc ../src/lib/pthread_fixes.cc
 add_benchmark(timer-bench timer-bench.cc ../src/tsc_clock.cc ../src/perf.cc ../src/perf_clock.cc
               ../src/perf_ringbuffer.cc)
 
+add_benchmark(prng-bench prng-bench.cc)
+
 add_benchmark(
   backpopulate-bench
   backpopulate-bench.cc

--- a/test/ddprofcmdline-ut.cc
+++ b/test/ddprofcmdline-ut.cc
@@ -12,7 +12,7 @@
 
 namespace ddprof {
 namespace {
-char const *const sTestPaterns[] = {"cAn", "yUo", "eVen", "tYpe"};
+const std::string_view sTestPaterns[] = {"cAn", "yUo", "eVen", "tYpe"};
 
 bool watcher_from_str(const char *s, PerfWatcher *watcher) {
   std::vector<PerfWatcher> watchers;
@@ -27,36 +27,30 @@ bool watcher_from_str(const char *s, PerfWatcher *watcher) {
 } // namespace
 
 TEST(CmdLineTst, ArgWhich) {
-  ASSERT_EQ(arg_which("tYpe", sTestPaterns, 4), 3);
-  ASSERT_EQ(arg_which("type", sTestPaterns, 4), 3);
-  ASSERT_EQ(arg_which("typo", sTestPaterns, 4), -1);
-  ASSERT_FALSE(arg_inset("typo", sTestPaterns, 4));
-  ASSERT_TRUE(arg_inset("tYpe", sTestPaterns, 4));
+  ASSERT_EQ(arg_which("tYpe", sTestPaterns), 3);
+  ASSERT_EQ(arg_which("type", sTestPaterns), 3);
+  ASSERT_EQ(arg_which("typo", sTestPaterns), -1);
 }
 
 TEST(CmdLineTst, ArgYesNo) {
   const char *yesStr = "YeS";
   const char *noStr = "nO";
-  ASSERT_TRUE(arg_yesno(yesStr, 1));
-  ASSERT_FALSE(arg_yesno(noStr, 1));
-  ASSERT_TRUE(arg_yesno(noStr, 0));
-  ASSERT_FALSE(arg_yesno(yesStr, 0));
+  ASSERT_TRUE(arg_yes(yesStr));
+  ASSERT_FALSE(arg_yes(noStr));
+  ASSERT_TRUE(arg_no(noStr));
+  ASSERT_FALSE(arg_no(yesStr));
 }
 
 TEST(CmdLineTst, PartialFilled) {
-  const char *partialPaterns[] = {"cAn", "temp", "eVen", "tYpe"};
-  ASSERT_EQ(arg_which("temp", partialPaterns, 4), 1);
-  partialPaterns[1] = nullptr; // one of the strings is null
-  ASSERT_EQ(arg_which("typo", partialPaterns, 4),
+  std::string_view partialPaterns[] = {"cAn", "temp", "eVen", "tYpe"};
+  ASSERT_EQ(arg_which("temp", partialPaterns), 1);
+  partialPaterns[1] = {};
+  ASSERT_EQ(arg_which("typo", partialPaterns),
             -1); // Check that we can iterate safely over everything
-  ASSERT_TRUE(arg_inset("tYpe", partialPaterns, 4));
 }
 
 TEST(CmdLineTst, NullPatterns) {
-  char const *const *testPaterns =
-      nullptr; // the actual pointers are not const, only the value inside of
-               // the pointers
-  ASSERT_EQ(arg_which("typo", testPaterns, 4),
+  ASSERT_EQ(arg_which("typo", {}),
             -1); // Check that we can iterate safely over everything
 }
 

--- a/test/prng-bench.cc
+++ b/test/prng-bench.cc
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include <benchmark/benchmark.h>
+
+#include "prng.hpp"
+
+namespace ddprof {
+
+static void BM_xoshiro256ss(benchmark::State &state) {
+  xoshiro256ss rng;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(rng());
+  }
+}
+
+BENCHMARK(BM_xoshiro256ss);
+
+static void BM_minstd(benchmark::State &state) {
+  std::minstd_rand rng{std::random_device{}()};
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(rng());
+  }
+}
+
+BENCHMARK(BM_minstd);
+
+static void BM_mt19937(benchmark::State &state) {
+  std::mt19937 rng{std::random_device{}()};
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(rng());
+  }
+}
+
+BENCHMARK(BM_mt19937);
+} // namespace ddprof

--- a/test/simple_malloc.cc
+++ b/test/simple_malloc.cc
@@ -373,6 +373,7 @@ int main(int argc, char *argv[]) {
       for (auto &a : exec_args) {
         new_args.push_back(a.data());
       }
+      new_args.push_back(nullptr);
       execvp(new_args[0], new_args.data());
       perror("Exec failed: ");
       return 1;


### PR DESCRIPTION
# What does this PR do?

This PR add the ability to profile allocations even after a process has exec'd into a new binary image.

# How do this work ?

ddprof now keeps a unix socket open, unix socket path can be overridden with `--socket` input option.
Worker accepts connections on this socket in a separate thread and sends ring buffer information upon request.
When a new process is exec'd, library looks up `DD_PROFILING_NATIVE_LIB_SOCKET` env variable to get socket path and if it exists, connects to it otherwise it spawns a ddprof process, then uses a pipe to synchronize with ddprof start and get socket path, and then connects to it.
By default ddprof creates an abstract socket, that does not exist on the filesystem: `\0/tmp/ddprof-<pid>.sock`.
Exec following can be disabled by setting env variable `DD_PROFILING_NATIVE_ALLOCATION_PROFILING_FOLLOW_EXECS` to 0/off/no.


