### PR TITLE
Fix size errors in structs and avoid sending keeping an address if ring buffer is full

### DIFF
--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -138,7 +138,7 @@ private:
   void check_timer(PerfClock::time_point now,
                    TrackerThreadLocalState &tl_state);
 
-  void free_on_consecutive_failures(bool success);
+  void free_on_consecutive_failures(bool failure);
 
   DDPROF_NOINLINE void update_timer(PerfClock::time_point now);
 


### PR DESCRIPTION
# What does this PR do?

* Use correct size for structs when pushing in ring buffer
* When push of allocation event fail because buffer is full, do not track the address