### PR TITLE
Add live allocation diagnostics

### DIFF
--- a/include/ddprof_perf_event.hpp
+++ b/include/ddprof_perf_event.hpp
@@ -12,7 +12,9 @@
 // There are <30 different perf events (starting at 1000 seems safe)
 enum : uint16_t {
   PERF_CUSTOM_EVENT_DEALLOCATION = 1000,
-  PERF_CUSTOM_EVENT_CLEAR_LIVE_ALLOCATION
+  PERF_CUSTOM_EVENT_CLEAR_LIVE_ALLOCATION,
+  PERF_CUSTOM_EVENT_LOST_ALLOCATION,
+  PERF_CUSTOM_EVENT_ALLOCATION_TRACKER_STATE,
 };
 
 static_assert(static_cast<uint32_t>(PERF_CUSTOM_EVENT_DEALLOCATION) >
@@ -32,6 +34,20 @@ struct DeallocationEvent {
 struct ClearLiveAllocationEvent {
   perf_event_header hdr;
   struct sample_id sample_id;
+};
+
+struct LostAllocationEvent {
+  struct perf_event_header header;
+  uint32_t lost_alloc_count;
+  uint32_t lost_dealloc_count;
+  struct sample_id sample_id;
+};
+
+struct AllocationTrackerStateEvent {
+  struct perf_event_header header;
+  struct sample_id sample_id;
+  uint32_t tracked_addresse_count;
+  uint32_t address_conflict_count;
 };
 
 } // namespace ddprof

--- a/include/ddprof_stats.hpp
+++ b/include/ddprof_stats.hpp
@@ -15,9 +15,12 @@ namespace ddprof {
 #define STATS_TABLE(X)                                                         \
   X(EVENT_COUNT, "event.count", STAT_GAUGE)                                    \
   X(EVENT_LOST, "event.lost", STAT_GAUGE)                                      \
+  X(EVENT_DEALLOC_LOST, "event.dealloc_lost", STAT_GAUGE)                      \
   X(EVENT_OUT_OF_ORDER, "event.out_of_order", STAT_GAUGE)                      \
   X(SAMPLE_COUNT, "sample.count", STAT_GAUGE)                                  \
   X(UNMATCHED_DEALLOCATION_COUNT, "unmatched_deallocation.count", STAT_GAUGE)  \
+  X(ALREADY_EXISTING_ALLOCATION_COUNT, "already_existing_allocation.count",    \
+    STAT_GAUGE)                                                                \
   X(TARGET_CPU_USAGE, "target_process.cpu_usage.millicores", STAT_GAUGE)       \
   X(UNWIND_AVG_TIME, "unwind.avg_time_ns", STAT_GAUGE)                         \
   X(UNWIND_FRAMES, "unwind.frames", STAT_GAUGE)                                \

--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -83,15 +83,19 @@ private:
     void init(bool track_alloc, bool track_dealloc) {
       track_allocations = track_alloc;
       track_deallocations = track_dealloc;
-      lost_count = 0;
+      lost_alloc_count = 0;
+      lost_dealloc_count = 0;
       failure_count = 0;
+      address_conflict_count = 0;
       pid = getpid();
     }
     std::mutex mutex;
     std::atomic<bool> track_allocations = false;
     std::atomic<bool> track_deallocations = false;
-    std::atomic<uint64_t> lost_count; // count number of lost events
+    std::atomic<uint64_t> lost_alloc_count;   // count number of lost events
+    std::atomic<uint64_t> lost_dealloc_count; // count number of lost events
     std::atomic<uint32_t> failure_count;
+    std::atomic<uint32_t> address_conflict_count;
     std::atomic<pid_t> pid; // lazy cache of pid (0 is un-init value)
     std::atomic<PerfClock::time_point> next_check_time;
   };
@@ -128,6 +132,8 @@ private:
   DDRes push_dealloc_sample(uintptr_t addr, TrackerThreadLocalState &tl_state);
 
   DDRes push_clear_live_allocation(TrackerThreadLocalState &tl_state);
+
+  DDRes push_allocation_tracker_state();
 
   void check_timer(PerfClock::time_point now,
                    TrackerThreadLocalState &tl_state);

--- a/src/live_allocation.cc
+++ b/src/live_allocation.cc
@@ -64,6 +64,7 @@ bool LiveAllocation::register_allocation(const UnwindOutput &uo,
     // unexpected, we already have an allocation here
     // This means we missed a previous free
     LG_DBG("Existing allocation: %lx (cleaning up)", address);
+    ++_stats._already_existing_allocations;
     if (v._unique_stack) {
       // we should decrement count / value
       v._unique_stack->second._value -= v._value;

--- a/src/perf_ringbuffer.cc
+++ b/src/perf_ringbuffer.cc
@@ -5,6 +5,7 @@
 
 #include "perf_ringbuffer.hpp"
 
+#include "ddprof_perf_event.hpp"
 #include "logger.hpp"
 #include "mpscringbuffer.hpp"
 
@@ -339,6 +340,16 @@ uint64_t hdr_time(const perf_event_header *hdr, uint64_t mask) {
         reinterpret_cast<const uint8_t *>(hdr) + hdr->size);
     return last_field_ptr[-nb_fields_after];
   }
+  case PERF_CUSTOM_EVENT_DEALLOCATION:
+    return reinterpret_cast<const DeallocationEvent *>(hdr)->sample_id.time;
+  case PERF_CUSTOM_EVENT_CLEAR_LIVE_ALLOCATION:
+    return reinterpret_cast<const ClearLiveAllocationEvent *>(hdr)
+        ->sample_id.time;
+  case PERF_CUSTOM_EVENT_LOST_ALLOCATION:
+    return reinterpret_cast<const LostAllocationEvent *>(hdr)->sample_id.time;
+  case PERF_CUSTOM_EVENT_ALLOCATION_TRACKER_STATE:
+    return reinterpret_cast<const AllocationTrackerStateEvent *>(hdr)
+        ->sample_id.time;
   default:
     break;
   }


### PR DESCRIPTION
## Description

This PR enhances the live allocation profiling system with comprehensive diagnostic capabilities to better track and troubleshoot allocation/deallocation mismatches and data loss.

### Key Changes:

**1. New Performance Event Types**
- Added `PERF_CUSTOM_EVENT_LOST_ALLOCATION` to track lost allocation and deallocation events separately
- Added `PERF_CUSTOM_EVENT_ALLOCATION_TRACKER_STATE` to periodically report the allocation tracker's internal state

**2. Enhanced Event Structures**
- `LostAllocationEvent`: Replaces generic lost events with separate counters for `lost_alloc_count` and `lost_dealloc_count`
- `AllocationTrackerStateEvent`: Reports `tracked_addresse_count` and `address_conflict_count` from the library

**3. Improved Statistics Tracking**
- Added `EVENT_DEALLOC_LOST` stat to separately track lost deallocation events
- Added `ALREADY_EXISTING_ALLOCATION_COUNT` stat to count duplicate allocations at the same address (indicating missed free events)

**4. Allocation Tracker Enhancements**
- Split `lost_count` into separate `lost_alloc_count` and `lost_dealloc_count` atomics for granular tracking
- Added `address_conflict_count` to track hash collisions in the address set
- Implemented `push_allocation_tracker_state()` to periodically report library state to the profiler
- Integrated state reporting with the timer callback mechanism

**5. Live Allocation Diagnostics**
- Added `register_library_state()` method to synchronize library state with profiler's view
- Tracks `address_conflict_count` and `tracked_address_count` per PID

**6. Enhanced Logging and Visibility**
- Consolidated diagnostic logging in `register_library_state()` showing:
  - Live allocations tracked by profiler (`_address_map.size()`)
  - Unique stacks (`_unique_stacks.size()`)
  - Library-tracked addresses (`_tracked_address_count`)
  - Address conflicts from library (`_address_conflict_count`)
- Above log was moved from aggregation phase, because consistency between library and profiler can only be assessed when library sends its status 
- Added debug logging for clearing live allocations and state reporting

### Benefits:
These diagnostics provide better visibility into allocation tracking health, making it easier to identify when events are lost, when allocations/deallocations are mismatched, and when the library and profiler states diverge. This is crucial for debugging live heap profiling in production environments.