### PR TITLE
Default runtime-id tag

### DIFF
--- a/include/exporter_input.hpp
+++ b/include/exporter_input.hpp
@@ -21,7 +21,8 @@ struct ExporterInput {
   std::string url;             // url (can contain port and schema)
   std::string port; // port appended to the host IP (ignored in agentless)
   std::string debug_pprof_prefix; // local pprof prefix (debug)
-  bool do_export{true};           // prevent exports if needed (debug flag)
+  std::string runtime_id;
+  bool do_export{true}; // prevent exports if needed (debug flag)
   std::string_view user_agent{
       "ddprof"}; // ignored for now (override in shared lib)
   std::string_view language{"native"}; // appended to the tags (set to native)

--- a/include/uuid.hpp
+++ b/include/uuid.hpp
@@ -5,8 +5,20 @@
 
 #pragma once
 
+#include <array>
+#include <cstdint>
 #include <string>
 
-namespace dd {
-std::string GenerateUuidV4();
-}
+namespace ddprof {
+struct Uuid {
+  Uuid();
+  static constexpr int k_version_position = 12;
+  static constexpr int k_variant_position = 16;
+  static constexpr int k_version = 4;
+  [[nodiscard]] int get_version() const { return data[k_version_position]; }
+  [[nodiscard]] std::string to_string() const;
+  // We could make this smaller, as it is hexadecimal and 32 characters
+  // but we are keeping one byte per element for simplicity
+  std::array<uint8_t, 32> data;
+};
+} // namespace ddprof

--- a/include/uuid.hpp
+++ b/include/uuid.hpp
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#pragma once
+
+#include <string>
+
+namespace dd {
+std::string GenerateUuidV4();
+}

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -18,6 +18,7 @@
 #include "ddprof_defs.hpp"
 #include "ddres.hpp"
 #include "logger.hpp"
+#include "uuid.hpp"
 #include "version.hpp"
 
 #include <chrono>
@@ -294,6 +295,17 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
                      "A debug option to work without the Datadog agent.\n")
           ->group("")
           ->envname("DD_API_KEY"));
