### PR TITLE
Only look for runtime symbols in executable mappings

### DIFF
--- a/include/dso.hpp
+++ b/include/dso.hpp
@@ -74,5 +74,11 @@ public:
   DsoOrigin _origin{DsoOrigin::kPerfMmapEvent};
 };
 
+// some runtimes such as java or .NET can publish maps to populate the symbols
+inline bool has_runtime_symbols(const Dso &dso) {
+  return (dso._type == DsoType::kRuntime || dso._type == DsoType::kAnon) &&
+      (dso._prot & PROT_EXEC);
+}
+
 std::ostream &operator<<(std::ostream &os, const Dso &dso);
 } // namespace ddprof

--- a/include/dso_type.hpp
+++ b/include/dso_type.hpp
@@ -34,11 +34,6 @@ inline bool has_relevant_path(DsoType dso_type) {
   return false;
 }
 
-// some runtimes such as java or .NET can publish maps to populate the symbols
-inline bool has_runtime_symbols(DsoType dso_type) {
-  return dso_type == DsoType::kRuntime || dso_type == DsoType::kAnon;
-}
-
 // todo : find an enum that supports to_str
 inline const char *dso_type_str(DsoType path_type) {
   switch (path_type) {

--- a/src/unwind_dwfl.cc
+++ b/src/unwind_dwfl.cc
@@ -105,7 +105,7 @@ DDRes add_symbol(Dwfl_Frame *dwfl_frame, UnwindState *us) {
     }
     const Dso &dso = find_res.first->second;
     std::string_view jitdump_path = {};
-    if (has_runtime_symbols(dso._type)) {
+    if (has_runtime_symbols(dso)) {
       if (pid_mapping._jitdump_addr) {
         DsoHdr::DsoFindRes const find_mapping = DsoHdr::dso_find_closest(
             pid_mapping._map, pid_mapping._jitdump_addr);


### PR DESCRIPTION
# What does this PR do?

Avoid looking for jit dump info when `pc` belongs to a non-executable mapping.