### PR TITLE
[PROF-9408] Fix pid mode to attach to all process threads

### DIFF
--- a/include/ddres_list.hpp
+++ b/include/ddres_list.hpp
@@ -39,7 +39,7 @@ enum { DD_COMMON_START_RANGE = 1000, DD_NATIVE_START_RANGE = 2000 };
   X(POLLTIMEOUT, "timeout when polling perf events")                           \
   X(POLLERROR, "Unknown poll error")                                           \
   X(POLLHANGUP, "perf event file descriptor hang up")                          \
-  X(PROCSTATE, "error when retrieveing procstate")                             \
+  X(PROCSTATE, "error when retrieving process state")                          \
   X(PPROF, "error in pprof manipulations")                                     \
   X(STATSD, "statsd interface")                                                \
   X(DDPROF_STATS, "error in stats module")                                     \

--- a/include/pevent.hpp
+++ b/include/pevent.hpp
@@ -26,6 +26,9 @@ struct PEvent {
   bool custom_event; // true if custom event (not handled by perf, eg. memory
                      // allocations)
   RingBuffer rb;     // metadata and buffers for processing perf ringbuffer
+  std::vector<int>
+      sub_fds; // perf FDs of other events outputting to the same ring buffer
+               // (eg. perf events for other process threads in PID mode)
 };
 
 struct PEventHdr {

--- a/include/pevent_lib.hpp
+++ b/include/pevent_lib.hpp
@@ -9,13 +9,15 @@
 #include "ddres_def.hpp"
 #include "pevent.hpp"
 
+#include <span>
+
 namespace ddprof {
 
 /// Sets initial state for every pevent in the pevent_hdr
 void pevent_init(PEventHdr *pevent_hdr);
 
 /// Setup perf event according to requested watchers.
-DDRes pevent_open(DDProfContext *ctx, pid_t pid, int num_cpu,
+DDRes pevent_open(DDProfContext *ctx, std::span<pid_t> pids, int num_cpu,
                   PEventHdr *pevent_hdr);
 
 /// Setup mmap buffers according to content of peventhdr
@@ -28,7 +30,7 @@ int pevent_compute_min_mmap_order(int min_buffer_size_order,
                                   unsigned min_number_samples);
 
 /// Setup watchers = setup mmap + setup perfevent
-DDRes pevent_setup(DDProfContext &ctx, pid_t pid, int num_cpu,
+DDRes pevent_setup(DDProfContext &ctx, std::span<pid_t> pids, int num_cpu,
                    PEventHdr *pevent_hdr);
 
 /// Call ioctl PERF_EVENT_IOC_ENABLE on available file descriptors

--- a/test/pevent-ut.cc
+++ b/test/pevent-ut.cc
@@ -26,7 +26,7 @@ TEST(PeventTest, setup_cleanup) {
   pid_t mypid = getpid();
   mock_ddprof_context(&ctx);
   pevent_init(&pevent_hdr);
-  DDRes res = pevent_setup(ctx, mypid, get_nprocs(), &pevent_hdr);
+  DDRes res = pevent_setup(ctx, {&mypid, 1}, get_nprocs(), &pevent_hdr);
   ASSERT_TRUE(IsDDResOK(res));
   ASSERT_TRUE(pevent_hdr.size == static_cast<unsigned>(get_nprocs()));
   res = pevent_cleanup(&pevent_hdr);


### PR DESCRIPTION
# What does this PR do?

In pid mode, attach to all process threads by doing a perf_event_open for each (tid,cpu) combination. For a given cpu, only fd from the first tid will be mmapped, output for fds from other tids will be redirected to the first one.
