### PR TITLE
fix: allow lazy TLS init for threads started before profiling

### DIFF
--- a/include/lib/allocation_tracker.hpp
+++ b/include/lib/allocation_tracker.hpp
@@ -54,6 +54,8 @@ public:
 
   static void notify_thread_start();
   static void notify_fork();
+  static void notify_pthread_getattr_np();
+  static void notify_pthread_getattr_np_end();
 
   static DDRes allocation_tracking_init(uint64_t allocation_profiling_rate,
                                         uint32_t flags,
@@ -76,8 +78,13 @@ public:
   static inline bool is_deallocation_tracking_active();
 
   static TrackerThreadLocalState *init_tl_state();
-  // can return null (does not init)
-  static TrackerThreadLocalState *get_tl_state();
+
+  // can return null if initialization failed/is not possible
+  static TrackerThreadLocalState *
+  get_tl_state(bool init_if_not_initialized = true);
+
+  // does not init
+  static TrackerThreadLocalState &get_tl_state_no_init();
 
 private:
   static constexpr unsigned k_ratio_max_elt_to_bitset_size = 16;

--- a/include/lib/allocation_tracker_tls.hpp
+++ b/include/lib/allocation_tracker_tls.hpp
@@ -18,7 +18,14 @@ struct TrackerThreadLocalState {
   bool reentry_guard{false}; // prevent reentry in AllocationTracker (eg. when
                              // allocation are done inside AllocationTracker)
                              // and double counting of allocations (eg. when new
-                             // calls malloc, or malloc calls mmap internally)
+                             // calls malloc, or malloc calls mmap internally).
+                             // Also used on uninitialized TLS (before placement
+                             // new) to indicate we are inside a hooked
+                             // pthread_getattr_np call, preventing get_tl_state
+                             // from calling init_tl_state which would deadlock
+                             // (init_tl_state -> save_context ->
+                             // pthread_getattr_np). Safe because placement new
+                             // in init_tl_state resets this field to false.
 
   bool allocation_allowed{true}; // Indicate if allocation is allowed or not
                                  // (eg. when we are in mmap hook, we

--- a/src/lib/allocation_tracker.cc
+++ b/src/lib/allocation_tracker.cc
@@ -64,11 +64,23 @@ DDPROF_NOINLINE auto sleep_and_retry_reserve(MPSCRingBufferWriter &writer,
 }
 } // namespace
 
-TrackerThreadLocalState *AllocationTracker::get_tl_state() {
+TrackerThreadLocalState &AllocationTracker::get_tl_state_no_init() {
+  return *reinterpret_cast<TrackerThreadLocalState *>(ddprof_lib_state);
+}
+
+TrackerThreadLocalState *
+AllocationTracker::get_tl_state(bool init_if_not_initialized) {
   // ddprof_lib_state is zero-initialized by libc for each new thread.
   // After placement new (init_tl_state), initialized is set to true.
-  auto *state = reinterpret_cast<TrackerThreadLocalState *>(ddprof_lib_state);
-  return state->initialized ? state : nullptr;
+  auto &state = get_tl_state_no_init();
+  if (state.initialized) {
+    return &state;
+  }
+  if (init_if_not_initialized && !state.reentry_guard) {
+    // We are not inside pthread_getattr_np, so we can initialize the state
+    return init_tl_state();
+  }
+  return nullptr;
 }
 
 TrackerThreadLocalState *AllocationTracker::init_tl_state() {
@@ -560,12 +572,8 @@ AllocationTracker::next_sample_interval(std::minstd_rand &gen) const {
 void AllocationTracker::notify_thread_start() {
   TrackerThreadLocalState *tl_state = get_tl_state();
   if (unlikely(!tl_state)) {
-    tl_state = init_tl_state();
-    if (!tl_state) {
-      LG_DBG("Unable to start allocation profiling on thread %d",
-             ddprof::gettid());
-      return;
-    }
+    LG_DBG("Unable to start allocation profiling on thread %d",
+           ddprof::gettid());
   }
 }
 
@@ -582,6 +590,20 @@ void AllocationTracker::notify_fork() {
     return;
   }
   tl_state->tid = ddprof::gettid();
+}
+
+void AllocationTracker::notify_pthread_getattr_np() {
+  auto &state = get_tl_state_no_init();
+  if (!state.initialized) {
+    state.reentry_guard = true;
+  }
+}
+
+void AllocationTracker::notify_pthread_getattr_np_end() {
+  auto &state = get_tl_state_no_init();
+  if (!state.initialized) {
+    state.reentry_guard = false;
+  }
 }
 
 } // namespace ddprof

--- a/src/lib/allocation_tracker.cc
+++ b/src/lib/allocation_tracker.cc
@@ -105,12 +105,8 @@ DDRes AllocationTracker::allocation_tracking_init(
     const IntervalTimerCheck &timer_check) {
   TrackerThreadLocalState *tl_state = get_tl_state();
   if (!tl_state) {
-    // This is the time at which the init_tl_state should not fail
-    // We will not attempt to re-create it in other code paths
-    tl_state = init_tl_state();
-    if (!tl_state) {
-      return ddres_error(DD_WHAT_DWFL_LIB_ERROR);
-    }
+    // This is the time at which the tl_state should be initialized
+    return ddres_error(DD_WHAT_DWFL_LIB_ERROR);
   }
 
   ReentryGuard const guard(&tl_state->reentry_guard);

--- a/src/lib/symbol_overrides.cc
+++ b/src/lib/symbol_overrides.cc
@@ -78,7 +78,7 @@ public:
   // malloc implementation and cause a deadlock when pthread_getattr_np (which
   // can call malloc) is called by tls state initialization.
   AllocTrackerHelperImpl()
-      : _tl_state{ddprof::AllocationTracker::get_tl_state(mmap_alloc)},
+      : _tl_state{ddprof::AllocationTracker::get_tl_state(!mmap_alloc)},
         _guard{_tl_state ? &(_tl_state->reentry_guard) : nullptr} {}
 
   void track(void *ptr, size_t size) {
@@ -106,7 +106,7 @@ template <bool mmap_alloc = false> class DeallocTrackerHelperImpl {
 public:
   DeallocTrackerHelperImpl()
       : _tl_state{ddprof::AllocationTracker::is_deallocation_tracking_active()
-                      ? ddprof::AllocationTracker::get_tl_state(mmap_alloc)
+                      ? ddprof::AllocationTracker::get_tl_state(!mmap_alloc)
                       : nullptr},
         _guard{_tl_state ? &(_tl_state->reentry_guard) : nullptr} {}
 

--- a/src/lib/symbol_overrides.cc
+++ b/src/lib/symbol_overrides.cc
@@ -71,26 +71,26 @@ private:
   ddprof::ReentryGuard _guard;
 };
 
-class AllocTrackerHelper {
+template <bool mmap_alloc> class AllocTrackerHelperImpl {
 public:
-  AllocTrackerHelper()
-      : _tl_state{ddprof::AllocationTracker::get_tl_state()},
+  // Do not try to initialize the TLS state when intercepting
+  // mmap/mmap64/munmap/munmap_ because those functions might be called from
+  // malloc implementation and cause a deadlock when pthread_getattr_np (which
+  // can call malloc) is called by tls state initialization.
+  AllocTrackerHelperImpl()
+      : _tl_state{ddprof::AllocationTracker::get_tl_state(mmap_alloc)},
         _guard{_tl_state ? &(_tl_state->reentry_guard) : nullptr} {}
 
   void track(void *ptr, size_t size) {
     if (_guard) {
+      if constexpr (mmap_alloc) {
+        _tl_state->allocation_allowed = false;
+      }
       ddprof::AllocationTracker::track_allocation_s(
-          reinterpret_cast<uintptr_t>(ptr), size, *_tl_state);
-    }
-  }
-
-  // disallow allocation during tracking
-  void track_no_alloc(void *ptr, size_t size, bool is_large_alloc = false) {
-    if (_guard) {
-      tl_state()->allocation_allowed = false;
-      ddprof::AllocationTracker::track_allocation_s(
-          reinterpret_cast<uintptr_t>(ptr), size, *_tl_state, is_large_alloc);
-      tl_state()->allocation_allowed = true;
+          reinterpret_cast<uintptr_t>(ptr), size, *_tl_state, mmap_alloc);
+      if constexpr (mmap_alloc) {
+        _tl_state->allocation_allowed = true;
+      }
     }
   }
 
@@ -102,28 +102,24 @@ private:
   ddprof::ReentryGuard _guard;
 };
 
-class DeallocTrackerHelper {
+template <bool mmap_alloc = false> class DeallocTrackerHelperImpl {
 public:
-  DeallocTrackerHelper()
+  DeallocTrackerHelperImpl()
       : _tl_state{ddprof::AllocationTracker::is_deallocation_tracking_active()
-                      ? ddprof::AllocationTracker::get_tl_state()
+                      ? ddprof::AllocationTracker::get_tl_state(mmap_alloc)
                       : nullptr},
         _guard{_tl_state ? &(_tl_state->reentry_guard) : nullptr} {}
 
   void track(void *ptr) {
     if (_guard) {
+      if constexpr (mmap_alloc) {
+        _tl_state->allocation_allowed = false;
+      }
       ddprof::AllocationTracker::track_deallocation_s(
-          reinterpret_cast<uintptr_t>(ptr), *_tl_state);
-    }
-  }
-
-  // disallow allocation during tracking
-  void track_no_alloc(void *ptr, bool is_large_alloc = false) {
-    if (_guard) {
-      tl_state()->allocation_allowed = false;
-      ddprof::AllocationTracker::track_deallocation_s(
-          reinterpret_cast<uintptr_t>(ptr), *_tl_state, is_large_alloc);
-      tl_state()->allocation_allowed = true;
+          reinterpret_cast<uintptr_t>(ptr), *_tl_state, mmap_alloc);
+      if constexpr (mmap_alloc) {
+        _tl_state->allocation_allowed = true;
+      }
     }
   }
 
@@ -134,6 +130,12 @@ private:
   ddprof::TrackerThreadLocalState *_tl_state;
   ddprof::ReentryGuard _guard;
 };
+
+using AllocTrackerHelper = AllocTrackerHelperImpl<false>;
+using DeallocTrackerHelper = DeallocTrackerHelperImpl<false>;
+
+using AllocTrackerHelperMmap = AllocTrackerHelperImpl<true>;
+using DeallocTrackerHelperMmap = DeallocTrackerHelperImpl<true>;
 
 struct HookBase {};
 
@@ -770,6 +772,19 @@ struct PthreadCreateHook : HookBase {
   }
 };
 
+struct PthreadGetattrHook : HookBase {
+  static constexpr auto name = "pthread_getattr_np";
+  using FuncType = decltype(&::pthread_getattr_np);
+  static inline FuncType ref{};
+
+  static int hook(pthread_t thread, pthread_attr_t *attr) noexcept {
+    ddprof::AllocationTracker::notify_pthread_getattr_np();
+    auto ret = ref(thread, attr);
+    ddprof::AllocationTracker::notify_pthread_getattr_np_end();
+    return ret;
+  }
+};
+
 struct MmapHook : HookBase {
   static constexpr auto name = "mmap";
   using FuncType = decltype(&::mmap);
@@ -777,10 +792,10 @@ struct MmapHook : HookBase {
 
   static void *hook(void *addr, size_t length, int prot, int flags, int fd,
                     off_t offset) noexcept {
-    AllocTrackerHelper helper;
+    AllocTrackerHelperMmap helper;
     void *ptr = ref(addr, length, prot, flags, fd, offset);
     if (addr == nullptr && fd == -1 && ptr != nullptr) {
-      helper.track_no_alloc(ptr, length, true); // is_large_alloc=true for mmap
+      helper.track(ptr, length);
     }
     return ptr;
   }
@@ -793,11 +808,10 @@ struct Mmap_Hook : HookBase {
 
   static void *hook(void *addr, size_t length, int prot, int flags, int fd,
                     off_t offset) noexcept {
-    AllocTrackerHelper helper;
+    AllocTrackerHelperMmap helper;
     void *ptr = ref(addr, length, prot, flags, fd, offset);
     if (addr == nullptr && fd == -1 && ptr != nullptr) {
-      helper.track_no_alloc(ptr, length,
-                            true); // is_large_alloc=true for __mmap
+      helper.track(ptr, length);
     }
     return ptr;
   }
@@ -810,11 +824,10 @@ struct Mmap64Hook : HookBase {
 
   static void *hook(void *addr, size_t length, int prot, int flags, int fd,
                     off_t offset) noexcept {
-    AllocTrackerHelper helper;
+    AllocTrackerHelperMmap helper;
     void *ptr = ref(addr, length, prot, flags, fd, offset);
     if (addr == nullptr && fd == -1 && ptr != nullptr) {
-      helper.track_no_alloc(ptr, length,
-                            true); // is_large_alloc=true for mmap64
+      helper.track(ptr, length);
     }
     return ptr;
   }
@@ -826,8 +839,8 @@ struct MunmapHook : HookBase {
   static inline FuncType ref{};
 
   static int hook(void *addr, size_t length) noexcept {
-    DeallocTrackerHelper helper;
-    helper.track_no_alloc(addr, true);
+    DeallocTrackerHelperMmap helper;
+    helper.track(addr);
     return ref(addr, length);
   }
 };
@@ -838,8 +851,8 @@ struct Munmap_Hook : HookBase {
   static inline FuncType ref{};
 
   static int hook(void *addr, size_t length) noexcept {
-    DeallocTrackerHelper helper;
-    helper.track_no_alloc(addr, true);
+    DeallocTrackerHelperMmap helper;
+    helper.track(addr);
     return ref(addr, length);
   }
 };
@@ -921,6 +934,7 @@ void register_hooks() {
 
   register_hook<PthreadCreateHook>();
   register_hook<DlopenHook>();
+  register_hook<PthreadGetattrHook>();
 }
 
 } // namespace

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -542,8 +542,20 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "SanitizedDebug")
   target_include_directories(pthread_deadlock PRIVATE ${CMAKE_SOURCE_DIR}/include)
   add_test(
     NAME pthread_deadlock
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/pthread_deadlock-ut.sh
+    COMMAND pthread_deadlock
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  set_tests_properties(pthread_deadlock PROPERTIES TIMEOUT 5)
+
+  if(TARGET jemalloc::jemalloc_static)
+    add_exe(pthread_deadlock_mmap pthread_deadlock_mmap.cc
+            LIBRARIES dd_profiling-shared jemalloc::jemalloc_static Threads::Threads dl)
+    target_include_directories(pthread_deadlock_mmap PRIVATE ${CMAKE_SOURCE_DIR}/include)
+    add_test(
+      NAME pthread_deadlock_mmap
+      COMMAND pthread_deadlock_mmap
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    set_tests_properties(pthread_deadlock_mmap PROPERTIES TIMEOUT 5)
+  endif()
 endif()
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -538,7 +538,8 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "SanitizedDebug")
 endif()
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "SanitizedDebug")
-  add_exe(pthread_deadlock pthread_deadlock.cc LIBRARIES Threads::Threads)
+  add_exe(pthread_deadlock pthread_deadlock.cc LIBRARIES dd_profiling-shared Threads::Threads dl)
+  target_include_directories(pthread_deadlock PRIVATE ${CMAKE_SOURCE_DIR}/include)
   add_test(
     NAME pthread_deadlock
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/pthread_deadlock-ut.sh

--- a/test/allocation_tracker_fork_test.cc
+++ b/test/allocation_tracker_fork_test.cc
@@ -47,7 +47,7 @@ void *thread_check_null_tls(void *arg) {
 int run_child(void *parent_state) {
   // After fork, the __thread buffer is inherited: the child's main thread
   // sees the initialized state at the same virtual address.
-  auto *child_inherited = AllocationTracker::get_tl_state();
+  auto *child_inherited = AllocationTracker::get_tl_state(false);
   CHECK_OR_EXIT(child_inherited == parent_state,
                 "expected inherited TLS %p, got %p", parent_state,
                 static_cast<void *>(child_inherited));
@@ -56,7 +56,7 @@ int run_child(void *parent_state) {
   auto *child_state = AllocationTracker::init_tl_state();
   CHECK_OR_EXIT(child_state != nullptr, "init_tl_state() returned NULL");
 
-  auto *retrieved = AllocationTracker::get_tl_state();
+  auto *retrieved = AllocationTracker::get_tl_state(false);
   CHECK_OR_EXIT(retrieved == child_state, "get/init mismatch: %p vs %p",
                 static_cast<void *>(retrieved),
                 static_cast<void *>(child_state));
@@ -105,7 +105,7 @@ int main() {
   CHECK_OR_RETURN(parent_state != nullptr,
                   "parent init_tl_state() returned NULL");
 
-  auto *retrieved = AllocationTracker::get_tl_state();
+  auto *retrieved = AllocationTracker::get_tl_state(false);
   CHECK_OR_RETURN(retrieved == parent_state, "parent get/init mismatch");
 
   fflush(stdout);
@@ -136,7 +136,7 @@ int main() {
   CHECK_OR_RETURN(exit_code == 0, "child exited with code %d", exit_code);
 
   // Parent TLS should be unaffected by the fork
-  auto *parent_after = AllocationTracker::get_tl_state();
+  auto *parent_after = AllocationTracker::get_tl_state(false);
   CHECK_OR_RETURN(parent_after == parent_state,
                   "parent TLS corrupted after fork (%p vs %p)",
                   static_cast<void *>(parent_after),

--- a/test/allocation_tracker_fork_test.cc
+++ b/test/allocation_tracker_fork_test.cc
@@ -34,7 +34,7 @@ namespace {
 
 void *thread_check_null_tls(void *arg) {
   auto *result = static_cast<int *>(arg);
-  auto *state = AllocationTracker::get_tl_state();
+  auto *state = AllocationTracker::get_tl_state(false);
   if (state != nullptr) {
     LG_ERR("new thread expected NULL TLS, got %p", static_cast<void *>(state));
     *result = 1;
@@ -83,7 +83,7 @@ int main() {
 
   // Before any init, main thread's TLS must be zero-initialized by libc,
   // so get_tl_state() should return NULL (initialized == false).
-  auto *pre_init = AllocationTracker::get_tl_state();
+  auto *pre_init = AllocationTracker::get_tl_state(false);
   CHECK_OR_RETURN(pre_init == nullptr,
                   "main thread TLS not zero-initialized before init (got %p)",
                   static_cast<void *>(pre_init));

--- a/test/pthread_deadlock-ut.sh
+++ b/test/pthread_deadlock-ut.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-timeout 5s ./ddprof --do_export no -e 'sALLOC period=1' ./test/pthread_deadlock
+timeout 5s ./test/pthread_deadlock

--- a/test/pthread_deadlock-ut.sh
+++ b/test/pthread_deadlock-ut.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-timeout 5s ./test/pthread_deadlock

--- a/test/pthread_deadlock.cc
+++ b/test/pthread_deadlock.cc
@@ -1,14 +1,50 @@
 #include <thread>
 
+#include "dd_profiling.h"
+
 namespace {
-void func() {
-  pthread_attr_t attrs;
-  pthread_getattr_np(pthread_self(), &attrs);
-  pthread_attr_destroy(&attrs);
+std::atomic<bool> g_stop{false};
+
+void getattr_loop(bool loop) {
+  while (!g_stop.load(std::memory_order_relaxed)) {
+    pthread_attr_t attrs;
+    pthread_getattr_np(pthread_self(), &attrs);
+    pthread_attr_destroy(&attrs);
+    if (!loop) {
+      break;
+    }
+  }
 }
 } // namespace
 
 int main() {
-  std::thread t(func);
+  // Start a thread that calls pthread_getattr_np in a tight loop
+  std::thread t(getattr_loop, true);
+
+  // Give the thread time to start running
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  // Start profiling while the thread is actively calling pthread_getattr_np
+  int ret = ddprof_start_profiling();
+  if (ret != 0) {
+    fprintf(stderr, "Failed to start profiling (ret=%d)\n", ret);
+    return 1;
+  }
+
+  // Let it run for a bit to exercise the race
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // Stop the thread
+  g_stop.store(true, std::memory_order_relaxed);
   t.join();
+
+  // Test thread start
+  std::thread t2(getattr_loop, false);
+  t2.join();
+
+  if (ret == 0) {
+    ddprof_stop_profiling(1000);
+  }
+
+  return 0;
 }

--- a/test/pthread_deadlock_mmap.cc
+++ b/test/pthread_deadlock_mmap.cc
@@ -1,0 +1,33 @@
+#include <cstdlib>
+#include <latch>
+#include <thread>
+
+#include "dd_profiling.h"
+
+// Test that when mmap hook is called from malloc implementation
+// (without malloc hook being called because statically linked)
+// the TLS state is not initialized (otherwise it would deadlock).
+int main() {
+  std::latch l(1);
+  std::thread t([&] {
+    l.wait();
+    // large allocation to exercise the mmap hooks path.
+    void *p = malloc(1024 * 1024 * 16);
+    free(p);
+  });
+
+  int ret = ddprof_start_profiling();
+  if (ret != 0) {
+    fprintf(stderr, "Failed to start profiling (ret=%d)\n", ret);
+    return 1;
+  }
+
+  l.count_down();
+  t.join();
+
+  if (ret == 0) {
+    ddprof_stop_profiling(1000);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
# What does this PR do?

When profiling starts on a process with already-running threads calling pthread_getattr_np, the allocation tracker's TLS state may not be initialized yet. This adds a pthread_getattr_np hook that guards against deadlock withthe following sequence:
(pthread_getattr_np -> malloc -> tracker -> init_tl_state -> save_context -> pthread_getattr_np deadlock) and enables lazy TLS init in get_tl_state() when safe.

# Motivation

Allow allocation profiling of existing threads when profiler is not started at process startup.