### PR TITLE
Remove code locations by default

### DIFF
--- a/include/symbolizer.hpp
+++ b/include/symbolizer.hpp
@@ -84,12 +84,6 @@ public:
                         const MapInfo &map_info,
                         std::span<ddog_prof_Location> locations,
                         unsigned &write_index, BlazeResultsWrapper &results);
-  static void free_session_results(BlazeResultsWrapper &results) {
-    for (auto &result : results.blaze_results) {
-      blaze_result_free(result);
-      result = nullptr;
-    }
-  }
   int remove_unvisited();
   void reset_unvisited_flag();
 
@@ -114,14 +108,14 @@ private:
     explicit BlazeSymbolizerWrapper(std::string elf_src, bool inlined_fns)
         : opts(create_opts(inlined_fns)),
           symbolizer(blaze_symbolizer_new_opts(&opts)),
-          elf_src(std::move(elf_src)) {}
+          elf_src(std::move(elf_src)), use_debug(inlined_fns) {}
 
     blaze_symbolizer_opts opts;
     std::unique_ptr<blaze_symbolizer, BlazeSymbolizerDeleter> symbolizer;
     ddprof::HeterogeneousLookupStringMap<std::string> demangled_names;
     std::string elf_src;
     bool visited{true};
-    bool use_debug{true};
+    bool use_debug;
   };
 
   BlazeSymbolizerWrapper &get_symbolizer(FileInfoId_t file_id,

--- a/src/symbolizer.cc
+++ b/src/symbolizer.cc
@@ -39,7 +39,6 @@ void Symbolizer::reset_unvisited_flag() {
 
 Symbolizer::BlazeSymbolizerWrapper &
 Symbolizer::get_symbolizer(FileInfoId_t file_id, const std::string &elf_src) {
-  ;
   if (auto it = _symbolizer_map.find(file_id); it != _symbolizer_map.end()) {
     return it->second;
   }


### PR DESCRIPTION
# What does this PR do?

There seems to be an excessive RSS usage with the usage of debug information. This is an experiment to see what is the cost of debug information with blazesym.

# Motivation

Understand the cost of debug information.

# Additional Notes

The Inlinie feature still allows to access code location feature.

# How to test the change?

The aim is to see what this yields in staging applications.