### PR TITLE
Avoid matching symbols at address 0

### DIFF
--- a/src/symbolizer.cc
+++ b/src/symbolizer.cc
@@ -99,6 +99,14 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
       // This will be moved to the backend
       for (size_t i = 0; i < blaze_res->cnt && i < elf_addrs.size(); ++i) {
         const blaze_sym *cur_sym = blaze_res->syms + i;
+        if (cur_sym->addr == 0) {
+          // Some binaries expose a single symbol at address 0 (ex:
+          // DD_AGENT_V1). Avoid emitting it so the backend still attempts
+          // symbolication.
+          write_location_no_sym(elf_addrs[i], map_info,
+                                &locations[write_index++]);
+          continue;
+        }
         DDRES_CHECK_FWD(write_location_blaze(
             elf_addrs[i], symbolizer_wrapper.demangled_names, map_info,
             *cur_sym, write_index, locations));


### PR DESCRIPTION
# What does this PR do?

Avoid matching symbols at address 0.

# Motivation

This will help our backend trigger remote symbolication calls
Ticket number: SMPTNG-723

# Additional Notes

NA

# How to test the change?

Before we would have a single DD_AGENT_1 symbol and we would not trigger remote symbolication

<img width="2418" height="767" alt="image" src="https://github.com/user-attachments/assets/18ae48b1-a8a6-4f4c-9b5d-7994e1450544" />
