### PR TITLE
loader: replace version check with SHA-256 hash verification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,8 +448,17 @@ if(BUILD_UNIVERSAL_DDPROF)
   endif()
 endif()
 
+set(_install_targets ddprof dd_profiling-static dd_profiling-shared)
+if(USE_LOADER)
+  # Install the embedded profiling library so the loader can dlopen it from a
+  # standard path instead of extracting the copy baked into the loader to /tmp.
+  # The /tmp fallback loses file capabilities (CAP_PERFMON) on the ddprof
+  # binary, which breaks perf_event_open.
+  list(APPEND _install_targets dd_profiling-embedded)
+endif()
+
 install(
-  TARGETS ddprof dd_profiling-static dd_profiling-shared
+  TARGETS ${_install_targets}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,15 +180,16 @@ set(dd_profiling_linker_script "${CMAKE_SOURCE_DIR}/cmake/dd_profiling.version")
 if(USE_LOADER)
   # Build small loader lib that is in charge of dlopening libdd_profiling-embedded.so
   ddprof_add_library(dd_loader SHARED src/lib/glibc_fixes.c src/lib/lib_embedded_data.c
-                     src/lib/loader.c)
+                     src/lib/loader.c src/lib/sha256.c)
   target_include_directories(dd_loader PRIVATE ${CMAKE_SOURCE_DIR}/include
-                                               ${CMAKE_SOURCE_DIR}/include/lib)
+                                               ${CMAKE_SOURCE_DIR}/include/lib ${CMAKE_BINARY_DIR})
   target_compile_definitions(dd_loader PRIVATE ${DDPROF_DEFINITION_LIST})
   set_target_properties(dd_loader PROPERTIES LINK_DEPENDS "${dd_profiling_linker_script}")
   target_link_options(dd_loader PRIVATE "LINKER:--version-script=${dd_profiling_linker_script}")
   target_static_libcxx(dd_loader)
   target_static_sanitizer(dd_loader)
   target_strip_debug_info(dd_loader)
+  add_dependencies(dd_loader generate_libddprofiling_embedded_object)
 
   if(BUILD_UNIVERSAL_DDPROF)
     target_link_options(dd_loader PRIVATE "-nolibc")
@@ -297,17 +298,23 @@ target_link_libraries(
 )
 target_link_libraries(dd_profiling-embedded PUBLIC dl pthread rt absl::base absl::str_format)
 
