### PR TITLE
Adjust how addresses are reported in pprof

### DIFF
--- a/include/ddog_profiling_utils.hpp
+++ b/include/ddog_profiling_utils.hpp
@@ -30,8 +30,7 @@ void write_function(std::string_view demangled_name, std::string_view file_name,
 void write_mapping(const MapInfo &mapinfo, ddog_prof_Mapping *ffi_mapping);
 
 void write_location(const FunLoc &loc, const MapInfo &mapinfo,
-                    const Symbol &symbol, ddog_prof_Location *ffi_location,
-                    bool use_process_adresses);
+                    const Symbol &symbol, ddog_prof_Location *ffi_location);
 
 void write_location(ProcessAddress_t ip_or_elf_addr,
                     std::string_view demangled_name, std::string_view file_name,
@@ -39,8 +38,8 @@ void write_location(ProcessAddress_t ip_or_elf_addr,
                     ddog_prof_Location *ffi_location);
 
 DDRes write_location_blaze(
-    ProcessAddress_t ip_or_elf_addr,
+    ElfAddress_t elf_addr,
     ddprof::HeterogeneousLookupStringMap<std::string> &demangled_names,
     const MapInfo &mapinfo, const blaze_sym &blaze_sym, unsigned &cur_loc,
-    std::span<ddog_prof_Location> locations_buff);
+    std::span<ddog_prof_Location> locations_buff, bool inlined_functions);
 } // namespace ddprof

--- a/include/pprof/ddprof_pprof.hpp
+++ b/include/pprof/ddprof_pprof.hpp
@@ -26,7 +26,6 @@ struct DDProfPProf {
   ddog_prof_Profile _profile{};
   unsigned _nb_values = 0;
   Tags _tags;
-  bool use_process_adresses{true};
   // avoid re-creating strings for all pid numbers
   std::unordered_map<pid_t, std::string> _pid_str;
 };

--- a/include/symbolizer.hpp
+++ b/include/symbolizer.hpp
@@ -21,17 +21,10 @@ struct ddog_prof_Location;
 namespace ddprof {
 class Symbolizer {
 public:
-  enum AddrFormat : uint8_t {
-    k_elf,
-    k_process,
-  };
-
   explicit Symbolizer(bool inlined_functions = false,
-                      bool disable_symbolization = false,
-                      AddrFormat reported_addr_format = k_process)
+                      bool disable_symbolization = false)
       : inlined_functions(inlined_functions),
-        _disable_symbolization(disable_symbolization),
-        _reported_addr_format(reported_addr_format) {}
+        _disable_symbolization(disable_symbolization) {}
 
   struct BlazeResultsWrapper {
     BlazeResultsWrapper() = default;
@@ -66,21 +59,19 @@ public:
   };
 
   /// Fills the locations at the write index using address and elf source.
-  /// assumption is that all addresses are from this source file
-  /// Parameters
-  /// addrs - Elf address
-  /// process_addrs - Process address (only used for pprof reporting)
+  /// Assumption is that all addresses are from this source file.
+  /// Addresses are always reported as ELF relative addresses.
+  /// Parameters:
+  /// addrs - ELF addresses
   /// file_id - a way to identify this file in a unique way
-  /// elf_src - a path to the source file (idealy stable)
+  /// elf_src - a path to the source file (ideally stable)
   /// map_info - the mapping information to write to the pprof
-  /// locations - the output pprof strucure
+  /// locations - the output pprof structure
   /// write_index - input / output parameter updated based on what is written
   /// results - A handle object for lifetime of strings.
   ///          Should be kept until interned strings are no longer needed.
-  DDRes symbolize_pprof(std::span<ElfAddress_t> addrs,
-                        std::span<ProcessAddress_t> process_addrs,
-                        FileInfoId_t file_id, const std::string &elf_src,
-                        const MapInfo &map_info,
+  DDRes symbolize_pprof(std::span<ElfAddress_t> addrs, FileInfoId_t file_id,
+                        const std::string &elf_src, const MapInfo &map_info,
                         std::span<ddog_prof_Location> locations,
                         unsigned &write_index, BlazeResultsWrapper &results);
   int remove_unvisited();
@@ -123,6 +114,5 @@ private:
   std::unordered_map<FileInfoId_t, BlazeSymbolizerWrapper> _symbolizer_map;
   bool inlined_functions;
   bool _disable_symbolization;
-  AddrFormat _reported_addr_format;
 };
 } // namespace ddprof

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -543,9 +543,7 @@ DDRes worker_library_init(DDProfContext &ctx,
     ctx.worker_ctx.user_tags =
         new UserTags(ctx.params.tags, ctx.params.num_cpu);
     ctx.worker_ctx.symbolizer = new ddprof::Symbolizer(
-        ctx.params.inlined_functions, ctx.params.disable_symbolization,
-        ctx.params.remote_symbolization ? Symbolizer::k_elf
-                                        : Symbolizer::k_process);
+        ctx.params.inlined_functions, ctx.params.disable_symbolization);
 
     // Zero out pointers to dynamically allocated memory
     ctx.worker_ctx.exp[0] = nullptr;

