### PR TITLE
[FIX] replace fprintf(), exit() with write(), _exit() to async-safe at SIGSEGV signal handler

### DIFF
--- a/src/ddprof.cc
+++ b/src/ddprof.cc
@@ -42,16 +42,16 @@ void sigsegv_handler(int sig, siginfo_t *si, void *uc) {
   static void *buf[k_stacktrace_buffer_size] = {};
   size_t const sz = backtrace(buf, std::size(buf));
 #endif
-  (void)fprintf(
-      stderr, "ddprof[%d]: <%.*s> has encountered an error and will exit\n",
-      getpid(), static_cast<int>(str_version().size()), str_version().data());
+  const char msg[] = "ddprof: encountered an error and will exit\n";
+  write(STDERR_FILENO, msg, sizeof(msg) - 1);
   if (sig == SIGSEGV) {
-    printf("[DDPROF] Fault address: %p\n", si->si_addr);
+    const char msg[] = "[DDPROF] Fault address\n";
+    write(STDOUT_FILENO, msg, sizeof(msg) - 1);
   }
 #ifdef __GLIBC__
   backtrace_symbols_fd(buf, sz, STDERR_FILENO);
 #endif
-  exit(-1);
+  _exit(-1);
 }
 
 void display_system_info() {

--- a/test/simple_malloc.cc
+++ b/test/simple_malloc.cc
@@ -187,20 +187,21 @@ namespace ddprof {
 void sigsegv_handler(int sig, siginfo_t *si, void *uc) {
   // TODO this really shouldn't call printf-family functions...
   (void)uc;
-#  ifdef __GLIBC__
+#ifdef __GLIBC__
   constexpr size_t k_stacktrace_buffer_size = 4096;
   static void *buf[k_stacktrace_buffer_size] = {};
-  const size_t sz = backtrace(buf, std::size(buf));
-#  endif
-  fprintf(stderr, "simplemalloc[%d]:has encountered an error and will exit\n",
-          getpid());
+  size_t const sz = backtrace(buf, std::size(buf));
+#endif
+  const char msg[] = "ddprof: encountered an error and will exit\n";
+  write(STDERR_FILENO, msg, sizeof(msg) - 1);
   if (sig == SIGSEGV) {
-    printf("Fault address: %p\n", si->si_addr);
+    const char msg[] = "[DDPROF] Fault address\n";
+    write(STDOUT_FILENO, msg, sizeof(msg) - 1);
   }
-#  ifdef __GLIBC__
+#ifdef __GLIBC__
   backtrace_symbols_fd(buf, sz, STDERR_FILENO);
-#  endif
-  exit(-1);
+#endif
+  _exit(-1);
 }
 
 void print_header() {


### PR DESCRIPTION
# What does this PR do?

This PR replaces the usage of non-async-safe functions (fprintf, printf, exit) in the SIGSEGV handler with async-safe alternatives (write, _exit). This aims to ensure more reliable behavior when a segmentation fault occurs.

# Motivation
https://docs.oracle.com/cd/E19455-01/806-5257/gen-26/index.html


When a SIGSEGV is triggered, the program’s state may already be corrupt. Using non-async-safe functions inside the signal handler can lead to reentrancy issues or additional faults. By switching to write and _exit, we minimize these risks and maintain a more stable crash-handling sequence.

# Additional Notes
- backtrace_symbols_fd is left as is for now, even though it’s not guaranteed to be fully async-safe, in order to keep the existing logic mostly unchanged.
- By TODO comment in the code, it appears that removing fprintf-family functions was already planned, suggesting that this problem was anticipated.
- I am not c++ developer, but the issue has already arisen and was known. This code must be updated in an async-safe manner, whether it’s through my proposal or another approach.


# How to test the change?
- Trigger a SIGSEGV intentionally and verify that the updated handler logs the message and terminates without additional faults.
- Compare the behavior with the previous handler to ensure no unexpected regressions.
- Observe whether the logs or any diagnostic outputs align with the expected error information under stress tests.
