### PR TITLE
Address tracking: use absl::flat_hash_set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,7 +280,8 @@ target_link_libraries(
   PRIVATE
     "$<$<AND:$<C_COMPILER_ID:GNU>,$<CONFIG:SanitizedDebug>>:-Wl,-Bstatic;-lubsan;-lasan;-lstdc++;-Wl,-Bdynamic>"
 )
-target_link_libraries(dd_profiling-embedded PUBLIC dl pthread rt absl::base absl::str_format)
+target_link_libraries(dd_profiling-embedded PUBLIC dl pthread rt absl::base absl::str_format
+                                                   absl::flat_hash_set)
 
 set(LIBDD_PROFILING_EMBEDDED_OBJECT "${CMAKE_BINARY_DIR}/libdd_profiling-embedded.o")
 set(LIBDD_PROFILING_EMBEDDED_HASH_HEADER "${CMAKE_BINARY_DIR}/libdd_profiling-embedded_hash.h")
@@ -365,7 +366,8 @@ target_include_directories(dd_profiling-static PUBLIC ${CMAKE_SOURCE_DIR}/includ
 set_target_properties(dd_profiling-static
                       PROPERTIES PUBLIC_HEADER "${CMAKE_SOURCE_DIR}/include/lib/dd_profiling.h")
 target_link_libraries(dd_profiling-static PRIVATE ddprof_exe_object)
-target_link_libraries(dd_profiling-static PUBLIC dl pthread rt absl::base absl::str_format)
+target_link_libraries(dd_profiling-static PUBLIC dl pthread rt absl::base absl::str_format
+                                                 absl::flat_hash_set)
 
 if(USE_LOADER)
   # When using a loader, libdd_profiling.so is a loader that embeds both libdd_profiling-embedded.so
@@ -398,7 +400,8 @@ else()
     PRIVATE
       "$<$<AND:$<C_COMPILER_ID:GNU>,$<CONFIG:SanitizedDebug>>:-Wl,-Bstatic;-lubsan;-lasan;-lstdc++;-Wl,-Bdynamic>"
   )
-  target_link_libraries(dd_profiling-shared PUBLIC dl pthread rt absl::base absl::str_format)
+  target_link_libraries(dd_profiling-shared PUBLIC dl pthread rt absl::base absl::str_format
+                                                   absl::flat_hash_set)
 endif()
 
 target_static_libcxx(dd_profiling-shared)

--- a/cmake/Findabsl.cmake
+++ b/cmake/Findabsl.cmake
@@ -12,6 +12,7 @@ FetchContent_Declare(
                                                    # tag#20230802.1
 )
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(ABSL_PROPAGATE_CXX_STD
     ON
     CACHE INTERNAL "")

--- a/include/ddprof_perf_event.hpp
+++ b/include/ddprof_perf_event.hpp
@@ -39,7 +39,6 @@ struct AllocationTrackerStateEvent {
   struct perf_event_header header;
   struct sample_id sample_id;
   uint32_t tracked_address_count;
-  uint32_t address_conflict_count;
   uint32_t lost_alloc_count;
   uint32_t lost_dealloc_count;
 };

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -473,8 +473,7 @@ void ddprof_pr_allocation_tracker_state(
     DDProfContext &ctx, const AllocationTrackerStateEvent *event,
     int watcher_pos) {
   ctx.worker_ctx.live_allocation.register_library_state(
-      watcher_pos, event->sample_id.pid, event->address_conflict_count,
-      event->tracked_address_count);
+      watcher_pos, event->sample_id.pid, event->tracked_address_count);
 
   ddprof_stats_add(STATS_EVENT_LOST, event->lost_alloc_count, nullptr);
   ddprof_stats_add(STATS_EVENT_DEALLOC_LOST, event->lost_dealloc_count,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -327,13 +327,19 @@ set(ALLOCATION_TRACKER_UT_SRCS
 
 add_unit_test(
   allocation_tracker-ut ${ALLOCATION_TRACKER_UT_SRCS}
-  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle dl rt Datadog::Profiling
+  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle dl rt Datadog::Profiling absl::flat_hash_set
   DEFINITIONS ${DDPROF_DEFINITION_LIST} KMAX_TRACKED_ALLOCATIONS=16384)
 
 if(TARGET jemalloc::jemalloc_shared)
   add_unit_test(
     allocation_tracker_jemalloc-ut ${ALLOCATION_TRACKER_UT_SRCS}
-    LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle dl rt jemalloc::jemalloc_shared Datadog::Profiling
+    LIBRARIES ${ELFUTILS_LIBRARIES}
+              llvm-demangle
+              dl
+              rt
+              jemalloc::jemalloc_shared
+              Datadog::Profiling
+              absl::flat_hash_set
     DEFINITIONS ${DDPROF_DEFINITION_LIST} KMAX_TRACKED_ALLOCATIONS=16384 USE_JEMALLOC=1)
 endif()
 
@@ -444,7 +450,7 @@ add_benchmark(
   ../src/tsc_clock.cc
   ../src/user_override.cc
   ../src/sys_utils.cc
-  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle
+  LIBRARIES ${ELFUTILS_LIBRARIES} llvm-demangle absl::flat_hash_set
   DEFINITIONS ${DDPROF_DEFINITION_LIST} KMAX_TRACKED_ALLOCATIONS=16384)
 
 set(SIMPLE_MALLOC_SRC simple_malloc.cc ../src/signal_helper.cc)


### PR DESCRIPTION
# What does this PR do?

This is a proposal from Nicolas to switch to absl
This removes the issues with collisions

I am comparing this to writing a manual sharded hashmap

# Motivation

Improve the state of live heap

# Additional Notes

The big question for this change is around thread safety & how to validate this.

# How to test the change?

Simple malloc allows some amount of testing.
