### PR TITLE
Jitdump error on replaced element

### DIFF
--- a/src/runtime_symbol_lookup.cc
+++ b/src/runtime_symbol_lookup.cc
@@ -83,12 +83,12 @@ bool RuntimeSymbolLookup::insert_or_replace(std::string_view symbol,
            code_load.code_addr, code_load.code_size + code_load.code_addr);
 #endif
     if (symbol_table[existing]._demangled_name == symbol) {
-      // nothing to do (unlikely size would change ?)
+      find_res.first->second.set_end(address + code_size - 1);
     } else {
       // remove current element (as start can be different)
       symbol_map.erase(find_res.first);
-      symbol_map.emplace(
-          address, SymbolSpan(address + code_size - 1, symbol_table.size()));
+      symbol_map.emplace(address,
+                         SymbolSpan(address + code_size - 1, existing));
       symbol_table[existing]._demangled_name = symbol;
       symbol_table[existing]._symname = symbol;
     }


### PR DESCRIPTION
# What does this PR do?

The index used was invalid, which could lead to a memory corruption

# Motivation

Avoiding a crash in dotnet JIT dump reads.

# Additional Notes

NA

# How to test the change?

I will think about how to improve JITDump coverage.