--- a/src/symbolizer.cc
+++ b/src/symbolizer.cc
@@ -53,17 +53,15 @@ Symbolizer::get_symbolizer(FileInfoId_t file_id, const std::string &elf_src) {
 }
 
 DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
-                                  std::span<ProcessAddress_t> process_addrs,
                                   FileInfoId_t file_id,
                                   const std::string &elf_src,
                                   const MapInfo &map_info,
                                   std::span<ddog_prof_Location> locations,
                                   unsigned &write_index,
                                   BlazeResultsWrapper &results) {
-  if (elf_addrs.size() != process_addrs.size() || elf_addrs.empty() ||
-      elf_src.empty()) {
+  if (elf_addrs.empty() || elf_src.empty()) {
     LG_WRN("Error in provided addresses when symbolizing pprofs");
-    return ddres_warn(DD_WHAT_PPROF); // or some other error handling
+    return ddres_warn(DD_WHAT_PPROF);
   }
 
   if (!_disable_symbolization) {
@@ -101,11 +99,9 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
       // This will be moved to the backend
       for (size_t i = 0; i < blaze_res->cnt && i < elf_addrs.size(); ++i) {
         const blaze_sym *cur_sym = blaze_res->syms + i;
-        // Update the location
         DDRES_CHECK_FWD(write_location_blaze(
-            _reported_addr_format == k_elf ? elf_addrs[i] : process_addrs[i],
-            symbolizer_wrapper.demangled_names, map_info, *cur_sym, write_index,
-            locations));
+            elf_addrs[i], symbolizer_wrapper.demangled_names, map_info,
+            *cur_sym, write_index, locations, inlined_functions));
       }
       return {};
     }
@@ -114,7 +110,7 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
   // Handle the case of no blaze result
   // This can happen when file descriptors are exhausted
   // OR symbolization is disabled
