### PR TITLE
Remove useless malloc/free calls

### DIFF
--- a/src/lib/allocation_tracker.cc
+++ b/src/lib/allocation_tracker.cc
@@ -98,11 +98,6 @@ DDRes AllocationTracker::allocation_tracking_init(
     DDRES_RETURN_ERROR_LOG(DD_WHAT_UKNW, "Allocation profiler already started");
   }
 
-  // force initialization of malloc wrappers if not done yet
-  // volatile prevents compiler from optimizing out calls to malloc/free
-  void *volatile p = ::malloc(1);
-  ::free(p);
-
   DDRES_CHECK_FWD(instance->init(allocation_profiling_rate,
                                  flags & kDeterministicSampling,
                                  flags & kTrackDeallocations, stack_sample_size,


### PR DESCRIPTION
# What does this PR do?

Since malloc wrappers are not used anymore, these call are not needed anymore.

