### PR TITLE
perf main loop - Change default to timeout 50ms

### DIFF
--- a/include/perf.hpp
+++ b/include/perf.hpp
@@ -23,7 +23,7 @@ inline constexpr int k_default_buffer_size_shift{6};
 inline constexpr int k_mpsc_buffer_size_shift{10};
 
 // sample frequency check
-inline constexpr std::chrono::milliseconds k_sample_default_wakeup{100};
+inline constexpr std::chrono::milliseconds k_sample_default_wakeup{50};
 
 struct read_format {
   uint64_t value;        // The value of the event


### PR DESCRIPTION
# What does this PR do?

@nsavoire described a case where allocation events would not trigger the wake up of the mainloop(on poll). This is a workaround to avoid loosing allocation events.

# Motivation

Ensure we loose no allocation events.

# Additional Notes

@nsavoire was trying to understand why this would happen.
We suspect a race between considering the event in the loop and setting the event as readable.

# How to test the change?

I do not have a good test for this.
