### PR TITLE
Ensure that logger context name is used instead of MYNAME

### DIFF
--- a/include/logger.hpp
+++ b/include/logger.hpp
@@ -78,18 +78,15 @@ bool LOG_open(int mode, const char *opts);
 
 // Formatted print to the ddprof logging facility
 // Log-print-Formatted with Level, Facility, and Name
-printflike(4, 5) void lprintfln(int lvl, int fac, const char *name,
-                                const char *fmt, ...);
+printflike(3, 4) void lprintfln(int lvl, int fac, const char *fmt, ...);
 
 // Same as above, but suppress printing if the level isn't high enough
 // O for optional
-printflike(4, 5) void olprintfln(int lvl, int fac, const char *name,
-                                 const char *fmt, ...);
+printflike(3, 4) void olprintfln(int lvl, int fac, const char *fmt, ...);
 
 // Same as the first, but with a single variadic arg instead of ...
 // V for variadic, as per libc's v*printf() functions
-void vlprintfln(int lvl, int fac, const char *name, const char *format,
-                va_list args);
+void vlprintfln(int lvl, int fac, const char *format, va_list args);
 
 // Setters for global logger context
 void LOG_setname(const char *name);
@@ -118,7 +115,7 @@ void LOG_set_logs_allowed_function(LogsAllowedCallback logs_allowed_function);
 #define LG_IF_LVL_OK(level, ...)                                               \
   do {                                                                         \
     if (unlikely(LOG_is_logging_enabled_for_level(level))) {                   \
-      olprintfln(ABS(level), -1, MYNAME, __VA_ARGS__);                         \
+      olprintfln(ABS(level), -1, __VA_ARGS__);                                 \
     }                                                                          \
   } while (false)
 

--- a/include/logger_setup.hpp
+++ b/include/logger_setup.hpp
@@ -11,7 +11,7 @@ namespace ddprof {
 inline constexpr auto kMaxLogPerSecForNonDebug = 100;
 
 void setup_logger(
-    const char *log_mode, const char *log_level,
+    const char *log_mode, const char *log_level, const char *name,
     uint64_t max_log_per_sec_for_non_debug = kMaxLogPerSecForNonDebug);
 
 } // namespace ddprof

--- a/src/ddprof_context_lib.cc
+++ b/src/ddprof_context_lib.cc
@@ -143,7 +143,8 @@ DDRes context_add_watchers(const DDProfCLI &ddprof_cli, DDProfContext &ctx) {
 } // namespace
 
 DDRes context_set(const DDProfCLI &ddprof_cli, DDProfContext &ctx) {
-  setup_logger(ddprof_cli.log_mode.c_str(), ddprof_cli.log_level.c_str());
+  setup_logger(ddprof_cli.log_mode.c_str(), ddprof_cli.log_level.c_str(),
+               MYNAME);
 
   copy_cli_values(ddprof_cli, ctx);
 

--- a/src/lib/dd_profiling.cc
+++ b/src/lib/dd_profiling.cc
@@ -132,9 +132,7 @@ std::string get_log_level() {
 void init_logger() {
   auto log_level = get_log_level();
   auto log_mode = get_log_mode();
-  setup_logger(log_mode.c_str(), log_level.c_str());
-
-  LOG_setname("ddprof-library");
+  setup_logger(log_mode.c_str(), log_level.c_str(), "ddprof-library");
 
   // Disable logging when allocations are not allowed
   LOG_set_logs_allowed_function([]() {

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -142,8 +142,7 @@ void LOG_setratelimit(uint64_t max_log_per_interval,
 // LOG_MSG_CAP compile-time parameter.  The accessible storage amount shall be
 // this region minus room for the following template:
 // `<XXX> MMM DD hh:mm:ss DDPROF[32768]: `  -- let's call this 38 chars
-void vlprintfln(int lvl, int fac, const char *name, const char *format,
-                va_list args) {
+void vlprintfln(int lvl, int fac, const char *format, va_list args) {
 
   char buf[LOG_MSG_CAP];
   ssize_t sz = -1;
@@ -157,9 +156,8 @@ void vlprintfln(int lvl, int fac, const char *name, const char *format,
   if (fac == -1) {
     fac = log_ctx.facility;
   }
-  if (!name || !*name) {
-    name = !log_ctx.name.empty() ? log_ctx.name.c_str() : name_default;
-  }
+  const char *name =
+      !log_ctx.name.empty() ? log_ctx.name.c_str() : name_default;
 
   // Sanity checks
   if (log_ctx.fd < 0) {
@@ -233,18 +231,18 @@ void vlprintfln(int lvl, int fac, const char *name, const char *format,
 }
 
 // NOLINTNEXTLINE(cert-dcl50-cpp)
-void olprintfln(int lvl, int fac, const char *name, const char *fmt, ...) {
+void olprintfln(int lvl, int fac, const char *fmt, ...) {
   va_list args;
   va_start(args, fmt);
-  vlprintfln(lvl, fac, name, fmt, args);
+  vlprintfln(lvl, fac, fmt, args);
   va_end(args);
 }
 
 // NOLINTNEXTLINE(cert-dcl50-cpp)
-void lprintfln(int lvl, int fac, const char *name, const char *fmt, ...) {
+void lprintfln(int lvl, int fac, const char *fmt, ...) {
   va_list args;
   va_start(args, fmt);
-  vlprintfln(lvl, fac, name, fmt, args);
+  vlprintfln(lvl, fac, fmt, args);
   va_end(args);
 }
 

--- a/src/logger_setup.cc
+++ b/src/logger_setup.cc
@@ -13,7 +13,7 @@
 
 namespace ddprof {
 
-void setup_logger(const char *log_mode, const char *log_level,
+void setup_logger(const char *log_mode, const char *log_level, const char *name,
                   uint64_t max_log_per_sec_for_non_debug) {
   // Process logging mode
   const std::string_view logpattern[] = {"stdout", "stderr", "syslog",
@@ -64,6 +64,8 @@ void setup_logger(const char *log_mode, const char *log_level,
   if (LOG_getlevel() > LL_DEBUG) {
     LOG_setratelimit(max_log_per_sec_for_non_debug, std::chrono::seconds(1));
   }
+
+  LOG_setname(name);
 }
 
 } // namespace ddprof


### PR DESCRIPTION
# What does this PR do?

Ensure that `LOG_setname` effectively changes name on log lines.

# Motivation

Before this change, setting name with `LOG_setname` had no effect because all log macros were passing `MYNAME` as name to log function, that would override name set with `LOG_setname`.