### PR TITLE
Timeline thread names

### DIFF
--- a/include/base_frame_symbol_lookup.hpp
+++ b/include/base_frame_symbol_lookup.hpp
@@ -22,6 +22,8 @@ public:
     _pid_map.erase(pid);
   }
 
+  std::string_view get_exe_name(pid_t pid) const;
+
 private:
   SymbolIdx_t insert_bin_symbol(pid_t pid, SymbolTable &symbol_table,
                                 DsoSymbolLookup &dso_symbol_lookup,
@@ -33,6 +35,8 @@ private:
     int _nb_bin_lookups{1};
   };
   std::unordered_map<pid_t, SymbolIdx_t> _bin_map;
+  std::unordered_map<pid_t, std::string> _exe_name_map;
+
   // holds generic symbol for this pid and a number of lookups to keep track of
   // failures looking for a given binary
   std::unordered_map<pid_t, PidSymbol> _pid_map;

--- a/include/ddprof_process.hpp
+++ b/include/ddprof_process.hpp
@@ -38,6 +38,8 @@ public:
 
   uint64_t increment_counter() { return ++_sample_counter; }
 
+  [[nodiscard]] std::string_view get_or_insert_thread_name(pid_t tid);
+
   [[nodiscard]] DwflWrapper *get_or_insert_dwfl();
   [[nodiscard]] DwflWrapper *get_dwfl();
   [[nodiscard]] const DwflWrapper *get_dwfl() const;
@@ -49,6 +51,7 @@ private:
   static DDRes read_cgroup_ns(pid_t pid, std::string_view path_to_proc,
                               CGroupId_t &cgroup);
 
+  std::unordered_map<pid_t, std::string> _thread_name_map;
   std::unique_ptr<DwflWrapper> _dwfl_wrapper;
   ContainerId _container_id;
   pid_t _pid;

