### PR TITLE
Align segment offset down to page size

### DIFF
--- a/include/ddprof_module_lib.hpp
+++ b/include/ddprof_module_lib.hpp
@@ -24,12 +24,11 @@ inline uint32_t elf_flags_to_prot(Elf64_Word flags) {
 struct Segment {
   ElfAddress_t addr;
   Offset_t offset;
-  uint64_t alignment;
   uint32_t prot;
 };
 
 struct Mapping {
-  ElfAddress_t addr;
+  ProcessAddress_t addr;
   Offset_t offset;
   uint32_t prot;
 };

--- a/test/ddprof_module_lib-ut.cc
+++ b/test/ddprof_module_lib-ut.cc
@@ -9,7 +9,7 @@
 
 namespace ddprof {
 Segment segment(Offset_t offset, uint32_t prot = PROT_EXEC | PROT_READ) {
-  return {.addr = 0, .offset = offset, .alignment = 0x1000, .prot = prot};
+  return {.addr = 0, .offset = offset, .prot = prot};
 }
 
 Mapping mapping(Offset_t offset, uint32_t prot = PROT_EXEC | PROT_READ) {


### PR DESCRIPTION
# What does this PR do?

Segment offset should not be aligned to `p_align` but to page size. `p_align` is only used by kernel/dynamic loader to find a suitable base address to load the elf file.
