### PR TITLE
Allocation tracker - fix deadlock when calling into logs

### DIFF
--- a/cmake/ExtendBuildTypes.cmake
+++ b/cmake/ExtendBuildTypes.cmake
@@ -25,7 +25,7 @@ endif()
 set(SAN_FLAGS "-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize-recover")
 set(ASAN_FLAGS "-fsanitize=address")
 set(TSAN_FLAGS "-fsanitize=thread")
-set(STACK_FLAGS "-fstack-protector-all")
+set(STACK_FLAGS "-fstack-protector-strong")
 
 # Frame pointers
 set(FRAME_PTR_FLAG "-fno-omit-frame-pointer")


### PR DESCRIPTION
# What does this PR do?

When entering error paths in the allocation profiler, we would log. This could create deadlocks while trying to acquire a lock to print timestamps in logs. Here is the backtrace where the deadlock was found: 

```
Thread 1 (Thread 0x7f0dffe31180 (LWP 1773386)):
#0  __lll_lock_wait_private (futex=futex@entry=0x7f0e000211a0 <tzset_lock>) at ./lowlevellock.c:35
#1  0x00007f0dfff04b61 in __tz_convert (timer=1727099936, use_localtime=1, tp=0x7ffcbb868d60) at tzset.c:572
#2  0x00007f0dffd15014 in ddprof::vlprintfln(int, int, char const*, char const*, __va_list_tag*) () from target:/tmp/libdd_profiling-embedded.so-4345326bddecccac9d9da7b291afef63d08085caa69e672db2a97995414b68d7
#3  0x00007f0dffd152c8 in ddprof::olprintfln(int, int, char const*, char const*, ...) () from target:/tmp/libdd_profiling-embedded.so-4345326bddecccac9d9da7b291afef63d08085caa69e672db2a97995414b68d7
#4  0x00007f0dffd0d804 in ddprof::AllocationTracker::push_alloc_sample(unsigned long, unsigned long, ddprof::TrackerThreadLocalState&) () from target:/tmp/libdd_profiling-embedded.so-4345326bddecccac9d9da7b291afef63d08085caa69e672db2a97995414b68d7
#5  0x00007f0dffd0dac5 in ddprof::AllocationTracker::track_allocation(unsigned long, unsigned long, ddprof::TrackerThreadLocalState&) () from target:/tmp/libdd_profiling-embedded.so-4345326bddecccac9d9da7b291afef63d08085caa69e672db2a97995414b68d7
```

This commit moves the logs to the debug level to make sure they would not print by default. We can still trigger the logs in debug mode.

# Motivation

Remove a dead lock.

# Additional Notes

NA

# How to test the change?

I am not able to reproduce this.
the conflict was with the appsec library also calling into the `__tz_convert` function.
TBD