### PR TITLE
Install libdd_profiling-embedded.so to fix /tmp extraction and CAP_PERFMON loss

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,8 +441,17 @@ if(BUILD_UNIVERSAL_DDPROF)
   endif()
 endif()
 
+set(_install_targets ddprof dd_profiling-static dd_profiling-shared)
+if(USE_LOADER)
+  # Install the embedded profiling library so the loader can dlopen it from a
+  # standard path instead of extracting the copy baked into the loader to /tmp.
+  # The /tmp fallback loses file capabilities (CAP_PERFMON) on the ddprof
+  # binary, which breaks perf_event_open.
+  list(APPEND _install_targets dd_profiling-embedded)
+endif()
+
 install(
-  TARGETS ddprof dd_profiling-static dd_profiling-shared
+  TARGETS ${_install_targets}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib


### PR DESCRIPTION
## Summary

When `USE_LOADER=ON`, the loader tries `dlopen("libdd_profiling-embedded.so")` before falling back to extracting the embedded copy. This dlopen always fails because `dd_profiling-embedded` is built but not included in the install targets.

As a result, the loader extracts both `libdd_profiling-embedded.so` and `ddprof` to `/tmp`. The extracted `ddprof` copy lacks file capabilities (`CAP_PERFMON`), so `perf_event_open` fails with `EPERM`.

## Fix

Add `dd_profiling-embedded` to the CMake install targets when `USE_LOADER=ON`. The loader finds `libdd_profiling-embedded.so` via standard dlopen, skips extraction, and `execvp("ddprof")` uses the installed binary with its file capabilities.

## Refs

- #535
- #529