### PR TITLE
fix: out-of-bounds access in `process_symbolization`

### DIFF
--- a/src/pprof/ddprof_pprof.cc
+++ b/src/pprof/ddprof_pprof.cc
@@ -310,7 +310,7 @@ DDRes process_symbolization(
     while (index < locs.size() && locs[index].file_info_id == file_id) {
       elf_addresses.push_back(locs[index].elf_addr);
       ++index;
-      if (locs[index].symbol_idx != k_symbol_idx_null) {
+      if (index < locs.size() && locs[index].symbol_idx != k_symbol_idx_null) {
         break; // Stop if we find a symbolized location
       }
     }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3abed928-8e07-463b-abb1-2c91b924612f","source":"chat","resourceId":"7fa3eeb4-abb5-48d2-aa48-26090a753499","workflowId":"77baa1b5-56a0-4d6d-8803-42a5962fdd01","codeChangeId":"77baa1b5-56a0-4d6d-8803-42a5962fdd01","sourceType":"chat"} -->
# What does this PR do?

Fixes an out-of-bounds array access in the `process_symbolization` function inside `ddprof_pprof.cc`.

In the inner loop that collects consecutive locations for the same file, `index` is incremented via `++index` before checking `locs[index].symbol_idx`. When the last element of `locs` is reached inside the loop, `index` becomes equal to `locs.size()` and the subsequent access to `locs[index]` is out of bounds, result in undefined behavior.

