### PR TITLE
Timeline ON by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.19)
 project(
   DDProf
   LANGUAGES C CXX
-  VERSION 0.17.1
+  VERSION 0.18.0
   DESCRIPTION "Datadog's native profiler for Linux")
 
 message(STATUS "Compiler ID: ${CMAKE_C_COMPILER_ID}")

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -47,10 +47,12 @@ Profiling settings:
   -I,--inlined_functions,--inlined-functions BOOLEAN [0]  (Env:DD_PROFILING_INLINED_FUNCTIONS)
                               Report inlined functions in call stacks.
                               This is possible if debug sections are available.
-                              This can have performance impacts for the profiler.
-  -t,--timeline (Env:DD_PROFILING_TIMELINE_ENABLE)
+                              Split debug information will be looked up if available.
+                              The option has performance impacts for the profiler.
+  --timeline,--no-timeline{false} [1]  (Env:DD_PROFILING_TIMELINE_ENABLE)
                               Enables Timeline view in the Datadog UI.
-                              Works by adding timestmaps to certain events.
+                              Timestamps are added to CPU samples captured by the profiler.
+                              
   -u,--upload_period,--upload-period UINT [59]  (Env:DD_PROFILING_UPLOAD_PERIOD)
                               Upload period for profiles (in seconds).
                               

--- a/include/ddprof_cli.hpp
+++ b/include/ddprof_cli.hpp
@@ -76,7 +76,7 @@ public:
   std::string socket_path;
   int pipefd_to_library{-1};
   bool continue_exec{false};
-  bool timeline{false};
+  bool timeline{true};
 
   // args
   std::vector<std::string> command_line;

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -184,14 +184,18 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
                  inlined_functions,
                  "Report inlined functions in call stacks.\n"
                  "This is possible if debug sections are available.\n"
-                 "This can have performance impacts for the profiler.")
+                 "Split debug information will be looked up if available.\n"
+                 "The option has performance impacts for the profiler.")
       ->group("Profiling settings")
       ->default_val(false)
       ->envname("DD_PROFILING_INLINED_FUNCTIONS");
-  app.add_flag("--timeline,-t", timeline,
-               "Enables Timeline view in the Datadog UI.\n"
-               "Works by adding timestmaps to certain events.")
+
+  app.add_flag(
+         "--timeline,!--no-timeline", timeline,
+         "Enables Timeline view in the Datadog UI.\n"
+         "Timestamps are added to CPU samples captured by the profiler.\n")
       ->group("Profiling settings")
+      ->default_val(true)
       ->envname("DD_PROFILING_TIMELINE_ENABLE");
 
   app.add_option<std::chrono::seconds, unsigned>(
@@ -498,6 +502,7 @@ void DDProfCLI::print() const {
   if (global) {
     PRINT_NFO("  - global: %s", global ? "true" : "false");
   }
+  PRINT_NFO("  - timeline: %s", timeline ? "true" : "false");
   if (!command_line.empty()) {
     std::string command_line_str = "[" + command_line[0];
     std::for_each(std::next(command_line.begin()), command_line.end(),
@@ -547,9 +552,6 @@ void DDProfCLI::print() const {
   }
   if (show_samples) {
     PRINT_NFO("  - show_samples: %s", show_samples ? "true" : "false");
-  }
-  if (timeline) {
-    PRINT_NFO("  - timeline: %s", timeline ? "true" : "false");
   }
   PRINT_NFO("  - fault_info: %s", fault_info ? "true" : "false");
 


### PR DESCRIPTION
# What does this PR do?

- Adjust timeline as ON by default
- bump version to 0.18.0

# Motivation

Ensure users discover the timeline feature

# Additional Notes

We should monitor the increase in memory usage in relenv

# How to test the change?

Prof-correctness can have some timestamp tests
