### PR TITLE
Refactor symbol overrides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,8 @@ endif()
 
 # ---- Dependencies ----
 
+find_package(absl REQUIRED)
+
 # libdatadog_profiling
 include(Findlibdatadog)
 
@@ -267,7 +269,7 @@ target_link_libraries(
   PRIVATE
     "$<$<AND:$<C_COMPILER_ID:GNU>,$<CONFIG:SanitizedDebug>>:-Wl,-Bstatic;-lubsan;-lasan;-lstdc++;-Wl,-Bdynamic>"
 )
-target_link_libraries(dd_profiling-embedded PUBLIC dl pthread rt)
+target_link_libraries(dd_profiling-embedded PUBLIC dl pthread rt absl::base)
 
 set(LIBDD_PROFILING_EMBEDDED_OBJECT "${CMAKE_BINARY_DIR}/libdd_profiling-embedded.o")
 set(LIBDD_PROFILING_EMBEDDED_HASH_HEADER "${CMAKE_BINARY_DIR}/libdd_profiling-embedded_hash.h")
@@ -291,7 +293,7 @@ add_exe(
   ddprof ${DDPROF_GLOBAL_SRC}
   LIBRARIES ${DDPROF_LIBRARY_LIST}
   DEFINITIONS ${DDPROF_DEFINITION_LIST})
-target_link_libraries(ddprof PRIVATE libddprofiling_embedded_object CLI11)
+target_link_libraries(ddprof PRIVATE libddprofiling_embedded_object CLI11 absl::base)
 if(USE_LOADER)
   target_compile_definitions(ddprof PRIVATE "DDPROF_USE_LOADER")
   target_link_libraries(ddprof PRIVATE libdd_loader_object)
