### PR TITLE
Fix live heap profiling when allocation profiling is also enabled

### DIFF
--- a/src/perf_mainloop.cc
+++ b/src/perf_mainloop.cc
@@ -140,8 +140,8 @@ ReplyMessage create_reply_message(const DDProfContext &ctx) {
       reply.loaded_libs_check_interval_ms =
           ctx.params.loaded_libs_check_interval.count();
 
-      if (ctx.watchers[alloc_watcher_idx].aggregation_mode ==
-          EventAggregationMode::kLiveSum) {
+      if (Any(ctx.watchers[alloc_watcher_idx].aggregation_mode &
+              EventAggregationMode::kLiveSum)) {
         reply.allocation_flags |= ReplyMessage::kLiveSum;
       }
     }


### PR DESCRIPTION
# What does this PR do?

When both allocation and live heap profiling were enabled, tracking of deallocations was not requested not the library 😞 
