### PR TITLE
Fix off-by-one heap-buffer-overflow in get_or_create_temp_file()

### DIFF
--- a/src/lib/loader.c
+++ b/src/lib/loader.c
@@ -209,8 +209,9 @@ static char *get_or_create_temp_file(const char *prefix, EmbeddedData data,
     return NULL;
   }
 
+  // +3 for '/' separator, '-' separator, and NUL terminator
   char *path =
-      malloc(strlen(tmp_dir) + strlen(prefix) + strlen(data.digest) + 2);
+      malloc(strlen(tmp_dir) + 1 + strlen(prefix) + 1 + strlen(data.digest) + 1);
   if (path == NULL) {
     return NULL;
   }


### PR DESCRIPTION
# What does this PR do?

Fix off-by-one heap-buffer-overflow in `get_or_create_temp_file()` in `src/lib/loader.c`.

The `malloc` allocates `strlen(tmp_dir) + strlen(prefix) + strlen(data.digest) + 2`, but the path `tmp_dir/prefix-digest\0` needs `+3` (for `/`, `-`, and `\0`). The NUL terminator overflows by 1 byte.

# Motivation

Detected via AddressSanitizer when `dlopen`ing `libdd_profiling.so` (v0.23.0 release):

```
==2568==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7bf027027061
WRITE of size 65 at 0x7bf027027061 thread T0
  [frame=0, function=strcat]
  [frame=1, function=get_or_create_temp_file, location=loader.c]
  [frame=2, function=loader, location=loader.c]
```

The sister function `create_temp_file()` is correct (only 1 separator).

# Additional Notes

In practice, the 1-byte NUL overflow is benign on most allocators — it only crashes under ASAN.

# How to test the change?

`dlopen` `libdd_profiling.so` under AddressSanitizer.

# Classification

- **[CWE-131](https://cwe.mitre.org/data/definitions/131.html)**: Incorrect Calculation of Buffer Size
- **[CWE-122](https://cwe.mitre.org/data/definitions/122.html)**: Heap-based Buffer Overflow

Fixes #492