--- a/include/unwind_output.hpp
+++ b/include/unwind_output.hpp
@@ -32,9 +32,13 @@ struct UnwindOutput {
   void clear() {
     locs.clear();
     container_id = k_container_id_unknown;
+    exe_name = {};
+    thread_name = {};
   }
   std::vector<FunLoc> locs;
-  std::string container_id;
+  std::string_view container_id;
+  std::string_view exe_name;
+  std::string_view thread_name;
   int pid;
   int tid;
   friend auto operator<=>(const UnwindOutput &, const UnwindOutput &) = default;

--- a/include/unwind_state.hpp
+++ b/include/unwind_state.hpp
@@ -42,9 +42,10 @@ struct UnwindRegisters {
 /// given through callbacks
 struct UnwindState {
   explicit UnwindState(UniqueElf ref_elf, int dd_profiling_fd = -1,
-                       int nb_max_pids = k_default_max_profiled_pids)
+                       int nb_max_pids = k_default_max_profiled_pids,
+                       bool timeline = true)
       : dso_hdr("", dd_profiling_fd), ref_elf(std::move(ref_elf)),
-        maximum_pids(nb_max_pids) {
+        maximum_pids(nb_max_pids), is_timeline(timeline) {
     output.clear();
     output.locs.reserve(kMaxStackDepth);
   }
@@ -63,11 +64,13 @@ struct UnwindState {
   UnwindOutput output;
   UniqueElf ref_elf; // reference elf object used to initialize dwfl
   int maximum_pids;
+  bool is_timeline;
 };
 
 std::optional<UnwindState>
 create_unwind_state(int dd_profiling_fd = -1,
-                    int maximum_pids = k_default_max_profiled_pids);
+                    int maximum_pids = k_default_max_profiled_pids,
+                    bool timeline = true);
 
 static inline bool unwind_registers_equal(const UnwindRegisters *lhs,
                                           const UnwindRegisters *rhs) {

--- a/src/ddprof_process.cc
+++ b/src/ddprof_process.cc
@@ -6,9 +6,14 @@
 #include "ddprof_process.hpp"
 
 #include "ddres.hpp"
+#include "unique_fd.hpp"
+#include "user_override.hpp"
 
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_cat.h>
+#include <absl/strings/str_format.h>
+
+#include <sys/stat.h>
 #include <unistd.h>
 #include <vector>
 
@@ -78,6 +83,58 @@ DDRes Process::read_cgroup_ns(pid_t pid, std::string_view path_to_proc,
                           pid);
   }
   return {};
+}
+
+UniqueFile open_proc_comm(pid_t pid, pid_t tid, const char *path_to_proc = "") {
+  const std::string proc_comm_filename =
+      absl::StrFormat("/proc/%d/task/%d/comm", pid, tid);
+  UniqueFile file{fopen(proc_comm_filename.c_str(), "r"), fclose};
+  if (!file) {
+    // Check if the file exists
+    struct stat info;
+    UIDInfo old_uids;
+    // warning could user switch create too much overhead ?
+    if (stat(proc_comm_filename.c_str(), &info) == 0 &&
+        IsDDResOK(user_override(info.st_uid, info.st_gid, &old_uids))) {
+      file.reset(fopen(proc_comm_filename.c_str(), "r"));
+      // Switch back to the original user
+      user_override(old_uids.uid, old_uids.gid);
+    }
+  }
+  return file;
+}
+
+std::string_view Process::get_or_insert_thread_name(pid_t tid) {
+  // Try to insert an empty string first, to ensure only one lookup happens
+  auto [it, inserted] = _thread_name_map.emplace(tid, "");
+
+  // If the thread name is already cached (not inserted), return the cached name
+  if (!inserted) {
+    return it->second;
+  }
+
+  // Attempt to open the comm file for the thread
+  UniqueFile comm_file = open_proc_comm(_pid, tid);
+  if (!comm_file) {
+    // Leave the empty string we just inserted
+    return it->second; // This will return the empty string
+  }
+
+  // Thread names in Linux are limited to 16 bytes, though 256 is fine
+  char thread_name[256];
+  if (fgets(thread_name, sizeof(thread_name), comm_file.get()) == nullptr) {
+    return it->second; // This will return the empty string
+  }
+
+  // Remove the trailing newline character if present
+  size_t len = strlen(thread_name);
+  if (len > 0 && thread_name[len - 1] == '\n') {
+    thread_name[len - 1] = '\0';
+  }
+
+  // Update the value with the actual thread name
+  it->second = thread_name;
+  return it->second;
 }
 
 const ContainerId &ProcessHdr::get_container_id(pid_t pid) {

--- a/src/ddprof_process.cc
+++ b/src/ddprof_process.cc
@@ -87,7 +87,7 @@ DDRes Process::read_cgroup_ns(pid_t pid, std::string_view path_to_proc,
 
 UniqueFile open_proc_comm(pid_t pid, pid_t tid, const char *path_to_proc = "") {
   const std::string proc_comm_filename =
-      absl::StrFormat("/proc/%d/task/%d/comm", pid, tid);
+      absl::StrFormat("%s/proc/%d/task/%d/comm", path_to_proc, pid, tid);
   UniqueFile file{fopen(proc_comm_filename.c_str(), "r"), fclose};
   if (!file) {
     // Check if the file exists
@@ -114,7 +114,7 @@ std::string_view Process::get_or_insert_thread_name(pid_t tid) {
   }
 
   // Attempt to open the comm file for the thread
-  UniqueFile comm_file = open_proc_comm(_pid, tid);
+  const UniqueFile comm_file = open_proc_comm(_pid, tid);
   if (!comm_file) {
     // Leave the empty string we just inserted
     return it->second; // This will return the empty string
@@ -127,7 +127,7 @@ std::string_view Process::get_or_insert_thread_name(pid_t tid) {
   }
 
   // Remove the trailing newline character if present
-  size_t len = strlen(thread_name);
+  const size_t len = strlen(thread_name);
   if (len > 0 && thread_name[len - 1] == '\n') {
     thread_name[len - 1] = '\0';
   }

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -341,8 +341,9 @@ DDRes worker_library_init(DDProfContext &ctx,
     // Make sure worker index is initialized correctly
     ctx.worker_ctx.i_current_pprof = 0;
     ctx.worker_ctx.exp_tid = {0};
-    auto unwind_state = create_unwind_state(ctx.params.dd_profiling_fd,
-                                            ctx.params.maximum_pids);
+    auto unwind_state =
+        create_unwind_state(ctx.params.dd_profiling_fd, ctx.params.maximum_pids,
+                            ctx.params.timeline);
     if (!unwind_state) {
       LG_ERR("Failed to create unwind state");
       return ddres_error(DD_WHAT_UW_ERROR);

--- a/src/unwind.cc
+++ b/src/unwind.cc
@@ -41,7 +41,7 @@ void add_container_id(Process &process, UnwindState *us) {
   }
 }
 
-void add_exe_name(Process &process, UnwindState *us) {
+void add_exe_name(UnwindState *us) {
   us->output.exe_name =
       us->symbol_hdr._base_frame_symbol_lookup.get_exe_name(us->pid);
 }
@@ -96,8 +96,12 @@ DDRes unwindstate_unwind(UnwindState *us) {
   // Add a frame that identifies executable to which these belong
   add_virtual_base_frame(us);
   add_container_id(process, us);
-  add_exe_name(process, us);
-  add_thread_name(process, us);
+  if (us->is_timeline) {
+    // the lookup is only useful in timeline view
+    // keep this as a way to remove the possible overhead of opening the files
+    add_exe_name(us);
+    add_thread_name(process, us);
+  }
   return res;
 }
 

--- a/src/unwind.cc
+++ b/src/unwind.cc
@@ -23,7 +23,6 @@
 namespace ddprof {
 
 namespace {
-
 void find_dso_add_error_frame(DDRes ddres, UnwindState *us) {
   if (ddres._what == DD_WHAT_UW_MAX_PIDS) {
     add_common_frame(us, SymbolErrors::max_pids);
@@ -36,10 +35,19 @@ void find_dso_add_error_frame(DDRes ddres, UnwindState *us) {
 }
 
 void add_container_id(Process &process, UnwindState *us) {
-  auto container_id = process.get_container_id();
+  const auto &container_id = process.get_container_id();
   if (container_id) {
     us->output.container_id = *container_id;
   }
+}
+
+void add_exe_name(Process &process, UnwindState *us) {
+  us->output.exe_name =
+      us->symbol_hdr._base_frame_symbol_lookup.get_exe_name(us->pid);
+}
+
+void add_thread_name(Process &process, UnwindState *us) {
+  us->output.thread_name = process.get_or_insert_thread_name(us->output.tid);
 }
 } // namespace
 
@@ -88,6 +96,8 @@ DDRes unwindstate_unwind(UnwindState *us) {
   // Add a frame that identifies executable to which these belong
   add_virtual_base_frame(us);
   add_container_id(process, us);
+  add_exe_name(process, us);
+  add_thread_name(process, us);
   return res;
 }
 

--- a/src/unwind_state.cc
+++ b/src/unwind_state.cc
@@ -9,12 +9,12 @@
 #include "logger.hpp"
 
 namespace ddprof {
-std::optional<UnwindState> create_unwind_state(int dd_profiling_fd,
-                                               int maximum_pids) {
+std::optional<UnwindState>
+create_unwind_state(int dd_profiling_fd, int maximum_pids, bool timeline) {
   auto elf = create_elf_from_self();
   if (!elf) {
     return std::nullopt;
   }
-  return UnwindState(std::move(elf), dd_profiling_fd, maximum_pids);
+  return UnwindState(std::move(elf), dd_profiling_fd, maximum_pids, timeline);
 }
 } // namespace ddprof

--- a/test/ddprof_process-ut.cc
+++ b/test/ddprof_process-ut.cc
@@ -7,8 +7,15 @@
 
 #include "loghandle.hpp"
 
+#include <atomic>
 #include <gtest/gtest.h>
 #include <unistd.h>
+
+#ifndef gettid
+#  include <sys/syscall.h>
+// There is not always a glibc wrapper
+#  define gettid() syscall(SYS_gettid)
+#endif
 
 namespace ddprof {
 TEST(DDProfProcess, simple_self) {
@@ -45,6 +52,36 @@ TEST(DDProfProcess, simple_pid_2) {
   if (opt_string) {
     LG_DBG("container id %s", opt_string.value().c_str());
   }
+}
+
+std::atomic<pid_t> s_tid;
+
+void *thread_function(void *) {
+  // Set the thread name using pthread API
+  pthread_setname_np(pthread_self(), "TestThread");
+  // Store the thread ID in the atomic variable
+  s_tid.store(syscall(SYS_gettid)); // syscall to get the thread ID
+  usleep(100000);
+  return nullptr;
+}
+
+TEST(DDProfProcess, simple_tid) {
+  LogHandle handle;
+  pthread_t test_thread;
+  int ret = pthread_create(&test_thread, nullptr, thread_function, nullptr);
+  ASSERT_EQ(ret, 0) << "Failed to create pthread";
+  ProcessHdr process_hdr{};
+  Process &p = process_hdr.get(getpid());
+  std::string_view s = p.get_or_insert_thread_name(gettid());
+  LG_DBG("Main thread name is %s", s.data());
+  while (!s_tid.load())
+    sched_yield();
+  ASSERT_NE(s_tid.load(), 0) << "Thread TID should be set";
+  std::string_view s2 = p.get_or_insert_thread_name(s_tid.load());
+  LG_DBG("New thread name is %s", s2.data());
+  EXPECT_EQ(s2, "TestThread");
+  // Wait for the thread to store its TID
+  pthread_join(test_thread, nullptr);
 }
 
 } // namespace ddprof

--- a/tools/launch_local_build.sh
+++ b/tools/launch_local_build.sh
@@ -162,6 +162,6 @@ else
   MOUNT_TOOLS_DIR=""
 fi
 
-CMD="docker run -it --rm -u $(id -u):$(id -g) -w /app ${MOUNT_SSH_AGENT} ${MOUNT_TOOLS_DIR} --cap-add CAP_SYS_PTRACE --cap-add SYS_ADMIN ${MOUNT_CMD} \"${DOCKER_NAME}${DOCKER_TAG}\" /bin/bash"
+CMD="docker run -it --rm -u $(id -u):$(id -g) --network=host -w /app ${MOUNT_SSH_AGENT} ${MOUNT_TOOLS_DIR} --cap-add CAP_SYS_PTRACE --cap-add SYS_ADMIN ${MOUNT_CMD} \"${DOCKER_NAME}${DOCKER_TAG}\" /bin/bash"
 
 eval "$CMD"


### PR DESCRIPTION
# What does this PR do?

Ensure we have thread names / process name in the timeline

# Motivation

This makes the timeline easier to read

# Additional Notes

This has some amount of overhead
I left the timeline trigger to allow the fallback
There is no new lookup if we have a thread name change. 

# How to test the change?

Using timeline you should know see thread names.