### PR TITLE
Arm fixups

### DIFF
--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -70,6 +70,32 @@ private:
 };
 
 /**************
+ * vDSO file  *
+ **************/
+
+class VdsoSnapshot {
+public:
+  VdsoSnapshot();
+  ~VdsoSnapshot();
+
+  VdsoSnapshot(const VdsoSnapshot &other) = delete;
+  VdsoSnapshot &operator=(const VdsoSnapshot &other) = delete;
+  VdsoSnapshot(VdsoSnapshot &&other) noexcept;
+  VdsoSnapshot &operator=(VdsoSnapshot &&other) noexcept;
+
+  void set(FileInfo info);
+
+  [[nodiscard]] bool ready() const;
+  [[nodiscard]] const FileInfo &info() const;
+
+private:
+  void reset();
+
+  FileInfo _info;
+  bool _ready{false};
+};
+
+/**************
  * DSO Header *
  **************/
 /// Keep track of binaries and associate them to address ranges
@@ -113,7 +139,12 @@ public:
 
   /******* MAIN APIS **********/
   explicit DsoHdr(std::string_view path_to_proc = "", int dd_profiling_fd = -1);
-  ~DsoHdr();
+  ~DsoHdr() = default;
+
+  DsoHdr(const DsoHdr &other) = delete;
+  DsoHdr &operator=(const DsoHdr &other) = delete;
+  DsoHdr(DsoHdr &&other) noexcept = default;
+  DsoHdr &operator=(DsoHdr &&other) noexcept = default;
 
   // Add the element check for overlap and remove them
   DsoFindRes insert_erase_overlap(Dso &&dso);
@@ -238,8 +269,7 @@ private:
   // Assumption is that we have a single version of the dd_profiling library
   // across all PIDs.
   FileInfoId_t _dd_profiling_file_info = k_file_info_undef;
-  FileInfo _vdso_snapshot_info;
-  bool _vdso_snapshot_ready{false};
+  VdsoSnapshot _vdso_snapshot;
   FileInfoId_t _vdso_file_info = k_file_info_undef;
 };
 

--- a/include/unwind_helper.hpp
+++ b/include/unwind_helper.hpp
@@ -32,4 +32,21 @@ void add_virtual_base_frame(UnwindState *us);
 void add_error_frame(const Dso *dso, UnwindState *us, ProcessAddress_t pc,
                      SymbolErrors error_case = SymbolErrors::unknown_mapping);
 
+#if defined(__aarch64__)
+inline uint64_t canonicalize_user_address(uint64_t addr) {
+  // Drop the top byte that may hold a pointer tag (TBI/MTE) before sign
+  // extension so we can match proc-maps entries.
+  constexpr uint64_t top_byte_mask = (uint64_t{1} << 56) - 1;
+  addr &= top_byte_mask;
+
+  constexpr unsigned canonical_bits = 48;
+  if (canonical_bits < 56) {
+    addr &= (uint64_t{1} << canonical_bits) - 1;
+  }
+  return addr;
+}
+#else
+inline uint64_t canonicalize_user_address(uint64_t addr) { return addr; }
+#endif
+
 } // namespace ddprof

