### PR TITLE
Do not override weak undefined symbols

### DIFF
--- a/include/ddprof_base.hpp
+++ b/include/ddprof_base.hpp
@@ -9,6 +9,7 @@
 #define DDPROF_NOINLINE __attribute__((noinline))
 #define DDPROF_ALWAYS_INLINE __attribute__((always_inline))
 #define DDPROF_NO_SANITIZER_ADDRESS __attribute__((no_sanitize("address")))
+#define DDPROF_WEAK __attribute__((weak))
 
 #if defined(__clang__)
 #  define DDPROF_NOIPO __attribute__((noinline))

--- a/src/lib/elfutils.cc
+++ b/src/lib/elfutils.cc
@@ -453,6 +453,11 @@ bool SymbolOverrides::register_override(std::string_view symbol_name,
                                         uintptr_t new_symbol,
                                         uintptr_t *ref_symbol,
                                         uintptr_t do_not_override_this_symbol) {
+  // refuse to override symbol if ref symbol is not defined
+  if (*ref_symbol == 0) {
+    return false;
+  }
+
   return _overrides
       .try_emplace(std::string{symbol_name}, ref_symbol, new_symbol,
                    do_not_override_this_symbol)

--- a/src/lib/symbol_overrides.cc
+++ b/src/lib/symbol_overrides.cc
@@ -29,24 +29,21 @@
 extern "C" {
 // NOLINTBEGIN
 // Declaration of reallocarray is only available starting from glibc 2.28
-__attribute__((weak)) void *reallocarray(void *ptr, size_t nmemb,
-                                         size_t nmenb) NOEXCEPT;
-__attribute__((weak)) void *pvalloc(size_t size) NOEXCEPT;
-__attribute__((weak)) int __libc_allocate_rtsig(int high) NOEXCEPT;
+DDPROF_WEAK void *reallocarray(void *ptr, size_t nmemb, size_t nmenb) NOEXCEPT;
+DDPROF_WEAK void *pvalloc(size_t size) NOEXCEPT;
+DDPROF_WEAK int __libc_allocate_rtsig(int high) NOEXCEPT;
 // NOLINTEND
 
 // sized free functions (C23, not yet available in glibc)
-__attribute__((weak)) void free_sized(void *ptr, size_t size);
-__attribute__((weak)) void free_aligned_sized(void *ptr, size_t alignment,
-                                              size_t size);
+DDPROF_WEAK void free_sized(void *ptr, size_t size);
+DDPROF_WEAK void free_aligned_sized(void *ptr, size_t alignment, size_t size);
 
 // jemalloc Non-standard API
-__attribute__((weak)) void *mallocx(size_t size, int flags);
-__attribute__((weak)) void *rallocx(void *ptr, size_t size, int flags);
-__attribute__((weak)) size_t xallocx(void *ptr, size_t size, size_t extra,
-                                     int flags);
-__attribute__((weak)) void dallocx(void *ptr, int flags);
-__attribute__((weak)) void sdallocx(void *ptr, size_t size, int flags);
+DDPROF_WEAK void *mallocx(size_t size, int flags);
+DDPROF_WEAK void *rallocx(void *ptr, size_t size, int flags);
+DDPROF_WEAK size_t xallocx(void *ptr, size_t size, size_t extra, int flags);
+DDPROF_WEAK void dallocx(void *ptr, int flags);
+DDPROF_WEAK void sdallocx(void *ptr, size_t size, int flags);
 }
 
 namespace ddprof {


### PR DESCRIPTION
# What does this PR do?

Overriding a weak undefined symbol will change its value from null to a non-null value and might change the behaviour of programs checking the value of the symbol, leading to crashes when program then tries to call the overridden symbol.
