### PR TITLE
Inlined functions

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -44,6 +44,10 @@ Profiling settings:
   -g,--global Excludes: command_line --pid
                               Instrument all processes.
                               Requires specific capabilities or a perf_event_paranoid value of less than 1.
+  -I,--inlined_functions BOOLEAN [0] 
+                              Report inlined functions in call stacks.
+                              This is possible if debug sections are available.
+                              This can have performance impacts for the profiler.
   -t,--timeline (Env:DD_PROFILING_TIMELINE_ENABLE)
                               Enables Timeline view in the Datadog UI.
                               Works by adding timestmaps to certain events.

--- a/include/ddprof_cli.hpp
+++ b/include/ddprof_cli.hpp
@@ -41,6 +41,7 @@ public:
   // Profiling options
   int pid{0};
   bool global{false};
+  bool inlined_functions{false};
   std::chrono::seconds upload_period;
   unsigned worker_period; // worker_period
   std::vector<std::string> events;

--- a/include/ddprof_context.hpp
+++ b/include/ddprof_context.hpp
@@ -21,6 +21,7 @@ namespace ddprof {
 struct DDProfContext {
   struct {
     bool enable{true};
+    bool inlined_functions{false};
     std::chrono::seconds upload_period{};
     bool fault_info{true};
     int nice{-1};

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -163,7 +163,12 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
       ->group("Profiling settings")
       ->excludes(pid_opt)
       ->excludes(exec_option);
-
+  app.add_option("--inlined_functions,-I", inlined_functions,
+                 "Report inlined functions in call stacks.\n"
+                 "This is possible if debug sections are available.\n"
+                 "This can have performance impacts for the profiler.")
+      ->group("Profiling settings")
+      ->default_val(false);
   app.add_flag("--timeline,-t", timeline,
                "Enables Timeline view in the Datadog UI.\n"
                "Works by adding timestmaps to certain events.")
@@ -483,6 +488,7 @@ void DDProfCLI::print() const {
   if (!enable) {
     PRINT_NFO("  - enable: %s", enable ? "true" : "false");
   }
+  PRINT_NFO("  - inlined_functions: %s", inlined_functions ? "true" : "false");
   if (!cpu_affinity.empty()) {
     PRINT_NFO("  - cpu_affinity: %s", cpu_affinity.c_str());
   }

--- a/src/ddprof_context_lib.cc
+++ b/src/ddprof_context_lib.cc
@@ -72,6 +72,7 @@ void copy_cli_values(const DDProfCLI &ddprof_cli, DDProfContext &ctx) {
     ctx.params.pid = ddprof_cli.pid;
   }
   ctx.params.upload_period = ddprof_cli.upload_period;
+  ctx.params.inlined_functions = ddprof_cli.inlined_functions;
   // todo : naming ?
   ctx.params.worker_period = ddprof_cli.worker_period;
   // Advanced

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -368,7 +368,7 @@ DDRes worker_library_init(DDProfContext &ctx,
     ctx.worker_ctx.user_tags =
         new UserTags(ctx.params.tags, ctx.params.num_cpu);
     ctx.worker_ctx.symbolizer = new ddprof::Symbolizer(
-        ctx.params.disable_symbolization,
+        ctx.params.inlined_functions, ctx.params.disable_symbolization,
         ctx.params.remote_symbolization ? Symbolizer::k_elf
                                         : Symbolizer::k_process);
 

--- a/src/symbolizer.cc
+++ b/src/symbolizer.cc
@@ -66,7 +66,8 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
     it->second._visited = true;
     demangled_names = &(it->second._demangled_names);
   } else {
-    auto pair = _symbolizer_map.emplace(file_id, SymbolizerWrapper(elf_src));
+    auto pair = _symbolizer_map.emplace(
+        file_id, SymbolizerWrapper(elf_src, inlined_functions));
     assert(pair.second);
     if (!pair.second) {
       DDRES_RETURN_ERROR_LOG(DD_WHAT_SYMBOLIZER,


### PR DESCRIPTION
# What does this PR do?

Add a flag to report inlined functions in call stacks

# Motivation

This is requested by Rust users.

# Additional Notes

This requires this PR first
https://github.com/DataDog/ddprof/pull/390

# How to test the change?

There is a test in prof-correctness that I will update.