### PR TITLE
Avoid doing allocations in m(un)map hooks

### DIFF
--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -129,6 +129,9 @@ private:
 
   DDRes push_clear_live_allocation(TrackerThreadLocalState &tl_state);
 
+  void check_timer(PerfClock::time_point now,
+                   TrackerThreadLocalState &tl_state);
+
   void free_on_consecutive_failures(bool success);
 
   DDPROF_NOINLINE void update_timer(PerfClock::time_point now);

--- a/include/lib/allocation_tracker_tls.hpp
+++ b/include/lib/allocation_tracker_tls.hpp
@@ -20,6 +20,11 @@ struct TrackerThreadLocalState {
                              // and double counting of allocations (eg. when new
                              // calls malloc, or malloc calls mmap internally)
 
+  bool allocation_allowed{true}; // Indicate if allocation is allowed or not
+                                 // (eg. when we are in mmap hook, we
+                                 // should not allocate because we might already
+                                 // be inside an allocation)
+
   // In the choice of random generators, this one is smaller
   // - smaller than mt19937 (8 vs 5K)
   std::minstd_rand gen{std::random_device{}()};


### PR DESCRIPTION
# What does this PR do?

m(un)map hooks may be called inside an allocation function (eg. malloc) that is not reentrant, hence we must avoid allocations in these hooks.
