### PR TITLE
Skip UID elevation for non-root users to preserve capabilities

### DIFF
--- a/src/ddprof_process.cc
+++ b/src/ddprof_process.cc
@@ -23,15 +23,14 @@ UniqueFile open_proc_comm(pid_t pid, pid_t tid, const char *path_to_proc = "") {
   const std::string proc_comm_filename =
       absl::StrFormat("%s/proc/%d/task/%d/comm", path_to_proc, pid, tid);
   UniqueFile file{fopen(proc_comm_filename.c_str(), "r"), fclose};
-  if (!file) {
-    // Check if the file exists
+  if (!file && is_root()) {
+    // Same rationale as open_proc_maps: UID elevation destroys
+    // capabilities for non-root users (capabilities(7)).
     struct stat info;
     UIDInfo old_uids;
-    // warning could user switch create too much overhead ?
     if (stat(proc_comm_filename.c_str(), &info) == 0 &&
         IsDDResOK(user_override(info.st_uid, info.st_gid, &old_uids))) {
       file.reset(fopen(proc_comm_filename.c_str(), "r"));
-      // Switch back to the original user
       user_override(old_uids.uid, old_uids.gid);
     }
   }

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -43,15 +43,16 @@ UniqueFile open_proc_maps(int pid, const char *path_to_proc = "") {
   }
 
   UniqueFile f{fopen(proc_map_filename, "r")};
-  if (!f) {
-    // Check if the file exists
+  if (!f && is_root()) {
+    // UID elevation is only safe when running as root (saved-set-user-ID
+    // stays 0, so the round-trip preserves capabilities).  For non-root
+    // users the UID transition back to nonzero clears all capabilities
+    // (see capabilities(7), "Effect of user ID changes on capabilities").
     struct stat info;
     UIDInfo old_uids;
     if (stat(proc_map_filename, &info) == 0 &&
-        // try to switch to file user
         IsDDResOK(user_override(info.st_uid, info.st_gid, &old_uids))) {
       f.reset(fopen(proc_map_filename, "r"));
-      // switch back to initial user
       user_override(old_uids.uid, old_uids.gid);
     }
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -144,6 +144,12 @@ target_include_directories(cap-ut PRIVATE ${LIBCAP_INCLUDE_DIR})
 
 add_unit_test(user_id-ut user_id-ut.cc ../src/user_override.cc DEFINITIONS MYNAME="userid-ut")
 
+add_unit_test(
+  user_override_caps-ut user_override_caps-ut.cc ../src/user_override.cc
+  LIBRARIES libcap
+  DEFINITIONS MYNAME="user_override_caps-ut")
+target_include_directories(user_override_caps-ut PRIVATE ${LIBCAP_INCLUDE_DIR})
+
 add_unit_test(procutils-ut ../src/procutils.cc procutils-ut.cc DEFINITIONS MYNAME="procutils-ut")
 
 add_unit_test(

--- a/test/user_override_caps-ut.cc
+++ b/test/user_override_caps-ut.cc
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include <gtest/gtest.h>
+
+#include "loghandle.hpp"
+#include "user_override.hpp"
+
+#include <sys/capability.h>
+#include <unistd.h>
+
+namespace ddprof {
+namespace {
+
+int count_effective_caps() {
+  cap_t caps = cap_get_proc();
+  if (!caps) {
+    return -1;
+  }
+  int count = 0;
+  for (int i = 0; i <= CAP_LAST_CAP; ++i) {
+    cap_flag_value_t value = CAP_CLEAR;
+    if (cap_get_flag(caps, i, CAP_EFFECTIVE, &value) == 0 && value == CAP_SET) {
+      ++count;
+    }
+  }
+  cap_free(caps);
+  return count;
+}
+
+} // namespace
+
+// Verify that is_root() agrees with getuid().
+TEST(UserOverrideCapsTest, is_root_matches_uid) {
+  LogHandle handle;
+  if (getuid() == 0) {
+    EXPECT_TRUE(is_root());
+  } else {
+    EXPECT_FALSE(is_root());
+  }
+}
+
+// For non-root users without CAP_SETUID, user_override(0,0) fails with
+// EPERM and must not destroy existing capabilities.
+TEST(UserOverrideCapsTest, failed_elevation_preserves_caps) {
+  LogHandle handle;
+
+  if (is_root()) {
+    GTEST_SKIP() << "only meaningful for non-root users";
+  }
+
+  int const caps_before = count_effective_caps();
+
+  UIDInfo old_uids;
+  DDRes res = user_override(0, 0, &old_uids);
+
+  if (IsDDResOK(res)) {
+    // Unlikely in CI, but restore if it succeeded.
+    user_override(old_uids.uid, old_uids.gid);
+  }
+
+  EXPECT_EQ(count_effective_caps(), caps_before)
+      << "capabilities lost during failed UID elevation";
+}
+
+} // namespace ddprof


### PR DESCRIPTION
# What does this PR do?

Fixes #494

Guards the UID elevation in `open_proc_maps()` and `open_proc_comm()` with `is_root()` so non-root users skip it entirely.

# Motivation

When ddprof runs as a non-root user with file capabilities (`cap_perfmon`, `cap_sys_ptrace`, etc.), profiling a target that owns different file capabilities (e.g. nginx with `cap_net_bind_service`) triggers a UID round-trip through 0 in `open_proc_maps()`. On the way back (`setresuid(1000, 1000, -1)`), the kernel permanently clears all capabilities from the permitted, effective, and ambient sets.

This is documented in capabilities(7) under "Effect of user ID changes on capabilities":

> If one or more of the real, effective, or saved set user IDs was previously 0, and as a result of the UID changes all of these IDs have a nonzero value, then all capabilities are cleared from the permitted, effective, and ambient capability sets.

The rule exists because the kernel treats the transition "was root, now isn't" as a credential downgrade and drops everything. See `cap_emulate_setxuid()` in `kernel/security/commoncap.c` (called from `setresuid`).

For root users the round-trip is safe: the saved-set-user-ID stays 0, so the condition never fires. For non-root users the elevation is also pointless: reading a non-dumpable process's `/proc/<pid>/maps` requires `CAP_SYS_PTRACE` regardless of UID.

# Additional Notes

Rebased on current main. Simplified test compared to v1.

# How to test the change?

The new `user_override_caps-ut` test verifies that a failed `user_override(0, 0)` call (the non-root CI case) does not destroy existing capabilities.

To reproduce the full bug path manually:
```
sudo setcap 'cap_setuid,cap_setgid,cap_ipc_lock,cap_perfmon=+ep' ./ddprof
# run ddprof as non-root against a target with file caps
# observe CapEff drops to 0 in /proc/<ddprof_pid>/status after first maps read
```