-set(LIBDD_PROFILING_EMBEDDED_OBJECT "${CMAKE_BINARY_DIR}/libdd_profiling-embedded.o")
+# Hash the .so directly (not the .o wrapper) so the same hash can serve as both the temp-file cache
+# key and the verification hash for installed copies.
 set(LIBDD_PROFILING_EMBEDDED_HASH_HEADER "${CMAKE_BINARY_DIR}/libdd_profiling-embedded_hash.h")
 add_custom_command(
-  OUTPUT ${LIBDD_PROFILING_EMBEDDED_OBJECT} ${LIBDD_PROFILING_EMBEDDED_HASH_HEADER}
+  OUTPUT ${LIBDD_PROFILING_EMBEDDED_HASH_HEADER}
+  COMMAND ${CMAKE_SOURCE_DIR}/tools/generate_hash_header.sh $<TARGET_FILE:dd_profiling-embedded>
+          libdd_profiling_embedded_hash ${LIBDD_PROFILING_EMBEDDED_HASH_HEADER}
+  DEPENDS dd_profiling-embedded)
+
+set(LIBDD_PROFILING_EMBEDDED_OBJECT "${CMAKE_BINARY_DIR}/libdd_profiling-embedded.o")
+add_custom_command(
+  OUTPUT ${LIBDD_PROFILING_EMBEDDED_OBJECT}
   # taken from https://dvdhrm.wordpress.com/2013/03/08/linking-binary-data/
   COMMAND ld -r -o ${LIBDD_PROFILING_EMBEDDED_OBJECT} -z noexecstack --format=binary
           $<TARGET_FILE_NAME:dd_profiling-embedded>
   COMMAND objcopy --rename-section .data=.rodata,alloc,load,readonly,data,contents
           ${LIBDD_PROFILING_EMBEDDED_OBJECT}
-  COMMAND ${CMAKE_SOURCE_DIR}/tools/generate_hash_header.sh ${LIBDD_PROFILING_EMBEDDED_OBJECT}
-          libdd_profiling_embedded_hash ${LIBDD_PROFILING_EMBEDDED_HASH_HEADER}
   DEPENDS dd_profiling-embedded)
 
 add_custom_target(
@@ -387,7 +394,7 @@ if(USE_LOADER)
   # When using a loader, libdd_profiling.so is a loader that embeds both libdd_profiling-embedded.so
   # and ddprof executable.
   ddprof_add_library(dd_profiling-shared SHARED src/lib/glibc_fixes.c src/lib/lib_embedded_data.c
-                     src/lib/loader.c)
+                     src/lib/loader.c src/lib/sha256.c)
   target_link_libraries(dd_profiling-shared PRIVATE libddprofiling_embedded_object
                                                     ddprof_exe_object)
   target_compile_definitions(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,10 +450,9 @@ endif()
 
 set(_install_targets ddprof dd_profiling-static dd_profiling-shared)
 if(USE_LOADER)
-  # Install the embedded profiling library so the loader can dlopen it from a
-  # standard path instead of extracting the copy baked into the loader to /tmp.
-  # The /tmp fallback loses file capabilities (CAP_PERFMON) on the ddprof
-  # binary, which breaks perf_event_open.
+  # Install the embedded profiling library so the loader can dlopen it from a standard path instead
+  # of extracting the copy baked into the loader to /tmp. The /tmp fallback loses file capabilities
+  # (CAP_PERFMON) on the ddprof binary, which breaks perf_event_open.
   list(APPEND _install_targets dd_profiling-embedded)
 endif()
 

--- a/cmake/dd_profiling.version
+++ b/cmake/dd_profiling.version
@@ -1,4 +1,4 @@
 {
-  global: ddprof_start_profiling; ddprof_stop_profiling; ddprof_lib_state; ddprof_profiling_version;
+  global: ddprof_start_profiling; ddprof_stop_profiling; ddprof_lib_state;
   local: *;
 };

--- a/include/lib/dd_profiling.h
+++ b/include/lib/dd_profiling.h
@@ -12,8 +12,6 @@ extern "C" {
 __attribute__((__visibility__("default"))) int ddprof_start_profiling();
 __attribute__((__visibility__("default"))) void
 ddprof_stop_profiling(int timeout_ms);
-__attribute__((__visibility__("default"))) const char *
-ddprof_profiling_version();
 
 #ifdef __cplusplus
 }

--- a/include/lib/sha256.h
+++ b/include/lib/sha256.h
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+// Compute SHA-256 of |data| (|len| bytes) into |out| (32 bytes).
+void sha256(const unsigned char *data, size_t len, unsigned char out[32]);
+
+// Convert a 32-byte hash to a 64-character hex string (plus NUL terminator).
+void sha256_hex(const unsigned char hash[32], char out[65]);

--- a/src/lib/dd_profiling.cc
+++ b/src/lib/dd_profiling.cc
@@ -16,8 +16,6 @@
 #include "signal_helper.hpp"
 #include "symbol_overrides.hpp"
 #include "syscalls.hpp"
-#include "version.hpp"
-
 #include <cassert>
 #include <cerrno>
 #include <chrono>
@@ -415,8 +413,6 @@ int ddprof_start_profiling_internal() {
 
 } // namespace
 } // namespace ddprof
