### PR TITLE
fix: flip inverted overflow check

### DIFF
--- a/src/perf.cc
+++ b/src/perf.cc
@@ -230,7 +230,7 @@ uint64_t perf_value_from_sample(const PerfWatcher *watcher,
     if (PERF_SAMPLE_RAW & watcher->sample_type) {
       uint64_t const raw_offset = watcher->raw_off;
       uint64_t const raw_sz = watcher->raw_sz;
-      if (raw_sz + raw_offset <= sample->size_raw) {
+      if (raw_sz + raw_offset > sample->size_raw) {
         assert(0 && "Overflow in raw event access");
         LG_WRN("Overflow in raw event access");
         return 0;


### PR DESCRIPTION
# What does this PR do?

This flips a comparison operator. Previously, we would early-return / fail if `raw_sz + raw_offset` was less than `sample->size_raw` and continue otherwise. In other words, if we were able to read past the bounds of `sample`, we would continue, and fail when within bounds. I think this should be the other way around. 