### PR TITLE
Disable event reordering by default

### DIFF
--- a/include/ddprof_cli.hpp
+++ b/include/ddprof_cli.hpp
@@ -70,7 +70,7 @@ public:
   bool help_extended{false};
   bool remote_symbolization{false};
   bool disable_symbolization{false};
-  bool reorder_events{true}; // reorder events by timestamp
+  bool reorder_events{false}; // reorder events by timestamp
   int maximum_pids{-1};
 
   std::string socket_path;


### PR DESCRIPTION
# What does this PR do?

Additional latency introduced by event reordering causes dealloc events to be lost when the free rate is high.