### PR TITLE
Add a limit on maximum number of profiled PIDs

### DIFF
--- a/include/common_symbol_errors.hpp
+++ b/include/common_symbol_errors.hpp
@@ -12,6 +12,7 @@ enum SymbolErrors {
   unknown_dso,
   dwfl_frame,
   incomplete_stack,
+  max_pids,
   lost_event,
 };
 

--- a/include/ddprof_defs.hpp
+++ b/include/ddprof_defs.hpp
@@ -31,6 +31,10 @@ inline constexpr auto k_min_number_samples_per_ring_buffer = 8;
 
 inline constexpr int k_size_api_key = 32;
 
+// Maximum number of profiled pids
+// Exceeding a number of PIDs overloads file descriptors and memory
+inline constexpr unsigned kMaxProfiledPids{100};
+
 // Linux Inode type
 using inode_t = uint64_t;
 

--- a/include/ddres_list.hpp
+++ b/include/ddres_list.hpp
@@ -23,6 +23,7 @@ enum { DD_COMMON_START_RANGE = 1000, DD_NATIVE_START_RANGE = 2000 };
   X(DWFL_LIB_ERROR, "error withing dwfl library")                              \
   X(UW_CACHE_ERROR, "error from unwinding cache")                              \
   X(UW_ERROR, "error from unwinding code")                                     \
+  X(UW_MAX_PIDS, "Maximum number of PIDs reached")                             \
   X(UW_MAX_DEPTH, "max depth reached in unwinding")                            \
   X(CAPLIB, "error when reading capabilities")                                 \
   X(USERID, "error in user ID manipulations")                                  \

--- a/include/dwfl_hdr.hpp
+++ b/include/dwfl_hdr.hpp
@@ -61,7 +61,8 @@ struct DwflWrapper {
 
 class DwflHdr {
 public:
-  DwflWrapper &get_or_insert(pid_t pid);
+  // checks against maximum number of PIDs
+  DwflWrapper *get_or_insert(pid_t pid);
   std::vector<pid_t> get_unvisited() const;
   void reset_unvisited();
   void clear_pid(pid_t pid);

--- a/src/common_symbol_lookup.cc
+++ b/src/common_symbol_lookup.cc
@@ -19,6 +19,8 @@ Symbol symbol_from_common(SymbolErrors lookup_case) {
     return {std::string(), std::string("[incomplete]"), 0, std::string()};
   case SymbolErrors::lost_event:
     return {std::string(), std::string("[lost]"), 0, std::string()};
+  case SymbolErrors::max_pids:
+    return {std::string(), std::string("[maximum pids]"), 0, std::string()};
   default:
     break;
   }

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -228,7 +228,7 @@ DDRes ddprof_unwind_sample(DDProfContext &ctx, perf_event_sample *sample,
     ddprof_stats_add(STATS_UNWIND_TRUNCATED_INPUT, 1, nullptr);
   }
 
-  if (us->_dwfl_wrapper->_inconsistent) {
+  if (us->_dwfl_wrapper && us->_dwfl_wrapper->_inconsistent) {
     // Loaded modules were inconsistent, assume we should flush everything.
     LG_WRN("(Inconsistent DWFL/DSOs)%d - Free associated objects", us->pid);
     DDRES_CHECK_FWD(worker_pid_free(ctx, us->pid));

--- a/src/dwfl_hdr.cc
+++ b/src/dwfl_hdr.cc
@@ -47,16 +47,19 @@ DDRes DwflWrapper::attach(pid_t pid, const Dwfl_Thread_Callbacks *callbacks,
   return {};
 }
 
-DwflWrapper &DwflHdr::get_or_insert(pid_t pid) {
+DwflWrapper *DwflHdr::get_or_insert(pid_t pid) {
   _visited_pid.insert(pid);
   auto it = _dwfl_map.find(pid);
   if (it == _dwfl_map.end()) {
+    if (_dwfl_map.size() >= kMaxProfiledPids) {
+      return nullptr;
+    }
     // insert new dwfl for this pid
     auto pair = _dwfl_map.emplace(pid, DwflWrapper());
     assert(pair.second); // expect insertion to be OK
-    return pair.first->second;
+    return &pair.first->second;
   }
-  return it->second;
+  return &it->second;
 }
 
 DDProfMod *DwflWrapper::unsafe_get(FileInfoId_t file_info_id) {


### PR DESCRIPTION
# What does this PR do?

- Ensure we have limits on maximum number of PIDs
- Avoid trying to mappings that are not backed by a file

# Motivation

Avoid exhausting memory / file descriptor limitations.

# Additional Notes

While we work on changing the caching around symbols and unwinding, we can raise this limit.

# How to test the change?

Full host in relenv will test this change.