-  for (auto el : (_reported_addr_format == k_elf) ? elf_addrs : process_addrs) {
+  for (auto el : elf_addrs) {
     write_location_no_sym(el, map_info, &locations[write_index++]);
   }
 

--- a/test/ddprof_pprof-ut.cc
+++ b/test/ddprof_pprof-ut.cc
@@ -9,9 +9,12 @@
 #include "ddprof_cmdline.hpp"
 #include "ddprof_cmdline_watcher.hpp"
 #include "loghandle.hpp"
+#include "map_utils.hpp"
 #include "pevent_lib_mocks.hpp"
 #include "symbol_hdr.hpp"
 #include "unwind_output_mock.hpp"
+
+#include <datadog/blazesym.h>
 
 #include <cstdlib>
 #include <fcntl.h>
@@ -118,6 +121,110 @@ TEST(DDProfPProf, just_live) {
   test_pprof(&pprof);
   res = pprof_free_profile(&pprof);
   EXPECT_TRUE(IsDDResOK(res));
+}
+
+// Test that location addresses are properly grouped based on inlining mode
+TEST(DDProfPProf, address_grouping_by_inlining_mode) {
+  LogHandle handle;
+
+  // Test with inlining disabled - should use function start address
+  {
+    MapInfo map_info(0x1000, 0x2000, 0, "/test/binary", BuildIdStr{});
+    std::array<ddog_prof_Location, 3> locations;
+    unsigned write_index = 0;
+
+    // Mock blaze_sym for same function, different instruction addresses
+    blaze_symbolize_code_info code_info{.dir = nullptr,
+                                        .file = "/test/source.c",
+                                        .line = 42,
+                                        .column = 0,
+                                        .reserved = {}};
+
+    blaze_sym sym{.name = "test_function",
+                  .module = "/test/binary",
+                  .addr = 0x1000, // Function start address
+                  .offset = 0x50, // Offset from function start
+                  .size = 0x100,
+                  .code_info = code_info,
+                  .inlined_cnt = 0,
+                  .inlined = nullptr,
+                  .reason = {},
+                  .reserved = {}};
+
+    HeterogeneousLookupStringMap<std::string> demangled_names;
+
+    // Write first location (inlining disabled)
+    ElfAddress_t addr1 = 0x1050; // Different instruction address
+    DDRes res = write_location_blaze(addr1, demangled_names, map_info, sym,
+                                     write_index, locations, false);
+    EXPECT_TRUE(IsDDResOK(res));
+    EXPECT_EQ(write_index, 1u);
+    // Should use function start address (sym.addr), not instruction address
+    EXPECT_EQ(locations[0].address, 0x1000u);
+
+    // Write second location with different instruction address (inlining
+    // disabled)
+    ElfAddress_t addr2 = 0x1070; // Different instruction in same function
+    sym.offset = 0x70;
+    res = write_location_blaze(addr2, demangled_names, map_info, sym,
+                               write_index, locations, false);
+    EXPECT_TRUE(IsDDResOK(res));
+    EXPECT_EQ(write_index, 2u);
+    // Should also use function start address
+    EXPECT_EQ(locations[1].address, 0x1000u);
+
+    // Verify both locations have same address (grouped)
+    EXPECT_EQ(locations[0].address, locations[1].address);
+  }
+
+  // Test with inlining enabled - should use instruction address
+  {
+    MapInfo map_info(0x1000, 0x2000, 0, "/test/binary", BuildIdStr{});
+    std::array<ddog_prof_Location, 3> locations;
+    unsigned write_index = 0;
+
+    blaze_symbolize_code_info code_info{.dir = nullptr,
+                                        .file = "/test/source.c",
+                                        .line = 42,
+                                        .column = 0,
+                                        .reserved = {}};
+
+    blaze_sym sym{.name = "test_function",
+                  .module = "/test/binary",
+                  .addr = 0x1000,
+                  .offset = 0x50,
+                  .size = 0x100,
+                  .code_info = code_info,
+                  .inlined_cnt = 0,
+                  .inlined = nullptr,
+                  .reason = {},
+                  .reserved = {}};
+
+    HeterogeneousLookupStringMap<std::string> demangled_names;
+
+    // Write first location (inlining enabled)
+    ElfAddress_t addr1 = 0x1050;
+    DDRes res = write_location_blaze(addr1, demangled_names, map_info, sym,
+                                     write_index, locations, true);
+    EXPECT_TRUE(IsDDResOK(res));
+    EXPECT_EQ(write_index, 1u);
+    // Should use actual instruction address
+    EXPECT_EQ(locations[0].address, 0x1050u);
+
+    // Write second location with different instruction address (inlining
+    // enabled)
+    ElfAddress_t addr2 = 0x1070;
+    sym.offset = 0x70;
+    res = write_location_blaze(addr2, demangled_names, map_info, sym,
+                               write_index, locations, true);
+    EXPECT_TRUE(IsDDResOK(res));
+    EXPECT_EQ(write_index, 2u);
+    // Should use actual instruction address
+    EXPECT_EQ(locations[1].address, 0x1070u);
+
+    // Verify locations have different addresses (not grouped)
+    EXPECT_NE(locations[0].address, locations[1].address);
+  }
 }
 
 } // namespace ddprof


### PR DESCRIPTION
# What does this PR do?

- Use elf addresses by default
- Group addresses by function when inlining is off

# Motivation

This makes it easier to do addr2line when debugging.
This will make it more efficient to cache locations.

# Additional Notes

New locations with aggregated locations pointing to start of function:
```
Locations
     1: 0xaab10 M=1 operator new(unsigned long) libstdc++.so.6.0.28:0:0 s=0()
     2: 0x12c9 M=2 allocate_memory(unsigned long) test:0:0 s=0()
     3: 0x1416 M=2 main test:0:0 s=0()
     4: 0x23f90 M=3 __libc_start_main libc-2.31.so:0:0 s=0()
     5: 0x11e0 M=2 _start test:0:0 s=0()
     6: 0x0 test /app/test:0:0 s=0()
```
Old locations (with many different locations for main)
```
Locations
     1: 0x7a49902d3b28 M=1 operator new(unsigned long) libstdc++.so.6.0.28:0:0 s=0()
...
     3: 0x6193d34cc4f5 M=2 main test:0:0 s=0()
...
     7: 0x6193d34cc4ff M=2 main test:0:0 s=0()
     8: 0x6193d34cc4e1 M=2 main test:0:0 s=0()
     9: 0x6193d34cc4eb M=2 main test:0:0 s=0()
    10: 0x6193d34cc4d7 M=2 main test:0:0 s=0()
...
```

# How to test the change?

This is mostly covered by existing tests.
I agree that number of locations & aggregation logics are never really considered. Though this is not something users would care about.
