### PR TITLE
Improve DsoHdr::erase_range

### DIFF
--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -190,6 +190,8 @@ public:
 
   PidMapping &get_pid_mapping(pid_t pid) { return _pid_map[pid]; }
 
+  bool checkInvariants() const;
+
 private:
   // erase range of elements
   static void erase_range(DsoMap &map, DsoRange range, const Dso &new_mapping);

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -371,7 +371,11 @@ DsoHdr::DsoFindRes DsoHdr::insert_erase_overlap(PidMapping &pid_mapping,
   _stats.incr_metric(DsoStats::kNewDso, dso._type);
   LG_DBG("[DSO] : Insert %s", dso.to_string().c_str());
   // warning rvalue : do not use dso after this line
-  return map.insert({dso._start, std::move(dso)});
+  auto r = map.insert({dso._start, std::move(dso)});
+
+  // only check in debug mode
+  DDPROF_DCHECK_FATAL(checkInvariants(), "DsoHdr invariant violation");
+  return r;
 }
 
 DsoHdr::DsoFindRes DsoHdr::insert_erase_overlap(Dso &&dso) {

--- a/src/unwind_dwfl.cc
+++ b/src/unwind_dwfl.cc
@@ -28,9 +28,9 @@ void trace_unwinding_end(UnwindState *us) {
   if (LL_DEBUG <= LOG_getlevel()) {
     DsoHdr::DsoFindRes const find_res =
         us->dso_hdr.dso_find_closest(us->pid, us->current_ip);
-    SymbolIdx_t const symIdx =
-        us->output.locs[us->output.locs.size() - 1]._symbol_idx;
-    if (find_res.second) {
+    if (find_res.second && !us->output.locs.empty()) {
+      SymbolIdx_t const symIdx =
+          us->output.locs[us->output.locs.size() - 1]._symbol_idx;
       const std::string &last_func =
           us->symbol_hdr._symbol_table[symIdx]._symname;
       LG_DBG("Stopped at %lx - dso %s - error %s (%s)", us->current_ip,

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -557,7 +557,7 @@ TEST(DSOTest, elf_load) {
     ASSERT_EQ(it3->second, dso1_right);
   }
 
-  // map 2rd segment
+  // map 3rd segment
   const Dso dso3{
       5, 0x4000, 0x4fff, 0x2000, "libfoo.so.1", 0, PROT_READ | PROT_WRITE};
   dso_hdr.insert_erase_overlap(Dso{dso3});


### PR DESCRIPTION
* Add DDPROF_CHECK_FATAL / DDPROF_DCHECK_FATAL assertions
* Add function to check DsoHdr invariants
* Change pid_fork to do nothing if child pid mappings already exist
    `pid_fork` directly copies mappings from parent to child pid,
    if child pid already has mappoings this can lead to overlapping mappings.
    Currently this cannot happens, because child mappings are cleared before
    `pid_fork`. This check adds a safegard by returning early if child pid
    has mappings.
* Add DsoHdr invariant check in debug mode after inserting a Dso
* Make erase_range function cleaner
    * Add check when re-inserting truncated last mapping
    * Return early in the case new mapping truncates end of a single mapping
      to avoid using range.first ierator that is invalidated by map::extract
      (the node pointed by first is extracted and then re-inserted hence
       the iterator should remain valid, but better be careful)
* Allow anonymous mapping to truncate existing file mapping
    Allow new mapping to truncate existing mappings if previous mapping is
    a file and new mapping is anonymous because a LOAD segment can have
    filesize < memsize as a size optimization when the end of segment is all
    zeros (eg. bss). In that case elf loader / dlopen will map the whole
    file + some extra space to cover the difference between memsize and file
    size and then map an anonymous mapping over the part not in the file.
* Avoid out-of-bound array access when printing unwinding error in debug logs