### PR TITLE
Add logging to the library

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -61,3 +61,4 @@ CheckOptions:
     cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted: true
     misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: true
     readability-magic-numbers.IgnorePowersOf2IntegerValues: true
+    readability-simplify-boolean-expr.IgnoreMacros: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,14 +207,12 @@ if(USE_LOADER)
 endif()
 
 set(DD_PROFILING_SOURCES
-    # cmake-format: sortable
     src/daemonize.cc
     src/ddprof_cmdline.cc
     src/ddres_list.cc
     src/ipc.cc
     src/lib/address_bitset.cc
     src/lib/allocation_tracker.cc
-    src/lib/dd_profiling.cc
     src/lib/elfutils.cc
     src/lib/lib_embedded_data.c
     src/lib/pthread_fixes.cc
@@ -234,7 +232,10 @@ set(DD_PROFILING_SOURCES
     src/sys_utils.cc
     src/tracepoint_config.cc
     src/tsc_clock.cc
-    src/user_override.cc)
+    src/user_override.cc
+    # Intentionally put dd_profiling.cc last to avoid leak sanitizer failure complaining that memory
+    # in LoggerContext::name is not freed
+    src/lib/dd_profiling.cc)
 
 if(BUILD_UNIVERSAL_DDPROF)
   # Compiling on different libc, we need to ensure some symbols are available everywhere

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ set(DD_PROFILING_SOURCES
     src/lib/saveregisters.cc
     src/lib/symbol_overrides.cc
     src/logger.cc
+    src/logger_setup.cc
     src/perf.cc
     src/perf_clock.cc
     src/perf_ringbuffer.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,7 @@ target_include_directories(dd_profiling-embedded PUBLIC ${CMAKE_SOURCE_DIR}/incl
                                                         ${CMAKE_SOURCE_DIR}/include)
 set_target_properties(dd_profiling-embedded
                       PROPERTIES PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/lib/dd_profiling.h")
+target_compile_definitions(dd_profiling-embedded PRIVATE DDPROF_PROFILING_LIBRARY)
 
 # Link libstdc++/libgcc statically and export only profiler API
 target_static_libcxx(dd_profiling-embedded)
@@ -356,7 +357,8 @@ add_dependencies(ddprof_exe_object generate_ddprof_object)
 
 add_library(dd_profiling-static STATIC ${DD_PROFILING_SOURCES})
 set_target_properties(dd_profiling-static PROPERTIES OUTPUT_NAME dd_profiling)
-target_compile_definitions(dd_profiling-static PRIVATE DDPROF_EMBEDDED_EXE_DATA)
+target_compile_definitions(dd_profiling-static PRIVATE DDPROF_EMBEDDED_EXE_DATA
+                                                       DDPROF_PROFILING_LIBRARY)
 target_include_directories(dd_profiling-static PUBLIC ${CMAKE_SOURCE_DIR}/include/lib
                                                       ${CMAKE_SOURCE_DIR}/include)
 set_target_properties(dd_profiling-static
@@ -371,14 +373,16 @@ if(USE_LOADER)
                                          src/lib/loader.c)
   target_link_libraries(dd_profiling-shared PRIVATE libddprofiling_embedded_object
                                                     ddprof_exe_object)
-  target_compile_definitions(dd_profiling-shared PRIVATE DDPROF_EMBEDDED_LIB_DATA
-                                                         DDPROF_EMBEDDED_EXE_DATA)
+  target_compile_definitions(
+    dd_profiling-shared PRIVATE DDPROF_EMBEDDED_LIB_DATA DDPROF_EMBEDDED_EXE_DATA
+                                DDPROF_PROFILING_LIBRARY)
 else()
   # Without loader, libdd_profiling.so is basically the same as libdd_profiling-embedded.so plus an
   # embedded ddprof executable.
   add_library(dd_profiling-shared SHARED ${DD_PROFILING_SOURCES} src/lib/lib_embedded_data.c)
   target_link_libraries(dd_profiling-shared PRIVATE ddprof_exe_object)
-  target_compile_definitions(dd_profiling-shared PRIVATE DDPROF_EMBEDDED_EXE_DATA)
+  target_compile_definitions(dd_profiling-shared PRIVATE DDPROF_EMBEDDED_EXE_DATA
+                                                         DDPROF_PROFILING_LIBRARY)
 
   # Fix for link error in sanitizeddebug build mode with gcc:
   # ~~~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,6 @@ if(BUILD_UNIVERSAL_DDPROF)
     target_link_options(
       dd_profiling-embedded PRIVATE
       "-Wl,-f,libpthread.so.0;-Wl,-f,libm.so.6;-Wl,-f,libdl.so.2;-Wl,-f,librt.so.1")
-    target_compile_definitions(dd_profiling-embedded PRIVATE DDPROF_MISSING_FSTAT)
   endif()
 endif()
 

--- a/include/ddres_helpers.hpp
+++ b/include/ddres_helpers.hpp
@@ -142,7 +142,8 @@ inline int ddres_sev_to_log_level(int sev) {
 // workaround once it is released. \fixme{nsavoire}
 #define DDPROF_CHECK_FATAL_IMPL(condition, condition_text, text, ...)          \
   do {                                                                         \
-    if (unlikely(!(condition))) {                                              \
+    if (unlikely(                                                              \
+            !(condition))) { /* NOLINT(readability-simplify-boolean-expr) */   \
       LG_IF_LVL_OK(LL_CRITICAL, "Check failed: `%s`. " text, condition_text,   \
                    ##__VA_ARGS__);                                             \
       std::abort();                                                            \
@@ -152,7 +153,8 @@ inline int ddres_sev_to_log_level(int sev) {
 #ifndef NDEBUG
 #  define DDPROF_DCHECK_FATAL_IMPL(condition, condition_text, text, ...)       \
     do {                                                                       \
-      if (unlikely(!(condition))) {                                            \
+      if (unlikely(                                                            \
+              !(condition))) { /* NOLINT(readability-simplify-boolean-expr) */ \
         LG_IF_LVL_OK(LL_CRITICAL, "Check failed: `%s`. " text, condition_text, \
                      ##__VA_ARGS__);                                           \
         std::abort();                                                          \

--- a/include/ddres_helpers.hpp
+++ b/include/ddres_helpers.hpp
@@ -164,10 +164,17 @@ inline int ddres_sev_to_log_level(int sev) {
     } while (0)
 #endif
 
+#ifndef DDPROF_PROFILING_LIBRARY
 // Fatal assertion check that terminates the program with a fatal error if
 // `condition` is not true.
-#define DDPROF_CHECK_FATAL(condition, ...)                                     \
-  DDPROF_CHECK_FATAL_IMPL(condition, #condition, __VA_ARGS__)
+#  define DDPROF_CHECK_FATAL(condition, ...)                                   \
+    DDPROF_CHECK_FATAL_IMPL(condition, #condition, __VA_ARGS__)
+#else
+// DDPROF_CHECK_FATAL must not be used inside profiling library
+#  define DDPROF_CHECK_FATAL(condition, ...)                                   \
+    static_assert(                                                             \
+        false, "DDPROF_CHECK_FATAL must not be used inside profiling library")
+#endif
 
 // `DDPROF_DCHECK_FATAL` behaves like `DDPROF_CHECK_FATAL` in debug mode but
 // does nothing otherwise (if NDEBUG is defined)

--- a/include/logger.hpp
+++ b/include/logger.hpp
@@ -5,11 +5,12 @@
 
 #pragma once
 
-#include <chrono>
-#include <stdarg.h>
-
 #include "unlikely.hpp"
 #include "version.hpp"
+
+#include <chrono>
+#include <functional>
+#include <stdarg.h>
 
 namespace ddprof {
 
@@ -99,6 +100,13 @@ void LOG_setfacility(int fac);
 void LOG_setratelimit(uint64_t max_log_per_interval,
                       std::chrono::nanoseconds interval);
 
+bool LOG_is_logging_enabled_for_level(int level);
+
+using LogsAllowedCallback = std::function<bool()>;
+
+// Allow to inject a function used by logger to check if logs are allowed
+void LOG_set_logs_allowed_function(LogsAllowedCallback logs_allowed_function);
+
 /******************************* Logging Macros *******************************/
 #define ABS(__x)                                                               \
   ({                                                                           \
@@ -109,7 +117,7 @@ void LOG_setratelimit(uint64_t max_log_per_interval,
 // Avoid calling arguments (which can have CPU costs unless level is OK)
 #define LG_IF_LVL_OK(level, ...)                                               \
   do {                                                                         \
-    if (unlikely(level <= LOG_getlevel())) {                                   \
+    if (unlikely(LOG_is_logging_enabled_for_level(level))) {                   \
       olprintfln(ABS(level), -1, MYNAME, __VA_ARGS__);                         \
     }                                                                          \
   } while (false)

--- a/src/lib/dd_profiling.cc
+++ b/src/lib/dd_profiling.cc
@@ -399,7 +399,7 @@ int ddprof_start_profiling_internal() {
         // fails ?
         g_state.allocation_profiling_started = true;
       } else {
-        LOG_ONCE("Error: %s", "Failure to start allocation profiling\n");
+        LG_ERR("Failed to start allocation profiling\n");
       }
     }
   } catch (const DDException &e) { return -1; }
@@ -407,7 +407,7 @@ int ddprof_start_profiling_internal() {
   if (g_state.allocation_profiling_started) {
     int const res = pthread_atfork(nullptr, nullptr, notify_fork);
     if (res) {
-      LOG_ONCE("Error:%s", "Unable to setup notify fork");
+      LG_ERR("Unable to setup notify fork. Error: %d: %s", res, strerror(res));
       assert(0);
     }
   }

--- a/src/lib/lib_embedded_data.c
+++ b/src/lib/lib_embedded_data.c
@@ -15,10 +15,10 @@ extern const unsigned char _binary_libdd_profiling_embedded_so_start[];
 extern const unsigned char _binary_libdd_profiling_embedded_so_end[];
 #else
 // NOLINTNEXTLINE(cert-dcl51-cpp)
-static const unsigned char _binary_libdd_profiling_embedded_so_start[] = {};
+static const unsigned char *_binary_libdd_profiling_embedded_so_start = 0;
 // NOLINTNEXTLINE(cert-dcl51-cpp)
+static const unsigned char *_binary_libdd_profiling_embedded_so_end = 0;
 static const char *libdd_profiling_embedded_hash = "";
-static const unsigned char _binary_libdd_profiling_embedded_so_end[] = {};
 #endif
 
 #ifdef DDPROF_EMBEDDED_EXE_DATA
@@ -28,9 +28,8 @@ static const unsigned char _binary_libdd_profiling_embedded_so_end[] = {};
 extern const unsigned char _binary_ddprof_start[]; // NOLINT(cert-dcl51-cpp)
 extern const unsigned char _binary_ddprof_end[];   // NOLINT(cert-dcl51-cpp)
 #else
-static const unsigned char _binary_ddprof_start[] =
-    {};                                               // NOLINT(cert-dcl51-cpp)
-static const unsigned char _binary_ddprof_end[] = {}; // NOLINT(cert-dcl51-cpp)
+static const unsigned char *_binary_ddprof_start = 0; // NOLINT(cert-dcl51-cpp)
+static const unsigned char *_binary_ddprof_end = 0;   // NOLINT(cert-dcl51-cpp)
 static const char *ddprof_exe_hash = "";
 #endif
 

--- a/test/simple_malloc-ut.sh
+++ b/test/simple_malloc-ut.sh
@@ -78,7 +78,7 @@ check_logs() {
             fi
         done
     else
-        if [ -f "${log_file}" ]; then
+        if [ -s "${log_file}" ]; then
             echo "Unexpected samples for $cmd"
             cat "${log_file}"
             exit 1


### PR DESCRIPTION
* Setup logger in library
* Use DD_PROFILING_NATIVE_LIBRARY_LOG_MODE with fallback to  DD_PROFILING_NATIVE_LOG_MODE to determine library log mode
* Use DD_PROFILING_NATIVE_LIBRARY_LOG_LEVEL with fallback to  DD_PROFILING_NATIVE_LOG_LEVEL to determine library log level
* Add callback in logger to determine if log is allowed, this callback is used to disable logging when allocations are forbidden