### PR TITLE
Add option to reorder events by timestamp across ring buffers

### DIFF
--- a/include/ddprof_cli.hpp
+++ b/include/ddprof_cli.hpp
@@ -69,6 +69,7 @@ public:
   bool help_extended{false};
   bool remote_symbolization{false};
   bool disable_symbolization{false};
+  bool reorder_events{false}; // reorder events by timestamp
 
   std::string socket_path;
   int pipefd_to_library{-1};

--- a/include/ddprof_context.hpp
+++ b/include/ddprof_context.hpp
@@ -34,6 +34,7 @@ struct DDProfContext {
     bool timeline{false};
     bool remote_symbolization{false};
     bool disable_symbolization{false};
+    bool reorder_events{false}; // reorder events by timestamp
 
     cpu_set_t cpu_affinity{};
     std::string switch_user;

--- a/include/ddprof_stats.hpp
+++ b/include/ddprof_stats.hpp
@@ -36,7 +36,8 @@ namespace ddprof {
   X(DSO_SIZE, "dso.size", STAT_GAUGE)                                          \
   X(PPROF_SIZE, "pprof.size", STAT_GAUGE)                                      \
   X(PROFILE_DURATION, "profile.duration_ms", STAT_GAUGE)                       \
-  X(AGGREGATION_AVG_TIME, "aggregation.avg_time_ns", STAT_GAUGE)
+  X(AGGREGATION_AVG_TIME, "aggregation.avg_time_ns", STAT_GAUGE)               \
+  X(BACKPOPULATE_COUNT, "backpopulate.count", STAT_GAUGE)
 
 // Expand the enum/index for the individual stats
 enum DDPROF_STATS { STATS_TABLE(X_ENUM) STATS_LEN };

--- a/include/ddprof_stats.hpp
+++ b/include/ddprof_stats.hpp
@@ -15,6 +15,7 @@ namespace ddprof {
 #define STATS_TABLE(X)                                                         \
   X(EVENT_COUNT, "event.count", STAT_GAUGE)                                    \
   X(EVENT_LOST, "event.lost", STAT_GAUGE)                                      \
+  X(EVENT_OUT_OF_ORDER, "event.out_of_order", STAT_GAUGE)                      \
   X(SAMPLE_COUNT, "sample.count", STAT_GAUGE)                                  \
   X(UNMATCHED_DEALLOCATION_COUNT, "unmatched_deallocation.count", STAT_GAUGE)  \
   X(TARGET_CPU_USAGE, "target_process.cpu_usage.millicores", STAT_GAUGE)       \

--- a/include/ddprof_stats.hpp
+++ b/include/ddprof_stats.hpp
@@ -32,7 +32,6 @@ namespace ddprof {
   X(SYMBOLS_JIT_SYMBOL_COUNT, "symbols.jit.symbol_count", STAT_GAUGE)          \
   X(PROFILER_RSS, "profiler.rss", STAT_GAUGE)                                  \
   X(PROFILER_CPU_USAGE, "profiler.cpu_usage.millicores", STAT_GAUGE)           \
-  X(DSO_UNHANDLED_SECTIONS, "dso.unhandled_sections", STAT_GAUGE)              \
   X(DSO_NEW_DSO, "dso.new", STAT_GAUGE)                                        \
   X(DSO_SIZE, "dso.size", STAT_GAUGE)                                          \
   X(PPROF_SIZE, "pprof.size", STAT_GAUGE)                                      \

--- a/include/ddprof_worker_context.hpp
+++ b/include/ddprof_worker_context.hpp
@@ -42,6 +42,7 @@ struct DDProfWorkerContext {
   std::array<uint64_t, kMaxTypeWatcher> lost_events_per_watcher{};
   LiveAllocation live_allocation;
   int64_t perfclock_offset;
+  PerfClock::time_point last_processed_event_timestamp{};
 };
 
 } // namespace ddprof

--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -46,6 +46,13 @@ public:
     for (auto &metric_array : _metrics) {
       reset_event_metric(metric_array);
     }
+    _backpopulate_count = 0;
+  }
+
+  void incr_backpopulate_count() { ++_backpopulate_count; }
+
+  [[nodiscard]] uint64_t backpopulate_count() const {
+    return _backpopulate_count;
   }
 
 private:
@@ -57,6 +64,7 @@ private:
   }
   // log events according to dso types
   std::array<MetricPerDsoType, kNbDsoEventTypes> _metrics;
+  uint64_t _backpopulate_count{0};
 };
 
 /**************

--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -20,8 +20,6 @@
 namespace ddprof {
 
 #define DSO_EVENT_TABLE(XX)                                                    \
-  XX(kUnhandledDso, "Unhandled")                                               \
-  XX(kUnwindFailure, "Failure")                                                \
   XX(kTargetDso, "Target")                                                     \
   XX(kNewDso, "New")
 

--- a/include/perf_ringbuffer.hpp
+++ b/include/perf_ringbuffer.hpp
@@ -21,8 +21,11 @@ struct RingBuffer {
   std::byte *data;
   void *base;
 
-  uint64_t *writer_pos;
-  uint64_t *reader_pos;
+  uint64_t *writer_pos;             // writer cursor
+  uint64_t *reader_pos;             // reader cursor
+  uint64_t intermediate_reader_pos; // intermediate_reader_pos > reader_pos,
+                                    // part read by reader but not yet reflected
+                                    // to the writer
 
   // only used for MPSCRingBuffer
   SpinLock *spinlock;

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -354,6 +354,12 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
                                  ->envname("DD_PROFILING_DISABLE_SYMBOLIZATION")
                                  ->group(""));
 
+  extended_options.push_back(
+      app.add_flag("--reorder-events,!--no-reorder-events", reorder_events,
+                   "Reorder perf events by timestamp")
+          ->default_val(false)
+          ->envname("DD_PROFILING_REORDER_EVENTS")
+          ->group(""));
   // Parse
   CLI11_PARSE(app, argc, argv);
 

--- a/src/ddprof_context_lib.cc
+++ b/src/ddprof_context_lib.cc
@@ -91,6 +91,7 @@ void copy_cli_values(const DDProfCLI &ddprof_cli, DDProfContext &ctx) {
   ctx.params.fault_info = ddprof_cli.fault_info;
   ctx.params.remote_symbolization = ddprof_cli.remote_symbolization;
   ctx.params.disable_symbolization = ddprof_cli.disable_symbolization;
+  ctx.params.reorder_events = ddprof_cli.reorder_events;
 
   ctx.params.initial_loaded_libs_check_delay =
       ddprof_cli.initial_loaded_libs_check_delay;

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -38,14 +38,10 @@ namespace ddprof {
 
 namespace {
 
-const DDPROF_STATS s_cycled_stats[] = {STATS_UNWIND_AVG_TIME,
-                                       STATS_AGGREGATION_AVG_TIME,
-                                       STATS_EVENT_COUNT,
-                                       STATS_EVENT_LOST,
-                                       STATS_EVENT_OUT_OF_ORDER,
-                                       STATS_SAMPLE_COUNT,
-                                       STATS_DSO_UNHANDLED_SECTIONS,
-                                       STATS_TARGET_CPU_USAGE};
+const DDPROF_STATS s_cycled_stats[] = {
+    STATS_UNWIND_AVG_TIME, STATS_AGGREGATION_AVG_TIME, STATS_EVENT_COUNT,
+    STATS_EVENT_LOST,      STATS_EVENT_OUT_OF_ORDER,   STATS_SAMPLE_COUNT,
+    STATS_TARGET_CPU_USAGE};
 
 const long k_clock_ticks_per_sec = sysconf(_SC_CLK_TCK);
 
@@ -133,8 +129,6 @@ DDRes worker_update_stats(DDProfWorkerContext &worker_context,
       (k_clock_ticks_per_sec * elapsed_nsec);
   ddprof_stats_set(STATS_PROFILER_RSS, get_page_size() * procstat->rss);
   ddprof_stats_set(STATS_PROFILER_CPU_USAGE, millicores);
-  ddprof_stats_set(STATS_DSO_UNHANDLED_SECTIONS,
-                   dso_hdr.stats().sum_event_metric(DsoStats::kUnhandledDso));
   ddprof_stats_set(STATS_DSO_NEW_DSO,
                    dso_hdr.stats().sum_event_metric(DsoStats::kNewDso));
   ddprof_stats_set(STATS_DSO_SIZE, dso_hdr.get_nb_dso());

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -636,7 +636,7 @@ void ddprof_pr_exit(DDProfContext &ctx, const perf_event_exit *ext,
 void ddprof_pr_clear_live_allocation(DDProfContext &ctx,
                                      const ClearLiveAllocationEvent *event,
                                      int watcher_pos) {
-  LG_DBG("<%d>(CLEAR LIVE)%d", watcher_pos, event->sample_id.pid);
+  LG_NTC("<%d>(CLEAR LIVE)%d", watcher_pos, event->sample_id.pid);
   ctx.worker_ctx.live_allocation.clear_pid_for_watcher(watcher_pos,
                                                        event->sample_id.pid);
 }

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -132,6 +132,8 @@ DDRes worker_update_stats(DDProfWorkerContext &worker_context,
   ddprof_stats_set(STATS_DSO_NEW_DSO,
                    dso_hdr.stats().sum_event_metric(DsoStats::kNewDso));
   ddprof_stats_set(STATS_DSO_SIZE, dso_hdr.get_nb_dso());
+  ddprof_stats_set(STATS_BACKPOPULATE_COUNT,
+                   dso_hdr.stats().backpopulate_count());
   ddprof_stats_set(
       STATS_UNMATCHED_DEALLOCATION_COUNT,
       worker_context.live_allocation.get_nb_unmatched_deallocations());

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -439,6 +439,7 @@ bool DsoHdr::pid_backpopulate(PidMapping &pid_mapping, pid_t pid,
   if (bp_state.perm != kAllowed) { // retry
     return false;
   }
+  _stats.incr_backpopulate_count();
   nb_elts_added = 0;
   LG_DBG("[DSO] Backpopulating PID %d", pid);
   bp_state.last_backpopulate_time = PerfClock::now();

--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -298,6 +298,10 @@ int start_profiler_internal(std::unique_ptr<DDProfContext> ctx,
   }
 
   ctx->perf_clock_source = PerfClock::init();
+  if (ctx->perf_clock_source == PerfClockSource::kNoClock) {
+    // If we can't use perf clock, we cannot reorder events
+    ctx->params.reorder_events = false;
+  }
 
   if (CPU_COUNT(&ctx->params.cpu_affinity) > 0) {
     LG_DBG("Setting affinity to 0x%s",

--- a/src/perf_mainloop.cc
+++ b/src/perf_mainloop.cc
@@ -24,6 +24,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <poll.h>
+#include <queue>
 #include <sys/mman.h>
 #include <sys/signalfd.h>
 #include <sys/socket.h>
@@ -31,15 +32,16 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <variant>
 
 namespace ddprof {
 namespace {
 
 pid_t g_child_pid = 0;
-bool g_termination_requested = false;
+std::atomic<bool> g_termination_requested{false};
 
 void handle_signal(int /*unused*/) {
-  g_termination_requested = true;
+  g_termination_requested.store(true, std::memory_order::relaxed);
 
   // forwarding signal to child
   if (g_child_pid) {
@@ -72,31 +74,34 @@ void modify_sigprocmask(int how) {
 
 DDRes spawn_workers(PersistentWorkerState *persistent_worker_state,
                     bool *is_worker) {
-  pid_t child_pid = 0;
   *is_worker = false;
 
   DDRES_CHECK_FWD(install_signal_handler());
 
-  // block signals to avoid a race condition between checking
-  // g_termination_requested flag and fork/waitpid
-  modify_sigprocmask(SIG_BLOCK);
-
   // child immediately exits the while() and returns from this function, whereas
   // the parent stays here forever, spawning workers.
-  while (!g_termination_requested && (child_pid = fork())) {
-    g_child_pid = child_pid;
-    {
-      LG_NTC("Created child %d", child_pid);
-      // unblock signals, we can now forward signals to child
-      modify_sigprocmask(SIG_UNBLOCK);
-      waitpid(g_child_pid, nullptr, 0);
+  while (!g_termination_requested.load(std::memory_order::relaxed)) {
+
+    // block signals to avoid a race condition between checking
+    // g_termination_requested flag and fork/waitpid
+    modify_sigprocmask(SIG_BLOCK);
+    g_child_pid = fork();
+    // unblock signals
+    modify_sigprocmask(SIG_UNBLOCK);
+
+    if (!g_child_pid) {
+      // worker process
+      *is_worker = true;
+      break;
     }
 
+    LG_NTC("Created child %d", g_child_pid);
+    waitpid(g_child_pid, nullptr, 0);
     g_child_pid = 0;
 
     // Harvest the exit state of the child process.  We will always reset it
     // to false so that a child who segfaults or exits erroneously does not
-    // cause a pointless loop of spawning
+    // cause a pointless loop of spawning.
     if (!persistent_worker_state->restart_worker) {
       if (persistent_worker_state->errors) {
         DDRES_RETURN_WARN_LOG(DD_WHAT_MAINLOOP, "Stop profiling");
@@ -107,7 +112,6 @@ DDRes spawn_workers(PersistentWorkerState *persistent_worker_state,
     LG_NFO("Refreshing worker process");
   }
 
-  *is_worker = child_pid == 0;
   return {};
 }
 
@@ -150,49 +154,125 @@ ReplyMessage create_reply_message(const DDProfContext &ctx) {
   return reply;
 }
 
-void pollfd_setup(const PEventHdr *pevent_hdr, struct pollfd *pfd,
-                  int *pfd_len) {
-  *pfd_len = pevent_hdr->size;
-  const PEvent *pes = pevent_hdr->pes;
+void pollfd_setup(std::span<PEvent> pes, struct pollfd *pfd) {
   // Setup poll() to watch perf_event file descriptors
-  for (int i = 0; i < *pfd_len; ++i) {
+  for (size_t i = 0; i < pes.size(); ++i) {
     // NOTE: if fd is negative, it will be ignored
     pfd[i].fd = pes[i].fd;
     pfd[i].events = POLLIN;
   }
 }
 
-DDRes signalfd_setup(pollfd *pfd) {
-  sigset_t mask;
+struct EventWrapper {
+  const perf_event_header *event;
+  PerfClock::time_point timestamp;
+  int buffer_idx;
 
-  sigemptyset(&mask);
-  sigaddset(&mask, SIGINT);
-  sigaddset(&mask, SIGTERM);
+  friend bool operator>(const EventWrapper &lhs, const EventWrapper &rhs) {
+    return lhs.timestamp > rhs.timestamp;
+  }
+};
 
-  // no need to block signal, since we inherited sigprocmask from parent
-  int const sfd = signalfd(-1, &mask, 0);
-  DDRES_CHECK_ERRNO(sfd, DD_WHAT_WORKERLOOP_INIT, "Could not set signalfd");
+using EventQueue = std::priority_queue<EventWrapper, std::vector<EventWrapper>,
+                                       std::greater<EventWrapper>>;
 
-  pfd->fd = sfd;
-  pfd->events = POLLIN;
+DDRes worker_process_ring_buffers_ordered(std::span<PEvent> pes,
+                                          DDProfContext &ctx,
+                                          EventQueue &event_queue, bool drain) {
+  const std::chrono::microseconds kMaxSampleLatency{100};
+
+  auto now = PerfClock::now();
+  auto deadline =
+      drain ? PerfClock::time_point::max() : now + k_sample_default_wakeup;
+
+  while (!g_termination_requested.load(std::memory_order::relaxed) &&
+         now <= deadline) {
+    auto max_timestamp =
+        drain ? PerfClock::time_point::max() : now - kMaxSampleLatency;
+    int new_events = 0;
+
+    for (int i = 0; i < static_cast<int>(pes.size()); ++i) {
+      auto &rb = pes[i].rb;
+
+      while (true) {
+        const perf_event_header *event =
+            (rb.type == RingBufferType::kPerfRingBuffer)
+            ? perf_rb_read_event(rb)
+            : mpsc_rb_read_event(rb);
+
+        if (!event) {
+          break;
+        }
+
+        auto timestamp = perf_clock_time_point_from_timestamp(
+            hdr_time(event, ctx.watchers[pes[i].watcher_pos].sample_type));
+        event_queue.push({event, timestamp, i});
+        ++new_events;
+        if (timestamp > max_timestamp) {
+          break;
+        }
+
+        // Read only a single event from perf ring buffer
+        if (rb.type == RingBufferType::kPerfRingBuffer) {
+          break;
+        }
+      }
+    }
+
+    while (!event_queue.empty()) {
+      const auto &evt = event_queue.top();
+      if (evt.timestamp > max_timestamp) {
+        // the next event is too recent, stop processing
+        return {};
+      }
+      auto &pevent = pes[evt.buffer_idx];
+      auto res =
+          ddprof_worker_process_event(evt.event, pevent.watcher_pos, ctx);
+      if (!IsDDResOK(res)) {
+        return res;
+      }
+
+      auto &rb = pevent.rb;
+      if (rb.type == RingBufferType::kPerfRingBuffer) {
+        perf_rb_advance(rb);
+
+        const perf_event_header *new_event = perf_rb_read_event(rb);
+        if (new_event) {
+          // enqueue next event for the same ring buffer
+          auto timestamp = perf_clock_time_point_from_timestamp(hdr_time(
+              new_event, ctx.watchers[pevent.watcher_pos].sample_type));
+          event_queue.push({new_event, timestamp, evt.buffer_idx});
+        }
+      } else {
+        mpsc_rb_advance_if_possible(rb, evt.event);
+      }
+      event_queue.pop();
+    }
+
+    if (!new_events) {
+      // no new events were queued, stop processing
+      return {};
+    }
+
+    now = PerfClock::now();
+  }
+
   return {};
 }
 
 inline DDRes
-worker_process_ring_buffers(PEvent *pes, int pe_len, DDProfContext &ctx,
-                            std::chrono::steady_clock::time_point *now,
-                            const int *ring_buffer_start_idx) {
+worker_process_ring_buffers(std::span<PEvent> pes, DDProfContext &ctx,
+                            std::chrono::steady_clock::time_point *now) {
   // While there are events to process, iterate through them
   // while limiting time spent in loop to at most k_sample_default_wakeup
   auto loop_start = std::chrono::steady_clock::now();
   std::chrono::steady_clock::time_point local_now;
 
-  int start_idx = *ring_buffer_start_idx;
   bool events;
   do {
     events = false;
-    for (int i = start_idx; i < pe_len; ++i) {
-      auto &ring_buffer = pes[i].rb;
+    for (auto &pevent : pes) {
+      auto &ring_buffer = pevent.rb;
       if (ring_buffer.type == RingBufferType::kPerfRingBuffer) {
         PerfRingBufferReader reader(&ring_buffer);
 
@@ -200,7 +280,7 @@ worker_process_ring_buffers(PEvent *pes, int pe_len, DDProfContext &ctx,
         while (!buffer.empty()) {
           const auto *hdr =
               reinterpret_cast<const perf_event_header *>(buffer.data());
-          DDRes res = ddprof_worker_process_event(hdr, pes[i].watcher_pos, ctx);
+          DDRes res = ddprof_worker_process_event(hdr, pevent.watcher_pos, ctx);
 
           // Check for processing error
           if (IsDDResNotOK(res)) {
@@ -217,7 +297,7 @@ worker_process_ring_buffers(PEvent *pes, int pe_len, DDProfContext &ctx,
              buffer = reader.read_sample()) {
           const auto *hdr =
               reinterpret_cast<const perf_event_header *>(buffer.data());
-          DDRes res = ddprof_worker_process_event(hdr, pes[i].watcher_pos, ctx);
+          DDRes res = ddprof_worker_process_event(hdr, pevent.watcher_pos, ctx);
 
           // Check for processing error
           if (IsDDResNotOK(res)) {
@@ -232,7 +312,6 @@ worker_process_ring_buffers(PEvent *pes, int pe_len, DDProfContext &ctx,
       // PerfRingBufferReader destructor takes care of advancing ring buffer
       // read position
     }
-    start_idx = 0;
     local_now = std::chrono::steady_clock::now();
   } while (events && (local_now - loop_start) < k_sample_default_wakeup);
 
@@ -244,14 +323,10 @@ DDRes worker_loop(DDProfContext &ctx, const WorkerAttr *attr,
                   PersistentWorkerState *persistent_worker_state) {
 
   // Setup poll() to watch perf_event file descriptors
-  int const pe_len = ctx.worker_ctx.pevent_hdr.size;
-  // one extra slot in pfd to accommodate for signal fd
-  pollfd poll_fds[k_max_nb_perf_event_open + 1];
-  int pfd_len = 0;
-  pollfd_setup(&ctx.worker_ctx.pevent_hdr, poll_fds, &pfd_len);
-
-  DDRES_CHECK_FWD(signalfd_setup(&poll_fds[pfd_len]));
-  int const signal_pos = pfd_len++;
+  pollfd poll_fds[k_max_nb_perf_event_open];
+  std::span const pevents{ctx.worker_ctx.pevent_hdr.pes,
+                          ctx.worker_ctx.pevent_hdr.size};
+  pollfd_setup(pevents, poll_fds);
 
   WorkerServer const server =
       start_worker_server(ctx.socket_fd.get(), create_reply_message(ctx));
@@ -260,20 +335,11 @@ DDRes worker_loop(DDProfContext &ctx, const WorkerAttr *attr,
   defer { attr->finish_fun(ctx); };
   DDRES_CHECK_FWD(attr->init_fun(ctx, persistent_worker_state));
 
-  // ring_buffer_start_idx serves to indicate at which ring buffer index
-  // processing loop should restart if it was interrupted in the middle of the
-  // loop by timeout.
-  // Not used yet, because currently we process all ring buffers or none
-  int const ring_buffer_start_idx = 0;
-  bool stop = false;
-
+  EventQueue event_queue;
   // Worker poll loop
-  while (!stop) {
-    // Convenience structs
-    PEvent *pes = ctx.worker_ctx.pevent_hdr.pes;
-
+  while (!g_termination_requested.load(std::memory_order::relaxed)) {
     int const n =
-        poll(poll_fds, pfd_len,
+        poll(poll_fds, pevents.size(),
              std::chrono::milliseconds{k_sample_default_wakeup}.count());
 
     // If there was an issue, return and let the caller check errno
@@ -282,32 +348,38 @@ DDRes worker_loop(DDProfContext &ctx, const WorkerAttr *attr,
     }
     DDRES_CHECK_ERRNO(n, DD_WHAT_POLLERROR, "poll failed");
 
-    if (poll_fds[signal_pos].revents & POLLIN) {
-      LG_NFO("Received termination signal");
-      break;
-    }
-
-    for (int i = 0; i < pe_len; ++i) {
+    bool stop = false;
+    for (size_t i = 0; i < pevents.size(); ++i) {
       pollfd const &pfd = poll_fds[i];
       if (pfd.revents & POLLHUP) {
         stop = true;
-      } else if (pfd.revents & POLLIN && pes[i].custom_event) {
+      } else if (pfd.revents & POLLIN && pevents[i].custom_event) {
         // for custom ring buffer, need to read from eventfd to flush POLLIN
         // status
         uint64_t count;
-        DDRES_CHECK_ERRNO(read(pes[i].fd, &count, sizeof(count)),
+        DDRES_CHECK_ERRNO(read(pevents[i].fd, &count, sizeof(count)),
                           DD_WHAT_PERFRB, "Failed to read from evenfd");
       }
     }
 
     std::chrono::steady_clock::time_point now;
-    DDRES_CHECK_FWD(worker_process_ring_buffers(pes, pe_len, ctx, &now,
-                                                &ring_buffer_start_idx));
+    if (ctx.params.reorder_events) {
+      DDRES_CHECK_FWD(
+          worker_process_ring_buffers_ordered(pevents, ctx, event_queue, stop));
+      now = std::chrono::steady_clock::now();
+    } else {
+      DDRES_CHECK_FWD(worker_process_ring_buffers(pevents, ctx, &now));
+    }
+
     DDRES_CHECK_FWD(ddprof_worker_maybe_export(ctx, now));
 
     if (ctx.worker_ctx.persistent_worker_state->restart_worker) {
       // return directly no need to do a final export
       return {};
+    }
+
+    if (stop) {
+      break;
     }
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -452,6 +452,14 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "SanitizedDebug")
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
   add_test(
+    NAME simple_malloc-with-event-reordering
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/simple_malloc-ut.sh
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+  set_tests_properties(simple_malloc-with-event-reordering
+                       PROPERTIES ENVIRONMENT "DD_PROFILING_REORDER_EVENTS=1")
+
+  add_test(
     NAME check_no_tls
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/check_no_tls-ut.sh
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
# What does this PR do?

Reorder events from ring buffers before processing them.
Events in each perf ring buffer are already ordered by timestamp. For MPSC ring buffers, there is no such guarantee.
The strategy is to dequeue events from ring buffers and push them in a priority queue, ordered by timestamp. And then process this priority queue.
When a ring buffer is empty, we cannot be sure that a new event with a timestamp less than a previously enqueued event will not be added to the ring buffer in the future.
That's why we arbitrarily define a maximum latency `kMaxSampleLatency` between the timestamp of an event and the time it appears in the ring buffer, and we process events with timestamps up to (now - kMaxSampleLatency).

For MPSC ring buffers, we dequeue events and push them into the priority queue until we reach an event with a timestamp greater than (now - kMaxSampleLatency) or the ring buffer is empty. Note that when an event with a timestamp greater than (now - kMaxSampleLatency) is dequeued, it is still pushed in the priority_queue.

For perf ring buffers, we ensure that at anytime at most one event from each ring buffer is in the priority queue. This ensures that events with identical timestamps in a ring buffer are processed in the same order as in
the ring buffer (priority queue is not stable, therefore pushing events with identical timestamps might permute them) and this also makes advancing the reader cursor position in the ring buffer easier since know that only one event has been read, we can just bump the reader cursor to the last read position.

When an event from a perf ring buffer is dequeued fron the priority queue, we advance the reader cursor position in the ring buffer to free the slot for the writer, and attempt to read the next event from the ring buffer if not empty.

When an event from a MPSC ring buffer is dequeued from the priority queue, we try to advance the reader cursor position in the ring buffer to free the slot for the writer. Since events might be out of order for this ring buffer, advancing is done by marking processed events as discarded and bumping the reader position until empty or we reach the first non-discarded event.

# Motivation

Avoid inconsistencies when processing events out of order.