### PR TITLE
Send lost (de)alloc events as part of state

### DIFF
--- a/include/ddprof_perf_event.hpp
+++ b/include/ddprof_perf_event.hpp
@@ -13,7 +13,6 @@
 enum : uint16_t {
   PERF_CUSTOM_EVENT_DEALLOCATION = 1000,
   PERF_CUSTOM_EVENT_CLEAR_LIVE_ALLOCATION,
-  PERF_CUSTOM_EVENT_LOST_ALLOCATION,
   PERF_CUSTOM_EVENT_ALLOCATION_TRACKER_STATE,
 };
 
@@ -36,18 +35,13 @@ struct ClearLiveAllocationEvent {
   struct sample_id sample_id;
 };
 
-struct LostAllocationEvent {
-  struct perf_event_header header;
-  uint32_t lost_alloc_count;
-  uint32_t lost_dealloc_count;
-  struct sample_id sample_id;
-};
-
 struct AllocationTrackerStateEvent {
   struct perf_event_header header;
   struct sample_id sample_id;
-  uint32_t tracked_addresse_count;
+  uint32_t tracked_address_count;
   uint32_t address_conflict_count;
+  uint32_t lost_alloc_count;
+  uint32_t lost_dealloc_count;
 };
 
 } // namespace ddprof

--- a/src/perf_ringbuffer.cc
+++ b/src/perf_ringbuffer.cc
@@ -345,8 +345,6 @@ uint64_t hdr_time(const perf_event_header *hdr, uint64_t mask) {
   case PERF_CUSTOM_EVENT_CLEAR_LIVE_ALLOCATION:
     return reinterpret_cast<const ClearLiveAllocationEvent *>(hdr)
         ->sample_id.time;
-  case PERF_CUSTOM_EVENT_LOST_ALLOCATION:
-    return reinterpret_cast<const LostAllocationEvent *>(hdr)->sample_id.time;
   case PERF_CUSTOM_EVENT_ALLOCATION_TRACKER_STATE:
     return reinterpret_cast<const AllocationTrackerStateEvent *>(hdr)
         ->sample_id.time;


### PR DESCRIPTION
# What does this PR do?

Stop sending lost (de)alloc events, instead send the (de)alloc stats as part of allocation tracker state.