-
-const char *ddprof_profiling_version() { return DDPROF_VERSION_STR; }
 
 int ddprof_start_profiling() {
   try {

--- a/src/lib/loader.c
+++ b/src/lib/loader.c
@@ -6,8 +6,9 @@
 #include "constants.hpp"
 #include "dd_profiling.h"
 #include "lib_embedded_data.h"
+#include "libdd_profiling-embedded_hash.h"
+#include "sha256.h"
 #include "tls_state_storage.h"
-#include "version.hpp"
 
 #include <dlfcn.h>
 #include <fcntl.h>
@@ -15,6 +16,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <time.h>
@@ -301,37 +303,71 @@ static void *s_profiling_lib_handle = NULL;
 __typeof(ddprof_start_profiling) *s_start_profiling_func = NULL;
 __typeof(ddprof_stop_profiling) *s_stop_profiling_func = NULL;
 
-// Try to load the installed libdd_profiling-embedded.so from the dynamic
-// linker search path (LD_LIBRARY_PATH, rpath, ldconfig cache).
-//
-// Returns a dlopen handle on success, NULL if the library was not found.
-// On version mismatch the library is still used (dlclose in a constructor is
-// risky and hard to get right), but a warning is printed so the user knows.
-static void *try_load_installed_profiling_lib() {
-  void *handle =
-      my_dlopen_silent(k_libdd_profiling_embedded_name, RTLD_LOCAL | RTLD_NOW);
-  if (!handle) {
+// ---------------------------------------------------------------------------
+// Find the installed libdd_profiling-embedded.so next to the loader and verify
+// its SHA-256 matches the build-time hash before dlopen'ing it.
+// Returns a malloc'd path on success, NULL if not found or hash mismatch.
+// Caller must free().
+// ---------------------------------------------------------------------------
+static char *find_installed_profiling_lib() {
+  Dl_info info;
+  if (!s_dladdr || !s_dladdr((void *)ddprof_start_profiling, &info) ||
+      !info.dli_fname) {
+    return NULL;
+  }
+  const char *last_slash = strrchr(info.dli_fname, '/');
+  if (!last_slash) {
+    return NULL;
+  }
+  size_t dir_len = last_slash - info.dli_fname;
+  size_t name_len = strlen(k_libdd_profiling_embedded_name);
+  char *lib_path = malloc(dir_len + 1 + name_len + 1);
+  if (!lib_path) {
+    return NULL;
+  }
+  memcpy(lib_path, info.dli_fname, dir_len);
+  lib_path[dir_len] = '/';
+  memcpy(lib_path + dir_len + 1, k_libdd_profiling_embedded_name, name_len + 1);
+
+  int fd = open(lib_path, O_RDONLY | O_CLOEXEC);
+  if (fd == -1) {
+    free(lib_path);
     return NULL;
   }
 
-  // Warn on version mismatch so the user can upgrade / remove the stale
-  // package.  We still use the installed library rather than attempting
-  // dlclose (which is unsafe this early and may leave partial state).
-  const char *(*version_func)() =
-      (const char *(*)())my_dlsym(handle, "ddprof_profiling_version");
-  const char *installed_version = version_func ? version_func() : NULL;
-  if (!installed_version ||
-      strcmp(installed_version, DDPROF_VERSION_STR) != 0) {
-    fprintf(stderr,
-            "ddprof: version mismatch for installed %s (got %s, expected %s); "
-            "using installed library anyway. Remove or upgrade the installed "
-            "package to match the injected library version.\n",
-            k_libdd_profiling_embedded_name,
-            installed_version ? installed_version : "<unknown>",
-            DDPROF_VERSION_STR);
+  struct stat st;
+  if (fstat(fd, &st) != 0 || st.st_size == 0) {
+    close(fd);
+    free(lib_path);
+    return NULL;
   }
 
-  return handle;
+  void *mapped = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+  close(fd);
+  if (mapped == MAP_FAILED) {
+    free(lib_path);
+    return NULL;
+  }
+
+  unsigned char hash[32];
+  sha256((const unsigned char *)mapped, st.st_size, hash);
+  munmap(mapped, st.st_size);
+
+  char hex[65];
+  sha256_hex(hash, hex);
+
+  if (strcmp(hex, libdd_profiling_embedded_hash) != 0) {
+    fprintf(stderr,
+            "ddprof: hash mismatch for installed %s "
+            "(got %.16s..., expected %.16s...); "
+            "falling back to embedded library.\n",
+            k_libdd_profiling_embedded_name, hex,
+            libdd_profiling_embedded_hash);
+    free(lib_path);
+    return NULL;
+  }
+
+  return lib_path;
 }
 
 // Find the ddprof executable relative to the loader's own on-disk location.
@@ -408,15 +444,24 @@ static void __attribute__((constructor)) loader() {
     s_profiling_lib_handle =
         my_dlopen(lib_profiling_path, RTLD_LOCAL | RTLD_NOW);
   } else {
-    // Check for the ddprof exe (relative to the loader) before loading the
-    // installed lib.  If the exe is missing there is no point loading it,
-    // and we avoid a dlopen we cannot safely undo.
+    // Check for the exe and an installed lib (with matching hash) before
+    // dlopen.  Both must exist; otherwise fall back to embedded extraction.
     char *exe_path = find_ddprof_exe();
     if (exe_path) {
-      void *installed = try_load_installed_profiling_lib();
-      if (installed) {
+      char *lib_path = find_installed_profiling_lib();
+      if (lib_path) {
         setenv(k_profiler_ddprof_exe_env_variable, exe_path, 1);
-        s_profiling_lib_handle = installed;
+        void *handle = my_dlopen(lib_path, RTLD_LOCAL | RTLD_NOW);
+        if (handle) {
+          s_profiling_lib_handle = handle;
+        } else {
+          fprintf(stderr,
+                  "ddprof: failed to dlopen installed %s, falling back to "
+                  "embedded library\n",
+                  lib_path);
+          unsetenv(k_profiler_ddprof_exe_env_variable);
+        }
+        free(lib_path);
       }
       free(exe_path);
     }

--- a/src/lib/sha256.c
+++ b/src/lib/sha256.c
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+// Minimal SHA-256 implementation (based on RFC 6234 / FIPS 180-4).
+// No external dependencies beyond standard C headers.
+
+#include "sha256.h"
+
+#include <string.h>
+
+static const uint32_t k_sha256_k[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+};
+
+#define RR(x, n) (((x) >> (n)) | ((x) << (32 - (n))))
+#define S0(x) (RR(x, 2) ^ RR(x, 13) ^ RR(x, 22))
+#define S1(x) (RR(x, 6) ^ RR(x, 11) ^ RR(x, 25))
+#define s0(x) (RR(x, 7) ^ RR(x, 18) ^ ((x) >> 3))
+#define s1(x) (RR(x, 17) ^ RR(x, 19) ^ ((x) >> 10))
+#define CH(x, y, z) (((x) & (y)) ^ (~(x) & (z)))
+#define MAJ(x, y, z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+
+static void sha256_transform(uint32_t state[8], const unsigned char block[64]) {
+  uint32_t w[64];
+  for (int i = 0; i < 16; i++) {
+    w[i] = (uint32_t)block[i * 4] << 24 | (uint32_t)block[i * 4 + 1] << 16 |
+        (uint32_t)block[i * 4 + 2] << 8 | (uint32_t)block[i * 4 + 3];
+  }
+  for (int i = 16; i < 64; i++) {
+    w[i] = s1(w[i - 2]) + w[i - 7] + s0(w[i - 15]) + w[i - 16];
+  }
+  uint32_t a = state[0], b = state[1], c = state[2], d = state[3];
+  uint32_t e = state[4], f = state[5], g = state[6], h = state[7];
+  for (int i = 0; i < 64; i++) {
+    uint32_t t1 = h + S1(e) + CH(e, f, g) + k_sha256_k[i] + w[i];
+    uint32_t t2 = S0(a) + MAJ(a, b, c);
+    h = g;
+    g = f;
+    f = e;
+    e = d + t1;
+    d = c;
+    c = b;
+    b = a;
+    a = t1 + t2;
+  }
+  state[0] += a;
+  state[1] += b;
+  state[2] += c;
+  state[3] += d;
+  state[4] += e;
+  state[5] += f;
+  state[6] += g;
+  state[7] += h;
+}
+
+void sha256(const unsigned char *data, size_t len, unsigned char out[32]) {
+  uint32_t state[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+                       0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19};
+  size_t i;
+  for (i = 0; i + 64 <= len; i += 64) {
+    sha256_transform(state, data + i);
+  }
+  // Padding
+  unsigned char block[64];
+  size_t rem = len - i;
+  memcpy(block, data + i, rem);
+  block[rem++] = 0x80;
+  if (rem > 56) {
+    memset(block + rem, 0, 64 - rem);
+    sha256_transform(state, block);
+    rem = 0;
+  }
+  memset(block + rem, 0, 56 - rem);
+  uint64_t bits = (uint64_t)len * 8;
+  for (int j = 7; j >= 0; j--) {
+    block[56 + (7 - j)] = (unsigned char)(bits >> (j * 8));
+  }
+  sha256_transform(state, block);
+  for (int j = 0; j < 8; j++) {
+    out[j * 4] = (unsigned char)(state[j] >> 24);
+    out[j * 4 + 1] = (unsigned char)(state[j] >> 16);
+    out[j * 4 + 2] = (unsigned char)(state[j] >> 8);
+    out[j * 4 + 3] = (unsigned char)(state[j]);
+  }
+}
+
+void sha256_hex(const unsigned char hash[32], char out[65]) {
+  static const char hex[] = "0123456789abcdef";
+  for (int i = 0; i < 32; i++) {
+    out[i * 2] = hex[hash[i] >> 4];
+    out[i * 2 + 1] = hex[hash[i] & 0xf];
+  }
+  out[64] = '\0';
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -529,24 +529,17 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "SanitizedDebug")
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/check_no_tls-ut.sh
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
-  # Fake libdd_profiling-embedded.so with wrong version for mismatch test
-  add_library(fake_profiling_version SHARED fake_profiling_version.c)
-  set_target_properties(fake_profiling_version PROPERTIES OUTPUT_NAME "dd_profiling-embedded")
-  target_compile_options(fake_profiling_version PRIVATE -fvisibility=default)
-  # Put it in test/ so it doesn't shadow the real one in the build root
-  set_target_properties(fake_profiling_version PROPERTIES LIBRARY_OUTPUT_DIRECTORY
-                                                          "${CMAKE_BINARY_DIR}/test")
+  if(USE_LOADER)
+    add_test(
+      NAME hash_mismatch
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/hash_mismatch-ut.sh
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
-  # Depends on simple_malloc-static and fake_profiling_version at runtime
-  add_test(
-    NAME version_mismatch
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/version_mismatch-ut.sh
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-  add_test(
-    NAME loader_installed_lib
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/loader_installed_lib-ut.sh
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    add_test(
+      NAME loader_installed_lib
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/loader_installed_lib-ut.sh
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  endif()
 
   if(BUILD_UNIVERSAL_DDPROF)
     add_test(NAME check-injected-lib

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -529,6 +529,8 @@ if(NOT CMAKE_BUILD_TYPE STREQUAL "SanitizedDebug")
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/check_no_tls-ut.sh
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
+  add_unit_test(sha256-ut sha256-ut.cc ../src/lib/sha256.c)
+
   if(USE_LOADER)
     add_test(
       NAME hash_mismatch

--- a/test/hash_mismatch-ut.sh
+++ b/test/hash_mismatch-ut.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Test that the loader rejects an installed libdd_profiling-embedded.so whose
+# SHA-256 does not match the build-time hash (USE_LOADER=ON only).
+# The loader should fall back to the embedded copy and print a warning.
+
+set -euo pipefail
+
+BUILDDIR="${PWD}"
+EMBEDDED_LIB="${BUILDDIR}/libdd_profiling-embedded.so"
+SHARED_LIB="${BUILDDIR}/libdd_profiling.so"
+
+echo "INFO: loader build — testing hash mismatch rejection"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+# Create a fake libdd_profiling-embedded.so with wrong contents.
+# A truncated copy is enough — the SHA-256 will not match.
+head -c 1024 "${EMBEDDED_LIB}" > "${tmpdir}/libdd_profiling-embedded.so"
+
+# Also place ddprof exe and the loader in the same directory so the loader
+# finds both via dladdr-relative lookup.
+cp "${SHARED_LIB}" "${tmpdir}/libdd_profiling.so"
+printf '#!/bin/sh\nexit 0\n' > "${tmpdir}/ddprof"
+chmod +x "${tmpdir}/ddprof"
+
+log="$(mktemp)"
+trap 'rm -rf "${tmpdir}" "${log}"' EXIT
+
+# LD_PRELOAD the loader from the temp dir.  The fake embedded lib sits next
+# to it, so the loader's find_installed_profiling_lib() will find it but the
+# hash should not match.
+LD_PRELOAD="${tmpdir}/libdd_profiling.so" \
+    "${BUILDDIR}/test/simple_malloc-static" --loop 10 --spin 10 \
+    > "${log}" 2>&1 || true
+
+grep -q "hash mismatch" "${log}" \
+    || { echo "FAIL: no hash mismatch warning"; cat "${log}"; exit 1; }
+echo "PASS: hash mismatch detected and reported"
+
+echo "PASS: all checks passed"

--- a/test/loader_installed_lib-ut.sh
+++ b/test/loader_installed_lib-ut.sh
@@ -20,13 +20,6 @@ BUILDDIR="${PWD}"
 EMBEDDED_LIB="${BUILDDIR}/libdd_profiling-embedded.so"
 SHARED_LIB="${BUILDDIR}/libdd_profiling.so"
 
-# Only meaningful for loader builds
-if nm -D "${SHARED_LIB}" | grep -q ddprof_profiling_version 2>/dev/null; then
-    echo "INFO: non-loader build — skipping loader exe-lookup test"
-    echo "PASS: all checks passed"
-    exit 0
-fi
-
 echo "INFO: loader build — testing exe path discovery"
 
 tmpdir="$(mktemp -d)"

--- a/test/sha256-ut.cc
+++ b/test/sha256-ut.cc
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+// SHA-256 test vectors from NIST FIPS 180-4.
+
+extern "C" {
+#include "sha256.h"
+}
+
+#include <gtest/gtest.h>
+
+namespace {
+
+std::string compute_sha256_hex(const char *data, size_t len) {
+  unsigned char hash[32];
+  sha256(reinterpret_cast<const unsigned char *>(data), len, hash);
+  char hex[65];
+  sha256_hex(hash, hex);
+  return hex;
+}
+
+// NIST one-block message
+TEST(Sha256Test, OneBlock) {
+  EXPECT_EQ(compute_sha256_hex("abc", 3),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+// NIST two-block message
+TEST(Sha256Test, TwoBlock) {
+  EXPECT_EQ(compute_sha256_hex(
+                "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", 56),
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+}
+
+// Empty string
+TEST(Sha256Test, Empty) {
+  EXPECT_EQ(compute_sha256_hex("", 0),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+}
+
+} // namespace


### PR DESCRIPTION
# What does this PR do?

Verify the installed libdd_profiling-embedded.so by computing its SHA-256 on disk and comparing against the build-time hash, before calling dlopen.  This avoids loading a library that cannot be safely unloaded on mismatch.

The build system now hashes the .so directly (instead of the .o wrapper), so the same hash serves as both the temp-file cache key and the installed-lib verification digest.

The ddprof_profiling_version symbol and the version-check infrastructure are removed — the hash check is strictly stronger and does not require dlopen.

SHA-256 implementation lives in src/lib/sha256.c.