@@ -342,7 +344,7 @@ target_include_directories(dd_profiling-static PUBLIC ${CMAKE_SOURCE_DIR}/includ
 set_target_properties(dd_profiling-static
                       PROPERTIES PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/lib/dd_profiling.h")
 target_link_libraries(dd_profiling-static PRIVATE ddprof_exe_object)
-target_link_libraries(dd_profiling-static PUBLIC dl pthread rt)
+target_link_libraries(dd_profiling-static PUBLIC dl pthread rt absl::base)
 
 if(USE_LOADER)
   # When using a loader, libdd_profiling.so is a loader that embeds both libdd_profiling-embedded.so
@@ -373,7 +375,7 @@ else()
     PRIVATE
       "$<$<AND:$<C_COMPILER_ID:GNU>,$<CONFIG:SanitizedDebug>>:-Wl,-Bstatic;-lubsan;-lasan;-lstdc++;-Wl,-Bdynamic>"
   )
-  target_link_libraries(dd_profiling-shared PUBLIC dl pthread rt)
+  target_link_libraries(dd_profiling-shared PUBLIC dl pthread rt absl::base)
 endif()
 
 target_static_libcxx(dd_profiling-shared)

--- a/CppCheckSuppressions.txt
+++ b/CppCheckSuppressions.txt
@@ -7,3 +7,6 @@ missingIncludeSystem
 
 // Ignore Lex and Yacc defects
 *:*/event_parser/*
+
+// Abseil makes cppcheck choke because of missing defines
+*:*/_deps/absl-src/absl/base/policy_checks.h

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -6,3 +6,4 @@ libunwind,"https://github.com/libunwind/libunwind",MIT License
 llvm-demangle,"https://github.com/llvm/llvm-project",Apache-2.0,llvm-project
 dpdk/lib/eal,"https://github.com/DPDK/dpdk",BSD-3-Clause
 CLI11,"https://github.com/CLIUtils/CLI11",BSD-3-Clause
+abseil-cpp,"https://github.com/abseil/abseil-cpp",Apache-2.0,Google Inc.

--- a/cmake/Findabsl.cmake
+++ b/cmake/Findabsl.cmake
@@ -1,0 +1,16 @@
+find_package(absl CONFIG NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+
+if(absl_FOUND)
+  return()
+endif()
+
+include(FetchContent)
+FetchContent_Declare(
+  absl
+  GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
+  GIT_TAG 20230802.1)
+
+set(ABSL_PROPAGATE_CXX_STD
+    ON
+    CACHE INTERNAL "")
+FetchContent_MakeAvailable(absl)

--- a/include/functionref.hpp
+++ b/include/functionref.hpp
@@ -1,0 +1,236 @@
+// Copyright 2019 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// File: function_ref.hpp
+// -----------------------------------------------------------------------------
+//
+// This header file defines the `absl::FunctionRef` type for holding a
+// non-owning reference to an object of any invocable type. This function
+// reference is typically most useful as a type-erased argument type for
+// accepting function types that neither take ownership nor copy the type; using
+// the reference type in this case avoids a copy and an allocation. Best
+// practices of other non-owning reference-like objects (such as
+// `absl::string_view`) apply here.
+//
+//  An `absl::FunctionRef` is similar in usage to a `std::function` but has the
+//  following differences:
+//
+//  * It doesn't own the underlying object.
+//  * It doesn't have a null or empty state.
+//  * It never performs deep copies or allocations.
+//  * It's much faster and cheaper to construct.
+//  * It's trivially copyable and destructable.
+//
+// Generally, `absl::FunctionRef` should not be used as a return value, data
+// member, or to initialize a `std::function`. Such usages will often lead to
+// problematic lifetime issues. Once you convert something to an
+// `absl::FunctionRef` you cannot make a deep copy later.
+//
+// This class is suitable for use wherever a "const std::function<>&"
+// would be used without making a copy. ForEach functions and other versions of
+// the visitor pattern are a good example of when this class should be used.
+//
+// This class is trivial to copy and should be passed by value.
+
+// clang-format off
+#ifndef ABSL_FUNCTIONAL_FUNCTION_REF_H_
+#define ABSL_FUNCTIONAL_FUNCTION_REF_H_
+
+#include <cassert>
+#include <functional>
+#include <type_traits>
+
+#if __has_cpp_attribute(clang::lifetimebound)
+#define ABSL_ATTRIBUTE_LIFETIME_BOUND [[clang::lifetimebound]]
+#elif __has_attribute(lifetimebound)
+#define ABSL_ATTRIBUTE_LIFETIME_BOUND __attribute__((lifetimebound))
+#else
+#define ABSL_ATTRIBUTE_LIFETIME_BOUND
+#endif
+
+namespace absl {
+
+namespace functional_internal {
+
+// Like a void* that can handle function pointers as well. The standard does not
+// allow function pointers to round-trip through void*, but void(*)() is fine.
+//
+// Note: It's important that this class remains trivial and is the same size as
+// a pointer, since this allows the compiler to perform tail-call optimizations
+// when the underlying function is a callable object with a matching signature.
+union VoidPtr {
+  const void* obj;
+  void (*fun)();
+};
+
+// Chooses the best type for passing T as an argument.
+// Attempt to be close to SystemV AMD64 ABI. Objects with trivial copy ctor are
+// passed by value.
+template <typename T,
+          bool IsLValueReference = std::is_lvalue_reference<T>::value>
+struct PassByValue : std::false_type {};
+
+template <typename T>
+struct PassByValue<T, /*IsLValueReference=*/false>
+    : std::integral_constant<bool,
+                             std::is_trivially_copy_constructible<T>::value &&
+                                 std::is_trivially_copy_assignable<
+                                     typename std::remove_cv<T>::type>::value &&
+                                 std::is_trivially_destructible<T>::value &&
+                                 sizeof(T) <= 2 * sizeof(void*)> {};
+
+template <typename T>
+struct ForwardT : std::conditional<PassByValue<T>::value, T, T&&> {};
+
+// An Invoker takes a pointer to the type-erased invokable object, followed by
+// the arguments that the invokable object expects.
+//
+// Note: The order of arguments here is an optimization, since member functions
+// have an implicit "this" pointer as their first argument, putting VoidPtr
+// first allows the compiler to perform tail-call optimization in many cases.
+template <typename R, typename... Args>
+using Invoker = R (*)(VoidPtr, typename ForwardT<Args>::type...);
+
+//
+// InvokeObject and InvokeFunction provide static "Invoke" functions that can be
+// used as Invokers for objects or functions respectively.
+//
+// static_cast<R> handles the case the return type is void.
+template <typename Obj, typename R, typename... Args>
+R InvokeObject(VoidPtr ptr, typename ForwardT<Args>::type... args) {
+  auto o = static_cast<const Obj*>(ptr.obj);
+  return static_cast<R>(
+     std::invoke(*o, std::forward<Args>(args)...));
+}
+
+template <typename Fun, typename R, typename... Args>
+R InvokeFunction(VoidPtr ptr, typename ForwardT<Args>::type... args) {
+  auto f = reinterpret_cast<Fun>(ptr.fun);
+  return static_cast<R>(
+      std::invoke(f, std::forward<Args>(args)...));
+}
+
+template <typename Sig>
+void AssertNonNull(const std::function<Sig>& f) {
+  assert(f != nullptr);
+  (void)f;
+}
+
+template <typename F>
+void AssertNonNull(const F&) {}
+
+template <typename F, typename C>
+void AssertNonNull(F C::*f) {
+  assert(f != nullptr);
+  (void)f;
+}
+
+template <bool C>
+using EnableIf = typename ::std::enable_if<C, int>::type;
+
+}  // namespace functional_internal
+
+// FunctionRef
+//
+// Dummy class declaration to allow the partial specialization based on function
+// types below.
+template <typename T>
+class FunctionRef;
+
+// FunctionRef
+//
+// An `absl::FunctionRef` is a lightweight wrapper to any invocable object with
+// a compatible signature. Generally, an `absl::FunctionRef` should only be used
+// as an argument type and should be preferred as an argument over a const
+// reference to a `std::function`. `absl::FunctionRef` itself does not allocate,
+// although the wrapped invocable may.
+//
+// Example:
+//
+//   // The following function takes a function callback by const reference
+//   bool Visitor(const std::function<void(my_proto&,
+//                                         absl::string_view)>& callback);
+//
+//   // Assuming that the function is not stored or otherwise copied, it can be
+//   // replaced by an `absl::FunctionRef`:
+//   bool Visitor(absl::FunctionRef<void(my_proto&, absl::string_view)>
+//                  callback);
+//
+// Note: the assignment operator within an `absl::FunctionRef` is intentionally
+// deleted to prevent misuse; because the `absl::FunctionRef` does not own the
+// underlying type, assignment likely indicates misuse.
+template <typename R, typename... Args>
+class FunctionRef<R(Args...)> {
+ private:
+  // Used to disable constructors for objects that are not compatible with the
+  // signature of this FunctionRef.
+  template <typename F,
+            typename FR = std::invoke_result_t<F, Args&&...>>
+  using EnableIfCompatible =
+      typename std::enable_if<std::is_void<R>::value ||
+                              std::is_convertible<FR, R>::value>::type;
+
+ public:
+  // Constructs a FunctionRef from any invocable type.
+  template <typename F, typename = EnableIfCompatible<const F&>>
+  // NOLINTNEXTLINE(runtime/explicit)
+  FunctionRef(const F& f ABSL_ATTRIBUTE_LIFETIME_BOUND)
+      : invoker_(&absl::functional_internal::InvokeObject<F, R, Args...>) {
+    absl::functional_internal::AssertNonNull(f);
+    ptr_.obj = &f;
+  }
+
+  // Overload for function pointers. This eliminates a level of indirection that
+  // would happen if the above overload was used (it lets us store the pointer
+  // instead of a pointer to a pointer).
+  //
+  // This overload is also used for references to functions, since references to
+  // functions can decay to function pointers implicitly.
+  template <
+      typename F, typename = EnableIfCompatible<F*>,
+      absl::functional_internal::EnableIf<std::is_function<F>::value> = 0>
+  FunctionRef(F* f)  // NOLINT(runtime/explicit)
+      : invoker_(&absl::functional_internal::InvokeFunction<F*, R, Args...>) {
+    assert(f != nullptr);
+    ptr_.fun = reinterpret_cast<decltype(ptr_.fun)>(f);
+  }
+
+  // To help prevent subtle lifetime bugs, FunctionRef is not assignable.
+  // Typically, it should only be used as an argument type.
+  FunctionRef& operator=(const FunctionRef& rhs) = delete;
+  FunctionRef(const FunctionRef& rhs) = default;
+
+  // Call the underlying object.
+  R operator()(Args... args) const {
+    return invoker_(ptr_, std::forward<Args>(args)...);
+  }
+
+ private:
+  absl::functional_internal::VoidPtr ptr_;
+  absl::functional_internal::Invoker<R, Args...> invoker_;
+};
+
+// Allow const qualified function signatures. Since FunctionRef requires
+// constness anyway we can just make this a no-op.
+template <typename R, typename... Args>
+class FunctionRef<R(Args...) const> : public FunctionRef<R(Args...)> {
+ public:
+  using FunctionRef<R(Args...)>::FunctionRef;
+};
+
+}  // namespace absl
+
+#endif  // ABSL_FUNCTIONAL_FUNCTION_REF_H_
+// clang-format on

--- a/include/functionref.hpp
+++ b/include/functionref.hpp
@@ -45,6 +45,7 @@
 // This class is trivial to copy and should be passed by value.
 
 // clang-format off
+// NOLINTBEGIN
 #ifndef ABSL_FUNCTIONAL_FUNCTION_REF_H_
 #define ABSL_FUNCTIONAL_FUNCTION_REF_H_
 
@@ -233,4 +234,5 @@ class FunctionRef<R(Args...) const> : public FunctionRef<R(Args...)> {
 }  // namespace absl
 
 #endif  // ABSL_FUNCTIONAL_FUNCTION_REF_H_
+// NOLINTEND
 // clang-format on

--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -121,7 +121,9 @@ private:
                           TrackerThreadLocalState &tl_state);
 
   // If notify_needed is true, consumer should be notified
-  DDRes push_lost_sample(MPSCRingBufferWriter &writer, bool &notify_needed);
+  DDRes push_lost_sample(MPSCRingBufferWriter &writer,
+                         TrackerThreadLocalState &tl_state,
+                         bool &notify_needed);
 
   DDRes push_dealloc_sample(uintptr_t addr, TrackerThreadLocalState &tl_state);
 

--- a/include/lib/elfutils.hpp
+++ b/include/lib/elfutils.hpp
@@ -5,10 +5,17 @@
 
 #pragma once
 
+#include "absl/functional/function_ref.h"
+#include "map_utils.hpp"
+
 #include <link.h>
+#include <span>
+#include <string>
 #include <string_view>
 
 namespace ddprof {
+
+struct DynamicInfo;
 
 const ElfW(Sym) *
     gnu_hash_lookup(const char *strtab, const ElfW(Sym) * symtab,
@@ -20,15 +27,86 @@ const ElfW(Sym) *
 uint32_t elf_hash_symbol_count(const uint32_t *hashtab);
 uint32_t gnu_hash_symbol_count(const uint32_t *hashtab);
 
+struct LookupResult {
+  ElfW(Sym) symbol;
+  std::string object_name;
+};
+
 // Lookup first symbol matching `symbol_name` and different from
 // `not_this_symbol`
-ElfW(Sym)
-    lookup_symbol(std::string_view symbol_name, bool accept_null_sized_symbol,
-                  void *not_this_symbol = nullptr);
+LookupResult lookup_symbol(std::string_view symbol_name,
+                           bool accept_null_sized_symbol,
+                           uintptr_t not_this_symbol = 0);
 
-void override_symbol(std::string_view symbol_name, void *new_symbol,
-                     void *do_not_override_this_symbol = nullptr);
+void override_symbol(std::string_view symbol_name, uintptr_t new_symbol,
+                     uintptr_t do_not_override_this_symbol = 0);
 
 int count_loaded_libraries();
+
+enum class LibraryCallbackStatus {
+  Continue,
+  Stop,
+};
+
+using LibraryCallback =
+    absl::FunctionRef<LibraryCallbackStatus(const dl_phdr_info &)>;
+
+LibraryCallbackStatus iterate_over_loaded_libraries(LibraryCallback callback);
+
+class SymbolOverrides {
+public:
+  // register a symbol override
+  // symbol_name: name of the symbol to override
+  // new_symbol: new symbol value
+  // ref_symbol: pointer to the initial value of symbol to override (will be
+  //             updated if symbol value is null or match a null sized symbol)
+  // do_not_override_this_symbol: if symbol value is equal to this value, do not
+  //                              override it
+  bool register_override(std::string_view symbol_name, uintptr_t new_symbol,
+                         uintptr_t *ref_symbol,
+                         uintptr_t do_not_override_this_symbol);
+
+  // override all registered symbols
+  void apply_overrides();
+
+  // apply overrides to newly loaded libraries
+  void update_overrides();
+
+  // restore all overriden symbols to their original value
+  void restore_overrides();
+
+private:
+  struct SymbolOverrideInfo {
+    uintptr_t *ref_symbol;
+    uintptr_t new_symbol;
+    uintptr_t do_not_override_this_symbol;
+  };
+
+  using SymbolNameToOverrideMap =
+      HeterogeneousLookupStringMap<SymbolOverrideInfo>;
+  using AddressToValueMap = std::unordered_map<uintptr_t, uintptr_t>;
+
+  struct LibraryRevertInfo {
+    explicit LibraryRevertInfo(std::string_view library_name)
+        : library_name(library_name) {}
+    std::string library_name;
+    AddressToValueMap old_value_per_address;
+    bool processed = false;
+  };
+
+  void restore_library_overrides(std::string_view library_name,
+                                 uintptr_t base_address);
+
+  void apply_overrides_to_library(const DynamicInfo &info,
+                                  std::string_view library_name);
+
+  template <typename Reloc>
+  void process_relocations(const DynamicInfo &dyn_info, std::span<Reloc> relocs,
+                           LibraryRevertInfo &revert_info);
+
+  std::unordered_map<uintptr_t, LibraryRevertInfo> _revert_info_per_library;
+  SymbolNameToOverrideMap _overrides;
+  int _nb_loaded_libs{-1};
+};
 
 } // namespace ddprof

--- a/include/lib/symbol_overrides.hpp
+++ b/include/lib/symbol_overrides.hpp
@@ -8,8 +8,12 @@
 #include <chrono>
 
 namespace ddprof {
-void setup_overrides(std::chrono::milliseconds initial_loaded_libs_check_delay,
-                     std::chrono::milliseconds loaded_libs_check_interval);
+
+void setup_overrides();
+
 void restore_overrides();
-void reinstall_timer_after_fork();
+
+// check if new libs have been loaded and update overrides accordingly
+void update_overrides();
+
 } // namespace ddprof

--- a/include/map_utils.hpp
+++ b/include/map_utils.hpp
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace ddprof {
+
+struct StringHash {
+  using Hasher = std::hash<std::string_view>;
+  using is_transparent = void;
+
+  std::size_t operator()(const char *str) const { return Hasher{}(str); }
+  std::size_t operator()(std::string_view str) const { return Hasher{}(str); }
+  std::size_t operator()(std::string const &str) const { return Hasher{}(str); }
+};
+
+template <typename T>
+using HeterogeneousLookupStringMap =
+    std::unordered_map<std::string, T, StringHash, std::equal_to<>>;
+
+} // namespace ddprof

--- a/include/runtime_symbol_lookup.hpp
+++ b/include/runtime_symbol_lookup.hpp
@@ -7,6 +7,7 @@
 
 #include "ddprof_defs.hpp"
 #include "ddres_def.hpp"
+#include "map_utils.hpp"
 #include "symbol_map.hpp"
 #include "symbol_table.hpp"
 #include "unique_fd.hpp"
@@ -51,25 +52,8 @@ public:
   }
 
 private:
-  struct hash_string {
-    // allow comparison between strings and string_views.
-    // This saves on some string creations
-    // as suggested by @sjanel
-    using is_transparent = void;
-    std::size_t operator()(const std::string &v) const {
-      return std::hash<std::string>{}(v);
-    }
-    std::size_t operator()(const char *v) const {
-      return std::hash<std::string_view>{}(v);
-    }
+  using FailedCycle = HeterogeneousLookupStringMap<uint32_t>;
 
-    std::size_t operator()(const std::string_view &v) const {
-      return std::hash<std::string_view>{}(v);
-    }
-  };
-
-  using FailedCycle =
-      std::unordered_map<std::string, uint32_t, hash_string, std::equal_to<>>;
   struct SymbolInfo {
     SymbolMap _map;
     FailedCycle _failed_cycle;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,7 +47,7 @@ function(add_unit_test name)
   # # Create exe with sources. Always add logger and error management in the unit tests
   add_exe(${name} ../src/ddres_list.cc ../src/logger.cc ../src/ratelimiter.cc ${ARGN})
 
-  target_link_libraries(${name} PRIVATE gtest Threads::Threads gmock_main gmock)
+  target_link_libraries(${name} PRIVATE gtest Threads::Threads gmock_main gmock absl::base)
   target_include_directories(${name} PRIVATE ${DDPROF_INCLUDE_LIST} ${GTEST_INCLUDE_DIRS}
                                              ${CMAKE_SOURCE_DIR}/include/lib)
 

--- a/test/allocation_tracker-bench.cc
+++ b/test/allocation_tracker-bench.cc
@@ -111,7 +111,7 @@ void perform_memory_operations(bool track_allocations,
   if (track_allocations) {
     ddprof::AllocationTracker::allocation_tracking_init(
         rate, flags, k_default_perf_stack_sample_size,
-        ring_buffer.get_buffer_info());
+        ring_buffer.get_buffer_info(), {});
   }
 
   for (auto _ : state) {
@@ -252,7 +252,7 @@ void perform_memory_operations_2(bool track_allocations,
   if (track_allocations) {
     ddprof::AllocationTracker::allocation_tracking_init(
         rate, flags, k_default_perf_stack_sample_size,
-        ring_buffer.get_buffer_info());
+        ring_buffer.get_buffer_info(), {});
   }
 
 #ifdef READER_THREAD

--- a/test/simple_malloc.cc
+++ b/test/simple_malloc.cc
@@ -376,9 +376,9 @@ int main(int argc, char *argv[]) {
 
     if (opts.avoid_dlopen_hook) {
       // Do an allocation to force a recheck of loaded libraries:
-      // Loaded libs check is requested in a signal handler triggered by a
-      // timer, but check is done next time a hook is called.
-      void *p = malloc(1);
+      // Check is done when a sample is sent.
+      constexpr auto kBigAlloc = 1024 * 1024;
+      void *p = malloc(kBigAlloc);
       ddprof::DoNotOptimize(p);
       free(p);
     }


### PR DESCRIPTION
# What does this PR do?

 * Instead of doing a pass over all relocations of all librariesfor each symbol to override, do a single pass for all symbols.
* Replace timer + signal with a time check when pushing a sample to trigger new loaded libs check.
* Loaded libs check now uses `dl_phdr_info.dlpi_adds` member to quickly get number of loaded libs and check if it has changed.

# Motivation

* Reduce overhead of symbol overriding on process startup.
* Remove clunky timer + signal code.