### PR TITLE
Presets - add an allocation live heap preset

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -64,7 +64,8 @@ Profiling settings:
                                    (profile only CPU when targeting a given PID)
                                 - cpu_only: profile CPU
                                 - alloc_only: profile memory allocations
-                                - cpu_live_heap: profile live allocations and CPU
+                                - alloc_live_heap: profile memory allocations and live heap
+                                - cpu_live_heap: CPU, memory allocations and live heap
                               
 
 

--- a/src/ddprof_cli.cc
+++ b/src/ddprof_cli.cc
@@ -215,14 +215,16 @@ int DDProfCLI::parse(int argc, const char *argv[]) {
       ->envname(k_events_env_variable)
       ->delimiter(';');
 
-  app.add_option("--preset", preset,
-                 "Select a predefined profiling configuration."
-                 "Available presets:\n"
-                 "  - default: profile CPU and memory allocations\n"
-                 "     (profile only CPU when targeting a given PID)\n"
-                 "  - cpu_only: profile CPU\n"
-                 "  - alloc_only: profile memory allocations\n"
-                 "  - cpu_live_heap: profile live allocations and CPU\n")
+  app.add_option(
+         "--preset", preset,
+         "Select a predefined profiling configuration."
+         "Available presets:\n"
+         "  - default: profile CPU and memory allocations\n"
+         "     (profile only CPU when targeting a given PID)\n"
+         "  - cpu_only: profile CPU\n"
+         "  - alloc_only: profile memory allocations\n"
+         "  - alloc_live_heap: profile memory allocations and live heap\n"
+         "  - cpu_live_heap: CPU, memory allocations and live heap\n")
       ->group("Profiling settings")
       ->envname("DD_PROFILING_NATIVE_PRESET");
 

--- a/src/presets.cc
+++ b/src/presets.cc
@@ -23,6 +23,7 @@ DDRes add_preset(std::string_view preset, bool pid_or_global_mode,
       {"default-pid", "sCPU"},
       {"cpu_only", "sCPU"},
       {"alloc_only", "sALLOC"},
+      {"alloc_live_heap", "sALLOC mode=sl"},
       {"cpu_live_heap", "sCPU;sALLOC mode=sl"},
   };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -178,6 +178,19 @@ add_unit_test(
   DEFINITIONS MYNAME="pevent-ut")
 
 add_unit_test(
+  presets-ut
+  ../src/presets.cc
+  ../src/ddprof_cli.cc
+  ../src/ddprof_cmdline_watcher.cc
+  ../src/version.cc
+  ../src/uuid.cc
+  ../src/tracepoint_config.cc
+  ../src/perf_watcher.cc
+  presets-ut.cc
+  LIBRARIES DDProf::Parser CLI11
+  DEFINITIONS MYNAME="presets-ut")
+
+add_unit_test(
   ddprof_pprof-ut
   ddprof_pprof-ut.cc
   ../src/ddog_profiling_utils.cc

--- a/test/presets-ut.cc
+++ b/test/presets-ut.cc
@@ -1,0 +1,135 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2025-Present
+// Datadog, Inc.
+
+#include "perf_watcher.hpp"
+#include "presets.hpp"
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace ddprof;
+
+TEST(presets, default_preset) {
+  std::vector<PerfWatcher> watchers;
+  DDRes res =
+      add_preset("default", false, k_default_perf_stack_sample_size, watchers);
+  EXPECT_TRUE(IsDDResOK(res));
+  EXPECT_EQ(watchers.size(), 2);
+
+  // Check CPU watcher
+  auto cpu_it =
+      std::find_if(watchers.begin(), watchers.end(), [](const auto &w) {
+        return w.ddprof_event_type == DDPROF_PWE_sCPU;
+      });
+  EXPECT_NE(cpu_it, watchers.end());
+  EXPECT_EQ(cpu_it->aggregation_mode, EventAggregationMode::kSum);
+
+  // Check ALLOC watcher
+  auto alloc_it =
+      std::find_if(watchers.begin(), watchers.end(), [](const auto &w) {
+        return w.ddprof_event_type == DDPROF_PWE_sALLOC;
+      });
+  EXPECT_NE(alloc_it, watchers.end());
+  EXPECT_EQ(alloc_it->aggregation_mode, EventAggregationMode::kSum);
+}
+
+TEST(presets, default_pid_preset) {
+  std::vector<PerfWatcher> watchers;
+  DDRes res =
+      add_preset("default", true, k_default_perf_stack_sample_size, watchers);
+  EXPECT_TRUE(IsDDResOK(res));
+  EXPECT_EQ(watchers.size(), 1);
+
+  // Check CPU watcher
+  auto cpu_it =
+      std::find_if(watchers.begin(), watchers.end(), [](const auto &w) {
+        return w.ddprof_event_type == DDPROF_PWE_sCPU;
+      });
+  EXPECT_NE(cpu_it, watchers.end());
+  EXPECT_EQ(cpu_it->aggregation_mode, EventAggregationMode::kSum);
+}
+
+TEST(presets, cpu_only_preset) {
+  std::vector<PerfWatcher> watchers;
+  DDRes res =
+      add_preset("cpu_only", false, k_default_perf_stack_sample_size, watchers);
+  EXPECT_TRUE(IsDDResOK(res));
+  EXPECT_EQ(watchers.size(), 1);
+
+  // Check CPU watcher
+  auto cpu_it =
+      std::find_if(watchers.begin(), watchers.end(), [](const auto &w) {
+        return w.ddprof_event_type == DDPROF_PWE_sCPU;
+      });
+  EXPECT_NE(cpu_it, watchers.end());
+  EXPECT_EQ(cpu_it->aggregation_mode, EventAggregationMode::kSum);
+}
+
+TEST(presets, alloc_only_preset) {
+  std::vector<PerfWatcher> watchers;
+  DDRes res = add_preset("alloc_only", false, k_default_perf_stack_sample_size,
+                         watchers);
+  EXPECT_TRUE(IsDDResOK(res));
+  EXPECT_EQ(watchers.size(), 1);
+
+  // Check ALLOC watcher
+  auto alloc_it =
+      std::find_if(watchers.begin(), watchers.end(), [](const auto &w) {
+        return w.ddprof_event_type == DDPROF_PWE_sALLOC;
+      });
+  EXPECT_NE(alloc_it, watchers.end());
+  EXPECT_EQ(alloc_it->aggregation_mode, EventAggregationMode::kSum);
+}
+
+TEST(presets, cpu_live_heap_preset) {
+  std::vector<PerfWatcher> watchers;
+  DDRes res = add_preset("cpu_live_heap", false,
+                         k_default_perf_stack_sample_size, watchers);
+  EXPECT_TRUE(IsDDResOK(res));
+  EXPECT_EQ(watchers.size(), 2);
+
+  // Check CPU watcher
+  auto cpu_it =
+      std::find_if(watchers.begin(), watchers.end(), [](const auto &w) {
+        return w.ddprof_event_type == DDPROF_PWE_sCPU;
+      });
+  EXPECT_NE(cpu_it, watchers.end());
+  EXPECT_EQ(cpu_it->aggregation_mode, EventAggregationMode::kSum);
+
+  // Check ALLOC watcher with live mode
+  auto alloc_it =
+      std::find_if(watchers.begin(), watchers.end(), [](const auto &w) {
+        return w.ddprof_event_type == DDPROF_PWE_sALLOC;
+      });
+  EXPECT_NE(alloc_it, watchers.end());
+  EXPECT_EQ(alloc_it->aggregation_mode,
+            EventAggregationMode::kLiveSum | EventAggregationMode::kSum);
+}
+
+TEST(presets, alloc_live_heap_preset) {
+  std::vector<PerfWatcher> watchers;
+  DDRes res = add_preset("alloc_live_heap", false,
+                         k_default_perf_stack_sample_size, watchers);
+  EXPECT_TRUE(IsDDResOK(res));
+  EXPECT_EQ(watchers.size(), 1);
+
+  // Check ALLOC watcher with live mode
+  auto alloc_it =
+      std::find_if(watchers.begin(), watchers.end(), [](const auto &w) {
+        return w.ddprof_event_type == DDPROF_PWE_sALLOC;
+      });
+  EXPECT_NE(alloc_it, watchers.end());
+  EXPECT_EQ(alloc_it->aggregation_mode,
+            EventAggregationMode::kLiveSum | EventAggregationMode::kSum);
+}
+
+TEST(presets, invalid_preset) {
+  std::vector<PerfWatcher> watchers;
+  DDRes res = add_preset("invalid_preset", false,
+                         k_default_perf_stack_sample_size, watchers);
+  EXPECT_FALSE(IsDDResOK(res));
+  EXPECT_EQ(watchers.size(), 0);
+}


### PR DESCRIPTION
# What does this PR do?

Add a preset that just allows for allocation and heap profiling

# Motivation

We now provide CPU profiling through the [host profiler](https://github.com/DataDog/dd-otel-host-profiler).
This preset allows users to only get allocations and heap profiles.

# Additional Notes

NA

# How to test the change?

I added a unit test and checked in our product for the expected.
![image](https://github.com/user-attachments/assets/71e0a199-2538-40c9-8f3e-d85737268d45)
