### PR TITLE
Remove check_invariants from hot code path

### DIFF
--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -190,7 +190,7 @@ public:
 
   PidMapping &get_pid_mapping(pid_t pid) { return _pid_map[pid]; }
 
-  bool checkInvariants() const;
+  bool check_invariants() const;
 
 private:
   // erase range of elements

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -543,6 +543,10 @@ DDRes ddprof_worker_cycle(DDProfContext &ctx,
   // Increase the counts of exports
   ctx.worker_ctx.count_worker += 1;
 
+  // In debug mode, check for possible issues in loaded segments
+  DDPROF_DCHECK_FATAL(ctx.worker_ctx.us->dso_hdr.check_invariants(),
+                      "DsoHdr invariant violation");
+
   // allow new backpopulates
   ctx.worker_ctx.us->dso_hdr.reset_backpopulate_state();
 

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -389,9 +389,6 @@ DsoHdr::DsoFindRes DsoHdr::insert_erase_overlap(PidMapping &pid_mapping,
   LG_DBG("[DSO] : Insert %s", dso.to_string().c_str());
   // warning rvalue : do not use dso after this line
   auto r = map.insert({dso._start, std::move(dso)});
-
-  // only check in debug mode
-  DDPROF_DCHECK_FATAL(checkInvariants(), "DsoHdr invariant violation");
   return r;
 }
 
@@ -597,7 +594,7 @@ void DsoHdr::pid_fork(pid_t child_pid, pid_t parent_pid) {
   }
 }
 
-bool DsoHdr::checkInvariants() const {
+bool DsoHdr::check_invariants() const {
   for (const auto &[pid, pid_mapping] : _pid_map) {
     const Dso *previous_dso = nullptr;
 


### PR DESCRIPTION
# What does this PR do?

Move the check on invariants to a code path where it is called once per cycle (60 seconds)

# Motivation

Debug mode is not usable currently.

# Additional Notes

N/A

# How to test the change?

Already tested