### PR TITLE
[PROF-9088] Force backpopulate upon worker start in PID mode

### DIFF
--- a/include/ddprof_context.hpp
+++ b/include/ddprof_context.hpp
@@ -45,6 +45,7 @@ struct DDProfContext {
   } params;
 
   ddprof::UniqueFd socket_fd;
+  bool backpopulate_pid_upon_start{false};
   PerfClockSource perf_clock_source{PerfClockSource::kNoClock};
   std::vector<PerfWatcher> watchers;
   ExporterInput exp_input;

--- a/src/exe/main.cc
+++ b/src/exe/main.cc
@@ -349,6 +349,9 @@ int start_profiler_internal(std::unique_ptr<DDProfContext> ctx,
     }
   }
 
+  // Force a backpopulate upon worker startup if we are in PID mode
+  ctx->backpopulate_pid_upon_start = !in_wrapper_mode && ctx->params.pid > 0;
+
   LG_NTC("Starting profiler");
 
   maybe_slowdown_startup();


### PR DESCRIPTION
# What does this PR do?

Force backpopulate upon worker start in PID mode.

# Motivation

In PID mode (or in library mode, since it is implemented with PID mode), profiler will not receive mmap events since process is already started when profiler starts. This can cause issues for short lived processes that may have already  exited when profiler will attempt a backpopulate upon receiving first event.
By forcing a backpopulate upon start, we ensure that profiler has mapping information as soon as possible.
