### PR TITLE
Ensure allocation tracker state is pushed on process exit

### DIFF
--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -29,7 +29,12 @@ public:
   AllocationTracker(const AllocationTracker &) = delete;
   AllocationTracker &operator=(const AllocationTracker &) = delete;
 
-  ~AllocationTracker() { free(); }
+  ~AllocationTracker() {
+    if (_instance) {
+      _instance->push_allocation_tracker_state();
+    }
+    free();
+  }
 
   enum AllocationTrackingFlags : uint8_t {
     kTrackDeallocations = 0x1,


### PR DESCRIPTION
# What does this PR do?

Upon target process exit, push allocation tracker state.
