### PR TITLE
Virtual frame adjustement - Filename only

### DIFF
--- a/src/base_frame_symbol_lookup.cc
+++ b/src/base_frame_symbol_lookup.cc
@@ -9,6 +9,7 @@
 #include "logger.hpp"
 
 #include <absl/strings/str_cat.h>
+#include <filesystem>
 
 namespace ddprof {
 
@@ -35,8 +36,10 @@ BaseFrameSymbolLookup::insert_bin_symbol(pid_t pid, SymbolTable &symbol_table,
     std::string exe_name;
     bool const exe_found = dso_hdr.find_exe_name(pid, exe_name);
     if (exe_found) {
+      const std::filesystem::path path(exe_name);
+      const std::string base_name = path.filename().string();
       symbol_idx = symbol_table.size();
-      symbol_table.emplace_back(Symbol({}, {}, 0, exe_name));
+      symbol_table.emplace_back(Symbol({}, base_name, 0, exe_name));
       _bin_map.insert({pid, symbol_idx});
     }
   }

--- a/src/dso_symbol_lookup.cc
+++ b/src/dso_symbol_lookup.cc
@@ -11,6 +11,7 @@
 
 #include <absl/strings/str_format.h>
 #include <algorithm>
+#include <filesystem>
 
 namespace ddprof {
 
@@ -25,7 +26,7 @@ Symbol symbol_from_dso(ElfAddress_t normalized_addr, const Dso &dso,
   // address that means something for our user (addr)
   std::string const dso_dbg_str = normalized_addr
       ? absl::StrFormat("[%#x:%s]", normalized_addr, addr_type)
-      : "";
+      : std::filesystem::path(dso.format_filename()).filename().string();
   return {dso_dbg_str, dso_dbg_str, 0, dso.format_filename()};
 }
 } // namespace


### PR DESCRIPTION
# What does this PR do?

Adjust binary and DSO frames to only keep the filename instead of the full path This makes the flamegraphs easier to read

# Motivation

Consistency with Otel profiler

# Additional Notes

NA

# How to test the change?

This is mostly a cosmetic change. The top frame for instance does not include the full path.
Prof correctness could be used for this.

![image](https://github.com/DataDog/ddprof/assets/74836499/50114fe8-e7de-491b-bc5b-f0c1518eb1f7)