+  // In theory, the runtime_id should be read from tracing
+  // However the otel-tracers do not seem to provide this type of information
+  // To ensure timelines can be searched, we need to provide this
+  // Disclaimer: In full host, this does not really make sense.
+  //      There should be several runtime_ids
+  extended_options.push_back(
+      app.add_option("--runtime_id,--runtime-id", exporter_input.runtime_id,
+                     "Override the generated runtime_id.\n")
+          ->default_val(Uuid().to_string())
+          ->group("")
+          ->envname("DD_PROFILING_RUNTIME_ID"));
 
   extended_options.push_back(
       app.add_option("--cpu_affinity,--cpu-affinity", cpu_affinity,
@@ -474,6 +486,7 @@ void DDProfCLI::print() const {
   PRINT_NFO("  - host: %s", exporter_input.host.c_str());
   PRINT_NFO("  - port: %s", exporter_input.port.c_str());
   PRINT_NFO("  - do_export: %s", exporter_input.do_export ? "true" : "false");
+  PRINT_NFO("  - runtime_id: %s", exporter_input.runtime_id.c_str());
 
   if (!tags.empty()) {
     PRINT_NFO("Tags: %s", tags.c_str());

--- a/src/exporter/ddprof_exporter.cc
+++ b/src/exporter/ddprof_exporter.cc
@@ -132,6 +132,9 @@ DDRes fill_stable_tags(const UserTags *user_tags,
                                    exporter->_input.profiler_version));
   }
 
+  DDRES_CHECK_FWD(
+      add_single_tag(tags_exporter, "runtime-id", exporter->_input.runtime_id));
+
   for (const auto &el : user_tags->_tags) {
     DDRES_CHECK_FWD(add_single_tag(tags_exporter, el.first, el.second));
   }

--- a/src/uuid.cc
+++ b/src/uuid.cc
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include <random>
+#include <sstream>
+#include <vector>
+
+#include "uuid.hpp"
+
+namespace dd {
+
+// Copied from dd-trace-dotnet, and previously
+// copied from https://stackoverflow.com/a/60198074
+// We replace std::mt19937 by std::mt19937_64 so we can generate 64bits numbers instead of 32bits
+std::string GenerateUuidV4()
+{
+  static std::random_device rd;
+  static std::mt19937_64 gen(rd());
+  static std::uniform_int_distribution<> dis(0, 15);
+  static std::uniform_int_distribution<> dis2(8, 11);
+
+  std::stringstream ss;
+  ss << std::hex;
+  for (auto i = 0; i < 8; i++)
+  {
+    ss << dis(gen);
+  }
+  ss << "-";
+  for (auto i = 0; i < 4; i++)
+  {
+    ss << dis(gen);
+  }
+  ss << "-4"; // according to the RFC, '4' is the 4 version
+  for (auto i = 0; i < 3; i++)
+  {
+    ss << dis(gen);
+  }
+  ss << "-";
+  ss << dis2(gen);
+  for (auto i = 0; i < 3; i++)
+  {
+    ss << dis(gen);
+  }
+  ss << "-";
+  for (auto i = 0; i < 12; i++)
+  {
+    ss << dis(gen);
+  }
+  return ss.str();
+}
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -156,6 +156,7 @@ add_unit_test(
   ../src/logger_setup.cc
   ../src/perf_watcher.cc
   ../src/presets.cc
+  ../src/uuid.cc
   ../src/tracepoint_config.cc
   ddprof_context-ut.cc
   LIBRARIES DDProf::Parser CLI11
@@ -370,6 +371,7 @@ add_unit_test(
   ../src/ddprof_cmdline_watcher.cc
   ../src/perf_watcher.cc
   ../src/tracepoint_config.cc
+  ../src/uuid.cc
   LIBRARIES DDProf::Parser CLI11)
 
 add_unit_test(pthread_tls-ut pthread_tls-ut.cc)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -392,6 +392,8 @@ add_unit_test(
 add_unit_test(ddprof_module_lib-ut ddprof_module_lib-ut.cc ../src/ddprof_module_lib.cc
               ../src/build_id.cc ../src/dso.cc LIBRARIES ${ELFUTILS_LIBRARIES})
 
+add_unit_test(uuid-ut ../src/uuid.cc ./uuid-ut.cc)
+
 add_benchmark(savecontext-bench savecontext-bench.cc ../src/lib/pthread_fixes.cc
               ../src/lib/savecontext.cc ../src/lib/saveregisters.cc LIBRARIES llvm-demangle)
 

--- a/test/uuid-ut.cc
+++ b/test/uuid-ut.cc
@@ -5,18 +5,28 @@
 
 #include <gtest/gtest.h>
 
+#include "loghandle.hpp"
 #include "uuid.hpp"
 
-TEST(Uuid, create) {
-  std::string uuid = dd::GenerateUuidV4();
+namespace ddprof {
+TEST(Uuid, simple_class) {
+  ddprof::LogHandle loghandle;
+  Uuid uuid;
+  std::string uuid_str = uuid.to_string();
+  LG_DBG("uuid: %s", uuid_str.c_str());
+  EXPECT_EQ(uuid.get_version(), 4);
   // Should be of the form
   // 07a931f2-c8b5-4527-a80a-b7405be05c68
-  EXPECT_EQ(uuid.size(), 36);
-  EXPECT_EQ(uuid[8], '-');
-  EXPECT_EQ(uuid[13], '-');
-  EXPECT_EQ(uuid[18], '-');
-  EXPECT_EQ(uuid[23], '-');
+  EXPECT_EQ(uuid_str.size(), 36);
+  EXPECT_EQ(uuid_str[8], '-');
+  EXPECT_EQ(uuid_str[13], '-');
+  EXPECT_EQ(uuid_str[14], '4');
+  EXPECT_TRUE(uuid_str[19] == '8' || uuid_str[19] == '9' ||
+              uuid_str[19] == 'a' || uuid_str[19] == 'b');
+  EXPECT_EQ(uuid_str[18], '-');
+  EXPECT_EQ(uuid_str[23], '-');
 
-  std::string uuid_2 = dd::GenerateUuidV4();
-  EXPECT_NE(uuid, uuid_2);
+  std::string uuid_2 = ddprof::Uuid().to_string();
+  EXPECT_NE(uuid.to_string(), uuid_2);
 }
+} // namespace ddprof

--- a/test/uuid-ut.cc
+++ b/test/uuid-ut.cc
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include <gtest/gtest.h>
+
+#include "uuid.hpp"
+
+TEST(Uuid, create) {
+  std::string uuid = dd::GenerateUuidV4();
+  // Should be of the form
+  // 07a931f2-c8b5-4527-a80a-b7405be05c68
+  EXPECT_EQ(uuid.size(), 36);
+  EXPECT_EQ(uuid[8], '-');
+  EXPECT_EQ(uuid[13], '-');
+  EXPECT_EQ(uuid[18], '-');
+  EXPECT_EQ(uuid[23], '-');
+
+  std::string uuid_2 = dd::GenerateUuidV4();
+  EXPECT_NE(uuid, uuid_2);
+}


### PR DESCRIPTION
# What does this PR do?

Provide a default `runtime-id` tag

# Motivation

Ensure that the timeline data can be discovered for native.

# Additional Notes

The `runtime_id` should come from tracing
When we do not find it, we should still generate a default `runtime-id`.

# How to test the change?

I have a minor test to check the format.
I did not add an end to end test for now.