### PR TITLE
fix: improve `statsd` write error handling

### DIFF
--- a/src/statsd.cc
+++ b/src/statsd.cc
@@ -137,12 +137,11 @@ DDRes statsd_send(int fd_sock, const char *key, const void *val, int type) {
   }
 
   // Nothing to do if the write fails
-  while (static_cast<ssize_t>(sz) != write(fd_sock, buf, sz) &&
-         errno == EINTR) {
+  while (static_cast<ssize_t>(sz) != write(fd_sock, buf, sz)) {
     // Don't consider this as fatal.
     if (errno == EWOULDBLOCK || errno == EAGAIN) {
       DDRES_RETURN_WARN_LOG(DD_WHAT_STATSD, "Write failed (sys buffer full)");
-    } else {
+    } else if (errno == EINTR) {
       DDRES_RETURN_WARN_LOG(DD_WHAT_STATSD, "Write failed");
     }
   }

--- a/src/statsd.cc
+++ b/src/statsd.cc
@@ -136,14 +136,21 @@ DDRes statsd_send(int fd_sock, const char *key, const void *val, int type) {
     DDRES_RETURN_WARN_LOG(DD_WHAT_STATSD, "Serialization failed");
   }
 
-  // Nothing to do if the write fails
-  while (static_cast<ssize_t>(sz) != write(fd_sock, buf, sz)) {
-    // Don't consider this as fatal.
-    if (errno == EWOULDBLOCK || errno == EAGAIN) {
-      DDRES_RETURN_WARN_LOG(DD_WHAT_STATSD, "Write failed (sys buffer full)");
-    } else if (errno == EINTR) {
+  size_t written = 0;
+  int eintr_retries = 0;
+  while (written < sz) {
+    const ssize_t ret = write(fd_sock, buf + written, sz - written);
+    if (ret == -1) {
+      constexpr int k_max_eintr_retries = 10;
+      if (errno == EINTR && ++eintr_retries < k_max_eintr_retries) {
+        continue;
+      }
+      if (errno == EWOULDBLOCK || errno == EAGAIN) {
+        DDRES_RETURN_WARN_LOG(DD_WHAT_STATSD, "Write failed (sys buffer full)");
+      }
       DDRES_RETURN_WARN_LOG(DD_WHAT_STATSD, "Write failed");
     }
+    written += static_cast<size_t>(ret);
   }
   return {};
 }


### PR DESCRIPTION
# What does this PR do?

This makes an error handling code path non dead. Previously, we would check the `errno` before getting into the block, making the second check on `errno` useless/redundant/dead. 