### PR TITLE
Reduce poll timeout to 10ms

### DIFF
--- a/src/perf_mainloop.cc
+++ b/src/perf_mainloop.cc
@@ -339,9 +339,8 @@ worker_process_ring_buffers(std::span<PEvent> pes, DDProfContext &ctx,
           if (IsDDResNotOK(res)) {
             return res;
           }
-          // \fixme{nsavoire} free slot as soon as possible ?
-          // reader.advance(hdr->size);
 
+          reader.advance(hdr->size);
           buffer = remaining(buffer, hdr->size);
         }
       } else {
@@ -358,8 +357,7 @@ worker_process_ring_buffers(std::span<PEvent> pes, DDProfContext &ctx,
             return res;
           }
 
-          // \fixme{nsavoire} free slot as soon as possible ?
-          // reader.advance();
+          reader.advance();
         }
       }
 


### PR DESCRIPTION
# What does this PR do?

* Reduce poll timeout to 10ms: sometimes in `alloc_live_heap` mode, consumer worker times out on poll call whereas there are many events to process in ringbuffer. It seems that producer fails to notify profiler through eventfd. Not sure why, this is a workaround.
* Eagerly advance ring buffer reader position as soon as an event is processed