### PR TITLE
Version bump v0.15.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.19)
 project(
   DDProf
   LANGUAGES C CXX
-  VERSION 0.15.0
+  VERSION 0.15.1
   DESCRIPTION "Datadog's native profiler for Linux")
 
 message(STATUS "Compiler ID: ${CMAKE_C_COMPILER_ID}")


### PR DESCRIPTION
# What does this PR do?

Bump version to 0.15.1 to prepare for patch release.

# Motivation

We need to publish a new version including a fix for the crash in version 0.15.0.