--- a/include/unwind_helper.hpp
+++ b/include/unwind_helper.hpp
@@ -36,11 +36,12 @@ void add_error_frame(const Dso *dso, UnwindState *us, ProcessAddress_t pc,
 inline uint64_t canonicalize_user_address(uint64_t addr) {
   // Drop the top byte that may hold a pointer tag (TBI/MTE) before sign
   // extension so we can match proc-maps entries.
-  constexpr uint64_t top_byte_mask = (uint64_t{1} << 56) - 1;
+  constexpr unsigned k_top_byte_shift = 56;
+  constexpr uint64_t top_byte_mask = (uint64_t{1} << k_top_byte_shift) - 1;
   addr &= top_byte_mask;
 
   constexpr unsigned canonical_bits = 48;
-  if (canonical_bits < 56) {
+  if (canonical_bits < k_top_byte_shift) {
     addr &= (uint64_t{1} << canonical_bits) - 1;
   }
   return addr;

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -16,12 +16,17 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
+#include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
+#include <filesystem>
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <sys/stat.h>
 #include <unistd.h>
+#include <vector>
 
 namespace ddprof {
 
@@ -61,6 +66,50 @@ UniqueFile open_proc_maps(int pid, const char *path_to_proc = "") {
 bool is_intersection_allowed(const Dso &old_so, const Dso &new_dso) {
   return old_so.is_same_file(new_dso) ||
       (old_so._type == DsoType::kStandard && new_dso._type == DsoType::kAnon);
+}
+
+struct VdsoBounds {
+  uintptr_t start;
+  size_t length;
+};
+
+std::optional<VdsoBounds> find_self_vdso_bounds() {
+  UniqueFile maps{fopen("/proc/self/maps", "r")};
+  if (!maps) {
+    return std::nullopt;
+  }
+  char *line = nullptr;
+  size_t cap = 0;
+  auto cleanup = make_defer([&]() { free(line); });
+  while (getline(&line, &cap, maps.get()) != -1) {
+    if (line != nullptr && strstr(line, "[vdso]") != nullptr) {
+      uintptr_t start = 0;
+      uintptr_t end = 0;
+      if (sscanf(line, "%lx-%lx", &start, &end) == 2 && end > start) {
+        return VdsoBounds{start, static_cast<size_t>(end - start)};
+      }
+      break;
+    }
+  }
+  return std::nullopt;
+}
+
+bool write_all(int fd, const uint8_t *data, size_t size) {
+  size_t written = 0;
+  while (written < size) {
+    ssize_t rc = ::write(fd, data + written, size - written);
+    if (rc < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    if (rc == 0) {
+      return false;
+    }
+    written += static_cast<size_t>(rc);
+  }
+  return true;
 }
 } // namespace
 
@@ -109,8 +158,15 @@ DsoHdr::DsoHdr(std::string_view path_to_proc, int dd_profiling_fd)
   } else {
     _path_to_proc = path_to_proc;
   }
+  init_workspace_remap();
   // 0 element is error element
   _file_info_vector.emplace_back(FileInfo(), 0);
+}
+
+DsoHdr::~DsoHdr() {
+  if (_vdso_snapshot_ready && !_vdso_snapshot_info._path.empty()) {
+    ::unlink(_vdso_snapshot_info._path.c_str());
+  }
 }
 
 namespace {
@@ -307,6 +363,48 @@ FileInfoId_t DsoHdr::update_id_dd_profiling(const Dso &dso) {
   return _dd_profiling_file_info;
 }
 
+FileInfoId_t DsoHdr::update_id_from_dso(const Dso &dso) {
+  if (dso._type == DsoType::kVdso) {
+    return update_id_vdso(dso);
+  }
+
+  if (!has_relevant_path(dso._type)) {
+    dso._id = k_file_info_error; // no file associated
+    return dso._id;
+  }
+
+  if (dso._type == DsoType::kDDProfiling) {
+    return update_id_dd_profiling(dso);
+  }
+
+  return update_id_from_path(dso);
+}
+
+FileInfoId_t DsoHdr::update_id_vdso(const Dso &dso) {
+  if (_vdso_file_info != k_file_info_undef) {
+    dso._id = _vdso_file_info;
+    return dso._id;
+  }
+
+  FileInfo file_info = find_vdso_file_info();
+  if (!file_info._inode) {
+    dso._id = k_file_info_error;
+    return dso._id;
+  }
+
+  const FileInfoInodeKey key(file_info._inode, file_info._size);
+  auto [it, inserted] =
+      _file_info_inode_map.emplace(key, _file_info_vector.size());
+  if (inserted) {
+    dso._id = it->second;
+    _file_info_vector.emplace_back(std::move(file_info), dso._id);
+  } else {
+    dso._id = it->second;
+  }
+  _vdso_file_info = dso._id;
+  return dso._id;
+}
+
 FileInfoId_t DsoHdr::update_id_from_path(const Dso &dso) {
 
   FileInfo file_info = find_file_info(dso);
@@ -335,19 +433,6 @@ FileInfoId_t DsoHdr::update_id_from_path(const Dso &dso) {
     }
   }
   return dso._id;
-}
-
-FileInfoId_t DsoHdr::update_id_from_dso(const Dso &dso) {
-  if (!has_relevant_path(dso._type)) {
-    dso._id = k_file_info_error; // no file associated
-    return dso._id;
-  }
-
-  if (dso._type == DsoType::kDDProfiling) {
-    return update_id_dd_profiling(dso);
-  }
-
-  return update_id_from_path(dso);
 }
 
 bool DsoHdr::maybe_insert_erase_overlap(Dso &&dso,
@@ -528,9 +613,91 @@ Dso DsoHdr::dso_from_proc_line(int pid, const char *line) {
           DsoOrigin::kProcMaps};
 }
 
+void DsoHdr::init_workspace_remap() {
+  _workspace_host_prefix.clear();
+  _workspace_container_root.clear();
+  if (const char *workspace_env = std::getenv("DDPROF_WORKSPACE_ROOT");
+      workspace_env && workspace_env[0] != '\0') {
+    std::string mapping = workspace_env;
+    auto const sep = mapping.find('|');
+    if (sep != std::string::npos) {
+      _workspace_host_prefix = mapping.substr(0, sep);
+      _workspace_container_root = mapping.substr(sep + 1);
+    } else {
+      LG_WRN("DDPROF_WORKSPACE_ROOT is expected to be "
+             "'<host_prefix>|<container_root>'");
+    }
+  }
+  auto trim_trailing_slash = [](std::string &path) {
+    while (path.size() > 1 && !path.empty() && path.back() == '/') {
+      path.pop_back();
+    }
+  };
+  trim_trailing_slash(_workspace_host_prefix);
+  trim_trailing_slash(_workspace_container_root);
+  if (_workspace_host_prefix.empty() || _workspace_container_root.empty()) {
+    _workspace_host_prefix.clear();
+    _workspace_container_root.clear();
+  } else {
+    LG_NTC("DDPROF_WORKSPACE_ROOT is set to %s|%s",
+           _workspace_host_prefix.c_str(), _workspace_container_root.c_str());
+  }
+}
+
+// Best-effort remapping for local macOS development. When the environment
+// variable DDPROF_WORKSPACE_ROOT is set to "<host_prefix>|<container_root>",
+// file paths backed by the host (for example /run/host_virtiofs/...) can be
+// converted to the in-container path so that libdwfl can locate the ELF.
+// Example when using the launch_local_build.sh script:
+// /run/host_virtiofs/Users/foo/dd/ddprof/build/... -> /app/build/...
+std::optional<std::string>
+DsoHdr::remap_host_workspace_path(std::string_view original) const {
+  if (_workspace_host_prefix.empty() || _workspace_container_root.empty()) {
+    return std::nullopt;
+  }
+
+  namespace fs = std::filesystem;
+
+  fs::path prefix_path(_workspace_host_prefix);
+  fs::path container_path(_workspace_container_root);
+  fs::path original_path(original);
+
+  prefix_path = prefix_path.lexically_normal();
+  container_path = container_path.lexically_normal();
+  original_path = original_path.lexically_normal();
+
+  if (prefix_path.empty() || container_path.empty()) {
+    return std::nullopt;
+  }
+
+  auto it_orig = original_path.begin();
+  auto it_prefix = prefix_path.begin();
+  for (; it_prefix != prefix_path.end(); ++it_prefix, ++it_orig) {
+    if (it_orig == original_path.end() || *it_prefix != *it_orig) {
+      return std::nullopt;
+    }
+  }
+
+  fs::path suffix;
+  for (; it_orig != original_path.end(); ++it_orig) {
+    suffix /= *it_orig;
+  }
+
+  fs::path remapped = container_path;
+  if (!suffix.empty()) {
+    remapped /= suffix;
+  }
+  remapped = remapped.lexically_normal();
+  return remapped.string();
+}
+
 FileInfo DsoHdr::find_file_info(const Dso &dso) {
   int64_t size;
   inode_t inode;
+
+  if (dso._type == DsoType::kVdso) {
+    return find_vdso_file_info();
+  }
 
   // First, try to find matching file in profiler mount namespace since it will
   // still be accessible when process exits
@@ -551,8 +718,23 @@ FileInfo DsoHdr::find_file_info(const Dso &dso) {
     return {proc_path, size, inode};
   }
 
+  if (auto remapped = remap_host_workspace_path(dso._filename)) {
+    if (get_file_inode(remapped->c_str(), &inode, &size)) {
+      LG_DBG("[DSO] Remapped %s -> %s", dso._filename.c_str(),
+             remapped->c_str());
+      return {*remapped, size, inode};
+    }
+  }
+
   LG_DBG("[DSO] Unable to find path to %s", dso._filename.c_str());
   return {};
+}
+
+FileInfo DsoHdr::find_vdso_file_info() {
+  if (!ensure_vdso_snapshot()) {
+    return {};
+  }
+  return _vdso_snapshot_info;
 }
 
 int DsoHdr::get_nb_dso() const {
@@ -633,5 +815,67 @@ int DsoHdr::clear_unvisited(const std::unordered_set<pid_t> &visited_pids) {
     _pid_map.erase(pid);
   }
   return pids_to_clear.size();
+}
+
+bool DsoHdr::ensure_vdso_snapshot() {
+  if (_vdso_snapshot_ready) {
+    return true;
+  }
+
+  auto bounds_opt = find_self_vdso_bounds();
+  if (!bounds_opt) {
+    LG_WRN("[DSO] Unable to locate local vDSO mapping");
+    return false;
+  }
+
+  UniqueFd mem_fd{::open("/proc/self/mem", O_RDONLY)};
+  if (!mem_fd) {
+    LG_WRN("[DSO] Unable to open /proc/self/mem: %s", strerror(errno));
+    return false;
+  }
+
+  std::vector<uint8_t> buffer(bounds_opt->length);
+  size_t copied = 0;
+  while (copied < buffer.size()) {
+    ssize_t rd =
+        pread(mem_fd.get(), buffer.data() + copied, buffer.size() - copied,
+              static_cast<off_t>(bounds_opt->start + copied));
+    if (rd < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      LG_WRN("[DSO] Failed to copy vDSO bytes: %s", strerror(errno));
+      return false;
+    }
+    if (rd == 0) {
+      LG_WRN("[DSO] Failed to copy vDSO bytes: %s", strerror(errno));
+      return false;
+    }
+    copied += static_cast<size_t>(rd);
+  }
+
+  char path_template[] = "/tmp/ddprof-vdsoXXXXXX";
+  int fd = mkstemp(path_template);
+  if (fd == -1) {
+    LG_WRN("[DSO] Unable to create vDSO snapshot file: %s", strerror(errno));
+    return false;
+  }
+  auto fd_cleanup = make_defer([&]() { ::close(fd); });
+  if (!write_all(fd, buffer.data(), buffer.size())) {
+    LG_WRN("[DSO] Unable to write vDSO snapshot file: %s", strerror(errno));
+    ::unlink(path_template);
+    return false;
+  }
+
+  struct stat st{};
+  if (fstat(fd, &st) != 0) {
+    LG_WRN("[DSO] Unable to stat vDSO snapshot file: %s", strerror(errno));
+    ::unlink(path_template);
+    return false;
+  }
+
+  _vdso_snapshot_info = FileInfo(path_template, st.st_size, st.st_ino);
+  _vdso_snapshot_ready = true;
+  return true;
 }
 } // namespace ddprof

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -49,7 +49,7 @@ struct LoggerContext {
   LogsAllowedCallback logs_allowed_function;
 };
 
-LoggerContext log_ctx{.fd = -1, .mode = LOG_STDERR, .level = LL_ERROR};
+LoggerContext log_ctx{};
 } // namespace
 
 void LOG_setlevel(int lvl) {
@@ -190,17 +190,13 @@ void vlprintfln(int lvl, int fac, const char *format, va_list args) {
                     "<%d>%s.%06ld %s[%d]: ", lvl + (fac * LL_LENGTH), tm_str,
                     d_us.count(), name, pid);
   } else {
+    // LL_EMERGENCY is 0
     const char *levels[LL_LENGTH] = {
-        [LL_EMERGENCY] = "EMERGENCY",
-        [LL_ALERT] = "ALERT",
-        [LL_CRITICAL] = "CRITICAL",
-        [LL_ERROR] = "ERROR",
-        [LL_WARNING] = "WARNING",
-        [LL_NOTICE] = "NOTICE",
-        [LL_INFORMATIONAL] = "INFORMATIONAL",
-        [LL_DEBUG] = "DEBUG",
+        "EMERGENCY", "ALERT",  "CRITICAL",      "ERROR",
+        "WARNING",   "NOTICE", "INFORMATIONAL", "DEBUG",
     };
-    sz_h = snprintf(buf, LOG_MSG_CAP, "<%s>%s.%06lu %s[%d]: ", levels[lvl],
+    sz_h = snprintf(buf, LOG_MSG_CAP, "<%s>%s.%06lu %s[%d]: ",
+                    (lvl >= 0 && lvl < LL_LENGTH ? levels[lvl] : "UNKNOWN"),
                     tm_str, d_us.count(), name, pid);
   }
 

--- a/src/unwind_dwfl.cc
+++ b/src/unwind_dwfl.cc
@@ -79,6 +79,7 @@ DDRes add_symbol(Dwfl_Frame *dwfl_frame, UnwindState *us) {
     add_error_frame(nullptr, us, pc, SymbolErrors::unwind_failure);
     return {}; // invalid pc : do not add frame
   }
+  pc = canonicalize_user_address(pc);
   us->current_ip = pc;
   DsoHdr &dsoHdr = us->dso_hdr;
   DsoHdr::PidMapping &pid_mapping = dsoHdr.get_pid_mapping(us->pid);
@@ -168,6 +169,7 @@ DDRes add_symbol(Dwfl_Frame *dwfl_frame, UnwindState *us) {
   if (!is_activation) {
     --pc;
   }
+  pc = canonicalize_user_address(pc);
   us->current_ip = pc;
 
   // Now we register

--- a/test/ddprof_stats-ut.cc
+++ b/test/ddprof_stats-ut.cc
@@ -81,7 +81,7 @@ TEST(ddprof_statsTest, ConnectAndSet) {
 }
 
 TEST(ddprof_statsTest, Arithmetic) {
-  const char path_listen[] = UNIT_TEST_DATA "/my_statsd_listener.sock";
+  const char path_listen[] = "/tmp/my_statsd_listener_arithmetic";
   unlink(path_listen); // make sure node is available, OK if this fails
 
   // Initiate "server"

--- a/tools/style-check.sh
+++ b/tools/style-check.sh
@@ -33,5 +33,5 @@ declare -a arr_folders=("src" "test" "include")
 FILES_TO_FORMAT=".*[.]\(cpp\|cc\|c\|cxx\|h\|hpp\)"
 find "${arr_folders[@]}" -regex "${FILES_TO_FORMAT}" -print0 | xargs -0 "${CLANG_FORMAT}" ${CLANG_OPTION}
 
-find . -maxdepth 1 -\( -name CMakeLists.txt -or -name '*.cmake' -\) -print0 | xargs -0 cmake-format ${CMAKE_FORMAT_OPTIONS}
-find cmake src test -\( -name CMakeLists.txt -or -name '*.cmake' -\) -print0 | xargs -0 cmake-format ${CMAKE_FORMAT_OPTIONS}
+find . -maxdepth 1 \( -name CMakeLists.txt -or -name '*.cmake' \) -print0 | xargs -0 cmake-format ${CMAKE_FORMAT_OPTIONS}
+find cmake src test \( -name CMakeLists.txt -or -name '*.cmake' \) -print0 | xargs -0 cmake-format ${CMAKE_FORMAT_OPTIONS}


### PR DESCRIPTION
# What does this PR do?

- Upgrade elfutils to 0.194
- Add some support to ensure we can work with virtiofs paths
```
(/run/host_virtiofs/Users/erwan.viollet/go/src/github.com/DataDog/ddprof/build_gcc_unknown-linux-2.39_Deb/test/simple_malloc)(T-Standard)(r-x)(ID#-1)
```
- Add a heuristic to get past vdso in arm64

# Motivation

Working from MacOS aarch64, I was not able to get proper frames.
With these changes, I no longer have failures on Simple Malloc tests.

# Additional Notes

This will require a branch in `ddprof-build` to cache elfutils:
https://github.com/DataDog/ddprof-build/pull/152

# How to test the change?

Describe here in detail how the change can be validated.  This is a great section to call out specific tests you've added or improved, or to acknowledge code sections which are particularly difficult to test.
