### PR TITLE
Add -fno-semantic-interposition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ target_static_libcxx(dd_profiling-embedded)
 target_static_sanitizer(dd_profiling-embedded)
 set_target_properties(dd_profiling-embedded PROPERTIES LINK_DEPENDS "${dd_profiling_linker_script}")
 target_link_options(dd_profiling-embedded PRIVATE
-                    "LINKER:--version-script=${dd_profiling_linker_script}")
+                    "LINKER:--version-script=${dd_profiling_linker_script};LINKER:-Bsymbolic")
 if(BUILD_UNIVERSAL_DDPROF)
   target_link_options(dd_profiling-embedded PRIVATE "-nolibc")
   if(USE_AUXILIARY)
@@ -393,7 +393,7 @@ target_static_libcxx(dd_profiling-shared)
 target_static_sanitizer(dd_profiling-shared)
 set_target_properties(dd_profiling-shared PROPERTIES LINK_DEPENDS "${dd_profiling_linker_script}")
 target_link_options(dd_profiling-shared PRIVATE
-                    "LINKER:--version-script=${dd_profiling_linker_script}")
+                    "LINKER:--version-script=${dd_profiling_linker_script};LINKER:-Bsymbolic")
 
 set_target_properties(dd_profiling-shared PROPERTIES OUTPUT_NAME dd_profiling)
 target_include_directories(dd_profiling-shared PUBLIC ${CMAKE_SOURCE_DIR}/include/lib

--- a/cmake/ExtendBuildTypes.cmake
+++ b/cmake/ExtendBuildTypes.cmake
@@ -12,7 +12,7 @@ endif()
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_C_STANDARD 11)
 
-add_compile_options(-Wall -g)
+add_compile_options(-Wall -g -fno-semantic-interposition -fvisibility=hidden)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)

--- a/include/ddprof_base.hpp
+++ b/include/ddprof_base.hpp
@@ -10,6 +10,7 @@
 #define DDPROF_ALWAYS_INLINE __attribute__((always_inline))
 #define DDPROF_NO_SANITIZER_ADDRESS __attribute__((no_sanitize("address")))
 #define DDPROF_WEAK __attribute__((weak))
+#define DDPROF_EXPORT __attribute__((__visibility__("default")))
 
 #if defined(__clang__)
 #  define DDPROF_NOIPO __attribute__((noinline))

--- a/include/lib/dd_profiling.h
+++ b/include/lib/dd_profiling.h
@@ -9,8 +9,9 @@
 extern "C" {
 #endif
 
-int ddprof_start_profiling();
-void ddprof_stop_profiling(int timeout_ms);
+__attribute__((__visibility__("default"))) int ddprof_start_profiling();
+__attribute__((__visibility__("default"))) void
+ddprof_stop_profiling(int timeout_ms);
 
 #ifdef __cplusplus
 }

--- a/test/simple_malloc.cc
+++ b/test/simple_malloc.cc
@@ -169,7 +169,8 @@ extern "C" DDPROF_NOINLINE void recursive_call(const Options &options,
   DDPROF_BLOCK_TAIL_CALL_OPTIMIZATION();
 }
 
-extern "C" DDPROF_NOINLINE void wrapper(const Options &options, Stats &stats) {
+extern "C" DDPROF_EXPORT DDPROF_NOINLINE void wrapper(const Options &options,
+                                                      Stats &stats) {
   recursive_call(options, stats, options.callstack_depth);
 }
 // NOLINTEND(clang-analyzer-unix.Malloc)


### PR DESCRIPTION
# Motivation

"-fno-semantic-interposition" allows the compiler to inline code within a compilation unit even with "-fPIC".
Also make all symbols hidden by default amd use "-Bsymbolic-functions". cf. https://maskray.me/blog/2021-05-16-elf-interposition-and-bsymbolic cf. https://maskray.me/blog/2021-05-09-fno-semantic-interposition

