### PR TITLE
configuration update for inlined functions

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -44,7 +44,7 @@ Profiling settings:
   -g,--global Excludes: command_line --pid
                               Instrument all processes.
                               Requires specific capabilities or a perf_event_paranoid value of less than 1.
-  -I,--inlined_functions,--inlined-functions BOOLEAN [0] 
+  -I,--inlined_functions,--inlined-functions BOOLEAN [0]  (Env:DD_PROFILING_INLINED_FUNCTIONS)
                               Report inlined functions in call stacks.
                               This is possible if debug sections are available.
                               This can have performance impacts for the profiler.

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -185,7 +185,8 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
                  "This is possible if debug sections are available.\n"
                  "This can have performance impacts for the profiler.")
       ->group("Profiling settings")
-      ->default_val(false);
+      ->default_val(false)
+      ->envname("DD_PROFILING_INLINED_FUNCTIONS");
   app.add_flag("--timeline,-t", timeline,
                "Enables Timeline view in the Datadog UI.\n"
                "Works by adding timestmaps to certain events.")


### PR DESCRIPTION
# What does this PR do?

Add an environment variable to allow the setting of the inlined functions setting 

# Motivation

A user wanted this to be possible 

# Additional Notes

NA

# How to test the change?

```
export DD_PROFILING_INLINED_FUNCTIONS=true
./ddprof --show_config -l notice ~/dd/bad-boggle-solver/build/src/BadBoggleSolver_run work 1000
```
