### PR TITLE
fix: symbolizer cache never rotates on cache hits

### DIFF
--- a/src/symbolizer.cc
+++ b/src/symbolizer.cc
@@ -42,6 +42,7 @@ void Symbolizer::reset_unvisited_flag() {
 Symbolizer::BlazeSymbolizerWrapper &
 Symbolizer::get_symbolizer(FileInfoId_t file_id, const std::string &elf_src) {
   if (auto it = _symbolizer_map.find(file_id); it != _symbolizer_map.end()) {
+    it->second.visited = true;
     return it->second;
   }
   auto [it, inserted] = _symbolizer_map.emplace(

--- a/src/symbolizer.cc
+++ b/src/symbolizer.cc
@@ -45,11 +45,11 @@ Symbolizer::get_symbolizer(FileInfoId_t file_id, const std::string &elf_src) {
     it->second.visited = true;
     return it->second;
   }
+  // visited is set on BlazeSymbolizerWrapper construction
   auto [it, inserted] = _symbolizer_map.emplace(
       file_id, BlazeSymbolizerWrapper(elf_src, inlined_functions));
   DDPROF_DCHECK_FATAL(inserted, "Unable to insert symbolizer object");
   auto &symbolizer_wrapper = it->second;
-  symbolizer_wrapper.visited = true;
   return symbolizer_wrapper;
 }
 


### PR DESCRIPTION
# What does this PR do?

Fixes a bug in the per-file symbolizer cache: reused entries were evicted after each cycle.

`remove_unvisited()` drops entries with `visited=false`, and `reset_unvisited_flag()` clears `visited` on every surviving entry at the end of each cycle. But `get_symbolizer()` only sets `visited=true` on the insert path — never on the cache-hit path. So an entry reused in the next cycle still ended that cycle with `visited=false` and was immediately evicted, throwing away the demangle / blazesym state every period.

One-line fix: set `visited=true` on cache hits too.

# Motivation

The cache was effectively never caching reused entries — the intended cross-cycle reuse of blazesym symbolizers and demangle maps was silently thrown away.