### PR TITLE
[FIX] replace fprintf(), exit() with write(), _exit() to async-safe at SIGSEGV signal handler

### DIFF
--- a/include/signal_helper.hpp
+++ b/include/signal_helper.hpp
@@ -5,4 +5,16 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+
+#include <signal.h>
+
+namespace ddprof {
 bool process_is_alive(int pidId);
+
+int convert_addr_to_string(uintptr_t ptr, char *buff, size_t buff_size);
+
+void sigsegv_handler(int sig, siginfo_t *si, void *uc);
+
+} // namespace ddprof

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -86,6 +86,12 @@ DebCMake() {
     CmakeWithOptions ${BUILD_TYPE} $@
 }
 
+# Requires clang as compiler
+DebTidyCMake() {
+    local BUILD_TYPE=Debug
+    CmakeWithOptions ${BUILD_TYPE} -DENABLE_CLANG_TIDY=ON $@
+}
+
 SanCMake() {
     local BUILD_TYPE=SanitizedDebug
     CmakeWithOptions ${BUILD_TYPE} $@

--- a/src/ddprof.cc
+++ b/src/ddprof.cc
@@ -15,44 +15,19 @@
 #include "logger.hpp"
 #include "perf_mainloop.hpp"
 #include "pevent_lib.hpp"
+#include "signal_helper.hpp"
 #include "sys_utils.hpp"
 #include "version.hpp"
-
-#ifdef __GLIBC__
-#  include <execinfo.h>
-#endif
 
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
 #include <cerrno>
 #include <csignal>
-#include <cstdio>
 #include <filesystem>
 #include <sys/resource.h>
-#include <unistd.h>
 
 namespace ddprof {
 namespace {
-/*****************************  SIGSEGV Handler *******************************/
-void sigsegv_handler(int sig, siginfo_t *si, void *uc) {
-  // TODO this really shouldn't call printf-family functions...
-  (void)uc;
-#ifdef __GLIBC__
-  constexpr size_t k_stacktrace_buffer_size = 4096;
-  static void *buf[k_stacktrace_buffer_size] = {};
-  size_t const sz = backtrace(buf, std::size(buf));
-#endif
-  const char msg[] = "ddprof: encountered an error and will exit\n";
-  write(STDERR_FILENO, msg, sizeof(msg) - 1);
-  if (sig == SIGSEGV) {
-    const char msg[] = "[DDPROF] Fault address\n";
-    write(STDOUT_FILENO, msg, sizeof(msg) - 1);
-  }
-#ifdef __GLIBC__
-  backtrace_symbols_fd(buf, sz, STDERR_FILENO);
-#endif
-  _exit(-1);
-}
 
 void display_system_info() {
 

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -446,7 +446,7 @@ bool DsoHdr::pid_backpopulate(PidMapping &pid_mapping, pid_t pid,
   auto proc_map_file_holder = open_proc_maps(pid, _path_to_proc.c_str());
   if (!proc_map_file_holder) {
     LG_DBG("[DSO] Failed to open procfs for %d", pid);
-    if (!process_is_alive(pid)) {
+    if (!ddprof::process_is_alive(pid)) {
       LG_DBG("[DSO] Process nonexistant");
     }
     return false;

--- a/src/signal_helper.cc
+++ b/src/signal_helper.cc
@@ -6,10 +6,75 @@
 #include "signal_helper.hpp"
 
 #include <cerrno>
-#include <csignal>
 #include <cstdio>
-#include <cstdlib>
+#include <unistd.h>
 
+#ifdef __GLIBC__
+#  include <execinfo.h>
+#endif
+
+namespace ddprof {
 bool process_is_alive(int pidId) {
   return -1 != kill(pidId, 0) || errno != ESRCH;
 }
+
+/// Signal-safe conversion of an address to a string in an existing buffer.
+/// Returns the length of the string on success, or -1 on error.
+int convert_addr_to_string(uintptr_t ptr, char *buff, size_t buff_size) {
+  // clang tidy requires constants to be defined even if trivial
+  const size_t k_hex_digits_per_byte = 2;
+  const size_t k_ptr_hex_digits = sizeof(uintptr_t) * k_hex_digits_per_byte;
+  const size_t k_required_buffer_size = k_ptr_hex_digits + 1;
+  const int k_nibble_mask = 0xF;
+  const int k_decimal_threshold = 10;
+
+  // Ensure the buffer is large enough
+  if (buff_size < k_required_buffer_size) {
+    return -1; // Buffer too small
+  }
+
+  int len = 0;
+  for (int i = k_ptr_hex_digits - 1; i >= 0; --i) {
+    const int nibble =
+        (ptr >> (i * 4)) & k_nibble_mask; // Extract 4 bits (1 hex digit)
+    buff[len++] = nibble < k_decimal_threshold
+        ? ('0' + nibble)                        // Convert to '0'-'9'
+        : ('a' + nibble - k_decimal_threshold); // Convert to 'a'-'f'
+  }
+  buff[len] = '\0'; // Null-terminate the string (not changing the size)
+  return len;       // Return the length of the generated string
+}
+
+/*****************************  SIGSEGV Handler *******************************/
+void sigsegv_handler(int sig, siginfo_t *si, void *uc) {
+  (void)uc;
+  constexpr char msg1[] = "ddprof: encountered a SIGSEGV and will exit.\n";
+  write(STDERR_FILENO, msg1, sizeof(msg1) - 1);
+
+  if (sig == SIGSEGV) {
+    constexpr char msg2[] = "Fault address: ";
+    write(STDERR_FILENO, msg2, sizeof(msg2) - 1);
+    const auto fault_addr = reinterpret_cast<uintptr_t>(si->si_addr);
+    char addr_buf[32]; // Ensure it's large enough for a 64-bit address
+    int len = convert_addr_to_string(fault_addr, addr_buf, 32);
+    if (len > 0) {
+      addr_buf[len++] = '\n';
+      addr_buf[len++] = '\0';
+      write(STDERR_FILENO, addr_buf, len);
+    }
+  }
+
+#ifdef __GLIBC__
+  // Unsafe but useful for debugging (performed last)
+  // This is not used in the deployed version (as we use a musl deployment)
+  constexpr size_t k_stacktrace_buffer_size = 4096;
+  static void *buf[k_stacktrace_buffer_size] = {};
+  size_t const sz = backtrace(buf, k_stacktrace_buffer_size);
+  backtrace_symbols_fd(buf, sz, STDERR_FILENO);
+#endif
+
+  // assumption is that flush is not needed as we relied on write
+  _exit(128 + sig); // standard exit codes for signals
+}
+
+} // namespace ddprof

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -434,23 +434,26 @@ add_benchmark(
   LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle
   DEFINITIONS ${DDPROF_DEFINITION_LIST} KMAX_TRACKED_ALLOCATIONS=16384)
 
+set(SIMPLE_MALLOC_SRC simple_malloc.cc ../src/signal_helper.cc)
+
 if(NOT CMAKE_BUILD_TYPE STREQUAL "SanitizedDebug")
   add_exe(
-    simple_malloc-static simple_malloc.cc
+    simple_malloc-static ${SIMPLE_MALLOC_SRC}
     LIBRARIES Threads::Threads dd_profiling-static CLI11 dl
     DEFINITIONS USE_DD_PROFILING)
   target_include_directories(simple_malloc-static PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
   add_exe(
-    simple_malloc-shared simple_malloc.cc
+    simple_malloc-shared ${SIMPLE_MALLOC_SRC}
     LIBRARIES dd_profiling-shared Threads::Threads CLI11 dl
     DEFINITIONS USE_DD_PROFILING COMPRESS_DEBUG_SECTION)
   target_include_directories(simple_malloc-shared PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
-  add_exe(simple_malloc simple_malloc.cc LIBRARIES Threads::Threads CLI11 dl COMPRESS_DEBUG_SECTION)
+  add_exe(simple_malloc ${SIMPLE_MALLOC_SRC} LIBRARIES Threads::Threads CLI11 dl
+                                                       COMPRESS_DEBUG_SECTION)
   target_include_directories(simple_malloc PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
-  add_library(simple_malloc_lib SHARED simple_malloc.cc)
+  add_library(simple_malloc_lib SHARED ${SIMPLE_MALLOC_SRC})
   target_compile_definitions(simple_malloc_lib PRIVATE "SIMPLE_MALLOC_SHARED_LIBRARY")
   set_target_properties(simple_malloc_lib PROPERTIES OUTPUT_NAME "simplemalloc")
   target_include_directories(simple_malloc_lib PRIVATE ${CMAKE_SOURCE_DIR}/include)

--- a/test/signal_helper-ut.cc
+++ b/test/signal_helper-ut.cc
@@ -6,13 +6,24 @@
 #include "signal_helper.hpp"
 
 #include <gtest/gtest.h>
-#include <sys/types.h>
 #include <unistd.h>
 
+namespace ddprof {
 TEST(SignalHelperTst, ProcessIsAlive) {
   pid_t myPid = getpid();
   // Expecting that this unit test is alive
-  EXPECT_TRUE(process_is_alive(myPid));
+  EXPECT_TRUE(ddprof::process_is_alive(myPid));
   pid_t impossiblePid = 99999 + 1;
   EXPECT_FALSE(process_is_alive(impossiblePid));
 }
+
+TEST(SignalHelperTst, convert_addr) {
+  char buff[100];
+  uintptr_t ptr = 0x12345678;
+  int len = convert_addr_to_string(ptr, buff, sizeof(buff));
+  EXPECT_EQ(len, 16);
+  //  includes 0 chars
+  EXPECT_STREQ(buff, "0000000012345678");
+}
+
+} // namespace ddprof

--- a/test/simple_malloc.cc
+++ b/test/simple_malloc.cc
@@ -22,6 +22,7 @@
 #include "clocks.hpp"
 #include "ddprof_base.hpp"
 #include "enum_flags.hpp"
+#include "signal_helper.hpp"
 #include "syscalls.hpp"
 
 #ifndef SIMPLE_MALLOC_SHARED_LIBRARY
@@ -182,27 +183,6 @@ using WrapperFuncPtr = decltype(&wrapper);
 
 #ifndef SIMPLE_MALLOC_SHARED_LIBRARY
 namespace ddprof {
-
-/*****************************  SIGSEGV Handler *******************************/
-void sigsegv_handler(int sig, siginfo_t *si, void *uc) {
-  // TODO this really shouldn't call printf-family functions...
-  (void)uc;
-#ifdef __GLIBC__
-  constexpr size_t k_stacktrace_buffer_size = 4096;
-  static void *buf[k_stacktrace_buffer_size] = {};
-  size_t const sz = backtrace(buf, std::size(buf));
-#endif
-  const char msg[] = "ddprof: encountered an error and will exit\n";
-  write(STDERR_FILENO, msg, sizeof(msg) - 1);
-  if (sig == SIGSEGV) {
-    const char msg[] = "[DDPROF] Fault address\n";
-    write(STDOUT_FILENO, msg, sizeof(msg) - 1);
-  }
-#ifdef __GLIBC__
-  backtrace_symbols_fd(buf, sz, STDERR_FILENO);
-#endif
-  _exit(-1);
-}
 
 void print_header() {
   printf("TestHeaders:%-8s,%-8s,%-14s,%-14s,%-14s,%-14s\n", "PID", "TID",


### PR DESCRIPTION
# What does this PR do?

This is a continuation of the work proposed [here](https://github.com/DataDog/ddprof/pull/433).
I made some minor changes to include the address on which we are crashing (the address we attempt to access).

# Motivation

Refer to original PR.
Thank you @Backend-Changyeon for suggesting the change.

# Additional Notes

There will be more work on crashtracking.

# How to test the change?

I added a minor unit test, though a proper test on the SIGSEGV would be welcome.
