### PR TITLE
perf: cache FunctionId2 handles in BlazeSymbolizerWrapper

### DIFF
--- a/include/ddprof_stats.hpp
+++ b/include/ddprof_stats.hpp
@@ -35,6 +35,10 @@ namespace ddprof {
   X(SYMBOLS_JIT_READS, "symbols.jit.reads", STAT_GAUGE)                        \
   X(SYMBOLS_JIT_FAILED_LOOKUPS, "symbols.jit.failed_lookups", STAT_GAUGE)      \
   X(SYMBOLS_JIT_SYMBOL_COUNT, "symbols.jit.symbol_count", STAT_GAUGE)          \
+  X(SYMBOLS_BLAZE_INTERN_FN_CALLS, "symbols.blaze.intern_fn_calls",            \
+    STAT_GAUGE)                                                                \
+  X(SYMBOLS_BLAZE_ADDR_MISSES, "symbols.blaze.addr_misses", STAT_GAUGE)        \
+  X(SYMBOLS_BLAZE_ADDR_HITS, "symbols.blaze.addr_hits", STAT_GAUGE)            \
   X(PROFILER_RSS, "profiler.rss", STAT_GAUGE)                                  \
   X(PROFILER_CPU_USAGE, "profiler.cpu_usage.millicores", STAT_GAUGE)           \
   X(DSO_NEW_DSO, "dso.new", STAT_GAUGE)                                        \

--- a/include/symbolizer.hpp
+++ b/include/symbolizer.hpp
@@ -81,6 +81,18 @@ public:
   int remove_unvisited();
   void reset_unvisited_flag();
 
+  struct BlazeStats {
+    uint64_t addr_hits{0};
+    uint64_t addr_misses{0};
+    uint64_t intern_fn_calls{0};
+  };
+  // Returns accumulated stats since last call, then resets.
+  BlazeStats get_and_reset_blaze_stats() {
+    BlazeStats s = _blaze_stats;
+    _blaze_stats = {};
+    return s;
+  }
+
 private:
   struct BlazeSymbolizerDeleter {
     void operator()(blaze_symbolizer *ptr) const {
@@ -173,5 +185,6 @@ private:
   std::unordered_map<FileInfoId_t, BlazeSymbolizerWrapper> _symbolizer_map;
   bool inlined_functions;
   bool _disable_symbolization;
+  BlazeStats _blaze_stats{};
 };
 } // namespace ddprof

--- a/include/symbolizer.hpp
+++ b/include/symbolizer.hpp
@@ -8,6 +8,7 @@
 #include "ddprof_defs.hpp"
 #include "ddprof_file_info-i.hpp"
 #include "ddres_def.hpp"
+#include "hash_helper.hpp"
 #include "map_utils.hpp"
 #include "mapinfo_table.hpp"
 #include "symbol.hpp"
@@ -138,19 +139,14 @@ private:
       std::vector<uint32_t> lines; // line per frame: inlined first, outer last
     };
 
-    // Pair hash for the inlined_id_cache.
+    // Pair hash for the inlined_id_cache using the shared hash_combine helper.
     // In theory a pair<ElfAddress_t, unsigned> could also be packed into a
     // uint64_t (ELF vaddrs are well under 48 bits on both aarch64 and x86_64
     // in practice), but using std::pair avoids any architectural assumption.
     struct InlinedKeyHash {
       std::size_t operator()(const std::pair<ElfAddress_t, unsigned> &p) const {
-        // Boost-style hash_combine: golden-ratio constant for avalanche mixing.
-        static constexpr std::size_t kGoldenRatio = 0x9E3779B9U;
-        static constexpr unsigned kShiftLeft = 6;
-        static constexpr unsigned kShiftRight = 2;
         std::size_t h = std::hash<ElfAddress_t>{}(p.first);
-        h ^= std::hash<unsigned>{}(p.second) + kGoldenRatio +
-            (h << kShiftLeft) + (h >> kShiftRight);
+        hash_combine(h, p.second);
         return h;
       }
     };

--- a/include/symbolizer.hpp
+++ b/include/symbolizer.hpp
@@ -10,6 +10,7 @@
 #include "ddres_def.hpp"
 #include "map_utils.hpp"
 #include "mapinfo_table.hpp"
+#include "symbol.hpp"
 #include <memory>
 #include <span>
 #include <string>
@@ -103,9 +104,20 @@ private:
           symbolizer(blaze_symbolizer_new_opts(&opts)),
           elf_src(std::move(elf_src)), use_debug(inlined_fns) {}
 
+    // Per-location cache entry for a blaze-symbolized address.
+    // Avoids re-interning strings into the ProfilesDictionary on every sample.
+    struct CachedLocation {
+      ddog_prof_FunctionId2 function;
+      uint32_t line;
+    };
+
     blaze_symbolizer_opts opts;
     std::unique_ptr<blaze_symbolizer, BlazeSymbolizerDeleter> symbolizer;
     ddprof::HeterogeneousLookupStringMap<std::string> demangled_names;
+    // elf_addr → ordered locations (outer frame last, inlined first)
+    std::unordered_map<ElfAddress_t, std::vector<CachedLocation>> function_cache;
+    // mapping_id → no-sym FunctionId2 (intern_function("", sopath) result)
+    std::unordered_map<ddog_prof_MappingId2, ddog_prof_FunctionId2> nosym_cache;
     std::string elf_src;
     bool visited{true};
     bool use_debug;
@@ -113,6 +125,13 @@ private:
 
   BlazeSymbolizerWrapper &get_symbolizer(FileInfoId_t file_id,
                                          const std::string &elf_src);
+
+  static void write_no_sym_cached(BlazeSymbolizerWrapper &wrapper,
+                                   ElfAddress_t ip,
+                                   ddog_prof_MappingId2 mapping_id,
+                                   const ddog_prof_ProfilesDictionary *dict,
+                                   std::span<ddog_prof_Location2> locations,
+                                   unsigned &write_index);
 
   std::unordered_map<FileInfoId_t, BlazeSymbolizerWrapper> _symbolizer_map;
   bool inlined_functions;

--- a/include/symbolizer.hpp
+++ b/include/symbolizer.hpp
@@ -138,7 +138,7 @@ private:
         static constexpr unsigned kShiftRight = 2;
         std::size_t h = std::hash<ElfAddress_t>{}(p.first);
         h ^= std::hash<unsigned>{}(p.second) + kGoldenRatio +
-             (h << kShiftLeft) + (h >> kShiftRight);
+            (h << kShiftLeft) + (h >> kShiftRight);
         return h;
       }
     };

--- a/include/symbolizer.hpp
+++ b/include/symbolizer.hpp
@@ -110,7 +110,7 @@ private:
     // Level 1 — function identity (shared across all call sites of same
     // function):
     //   func_start_addr → FunctionId2  (outer frames, keyed by blaze_sym.addr)
-    //   pack(elf_addr, inlined_idx)    → FunctionId2  (inlined frames)
+    //   {elf_addr, inlined_idx}        → FunctionId2  (inlined frames)
     //
     // Level 2 — per call-site (fast full hit when we've seen this exact
     // address):
@@ -126,20 +126,32 @@ private:
       std::vector<uint32_t> lines; // line per frame: inlined first, outer last
     };
 
-    // function_id_cache keys:
-    //   outer frame   → blaze_sym.addr  (low bits of address, top tag bits 0)
-    //   inlined frame → elf_addr | ((idx+1) << kInlinedTagShift)
-    // ELF virtual addresses on Linux are at most 48 bits; the top 16 bits are
-    // used as a tag to distinguish inlined-frame entries from outer-frame ones.
-    static constexpr unsigned kInlinedTagShift = 48;
-    static uint64_t inlined_key(ElfAddress_t addr, unsigned idx) {
-      return addr | (static_cast<uint64_t>(idx + 1) << kInlinedTagShift);
-    }
+    // Pair hash for the inlined_id_cache.
+    // In theory a pair<ElfAddress_t, unsigned> could also be packed into a
+    // uint64_t (ELF vaddrs are well under 48 bits on both aarch64 and x86_64
+    // in practice), but using std::pair avoids any architectural assumption.
+    struct InlinedKeyHash {
+      std::size_t operator()(const std::pair<ElfAddress_t, unsigned> &p) const {
+        // Boost-style hash_combine: golden-ratio constant for avalanche mixing.
+        static constexpr std::size_t kGoldenRatio = 0x9E3779B9U;
+        static constexpr unsigned kShiftLeft = 6;
+        static constexpr unsigned kShiftRight = 2;
+        std::size_t h = std::hash<ElfAddress_t>{}(p.first);
+        h ^= std::hash<unsigned>{}(p.second) + kGoldenRatio +
+             (h << kShiftLeft) + (h >> kShiftRight);
+        return h;
+      }
+    };
 
     blaze_symbolizer_opts opts;
     std::unique_ptr<blaze_symbolizer, BlazeSymbolizerDeleter> symbolizer;
     ddprof::HeterogeneousLookupStringMap<std::string> demangled_names;
-    std::unordered_map<uint64_t, ddog_prof_FunctionId2> function_id_cache;
+    // func_start → FunctionId2 (outer frames, shared across all call sites)
+    std::unordered_map<ElfAddress_t, ddog_prof_FunctionId2> function_id_cache;
+    // {elf_addr, inlined_idx} → FunctionId2 (inlined frames, per call site)
+    std::unordered_map<std::pair<ElfAddress_t, unsigned>, ddog_prof_FunctionId2,
+                       InlinedKeyHash>
+        inlined_id_cache;
     std::unordered_map<ElfAddress_t, AddressCacheEntry> address_cache;
     // mapping_id → no-sym FunctionId2 (intern_function("", sopath) result)
     std::unordered_map<ddog_prof_MappingId2, ddog_prof_FunctionId2> nosym_cache;

--- a/include/symbolizer.hpp
+++ b/include/symbolizer.hpp
@@ -104,18 +104,43 @@ private:
           symbolizer(blaze_symbolizer_new_opts(&opts)),
           elf_src(std::move(elf_src)), use_debug(inlined_fns) {}
 
-    // Per-location cache entry for a blaze-symbolized address.
-    // Avoids re-interning strings into the ProfilesDictionary on every sample.
-    struct CachedLocation {
-      ddog_prof_FunctionId2 function;
-      uint32_t line;
+    // Two-level cache to avoid re-interning FunctionId2 handles on every
+    // sample.
+    //
+    // Level 1 — function identity (shared across all call sites of same
+    // function):
+    //   func_start_addr → FunctionId2  (outer frames, keyed by blaze_sym.addr)
+    //   pack(elf_addr, inlined_idx)    → FunctionId2  (inlined frames)
+    //
+    // Level 2 — per call-site (fast full hit when we've seen this exact
+    // address):
+    //   elf_addr → { func_start, lines[] }
+    //
+    // On a cache miss for a new elf_addr, we still run blaze but check
+    // function_id_cache[func_start] for the outer frame — saving
+    // intern_function calls when the same function is reached from multiple
+    // call sites.
+
+    struct AddressCacheEntry {
+      ElfAddress_t func_start;     // blaze_sym.addr (function start address)
+      std::vector<uint32_t> lines; // line per frame: inlined first, outer last
     };
+
+    // function_id_cache keys:
+    //   outer frame   → blaze_sym.addr  (low bits of address, top tag bits 0)
+    //   inlined frame → elf_addr | ((idx+1) << kInlinedTagShift)
+    // ELF virtual addresses on Linux are at most 48 bits; the top 16 bits are
+    // used as a tag to distinguish inlined-frame entries from outer-frame ones.
+    static constexpr unsigned kInlinedTagShift = 48;
+    static uint64_t inlined_key(ElfAddress_t addr, unsigned idx) {
+      return addr | (static_cast<uint64_t>(idx + 1) << kInlinedTagShift);
+    }
 
     blaze_symbolizer_opts opts;
     std::unique_ptr<blaze_symbolizer, BlazeSymbolizerDeleter> symbolizer;
     ddprof::HeterogeneousLookupStringMap<std::string> demangled_names;
-    // elf_addr → ordered locations (outer frame last, inlined first)
-    std::unordered_map<ElfAddress_t, std::vector<CachedLocation>> function_cache;
+    std::unordered_map<uint64_t, ddog_prof_FunctionId2> function_id_cache;
+    std::unordered_map<ElfAddress_t, AddressCacheEntry> address_cache;
     // mapping_id → no-sym FunctionId2 (intern_function("", sopath) result)
     std::unordered_map<ddog_prof_MappingId2, ddog_prof_FunctionId2> nosym_cache;
     std::string elf_src;
@@ -126,7 +151,7 @@ private:
   BlazeSymbolizerWrapper &get_symbolizer(FileInfoId_t file_id,
                                          const std::string &elf_src);
 
-  static void write_no_sym_cached(BlazeSymbolizerWrapper &wrapper,
+  static DDRes write_no_sym_cached(BlazeSymbolizerWrapper &wrapper,
                                    ElfAddress_t ip,
                                    ddog_prof_MappingId2 mapping_id,
                                    const ddog_prof_ProfilesDictionary *dict,

--- a/src/ddprof_worker.cc
+++ b/src/ddprof_worker.cc
@@ -98,7 +98,8 @@ inline void export_time_set(DDProfContext &ctx) {
           .count();
 }
 
-DDRes symbols_update_stats(const SymbolHdr &symbol_hdr) {
+DDRes symbols_update_stats(const SymbolHdr &symbol_hdr,
+                           Symbolizer *symbolizer) {
   const auto &stats = symbol_hdr._runtime_symbol_lookup.get_stats();
   DDRES_CHECK_FWD(
       ddprof_stats_set(STATS_SYMBOLS_JIT_READS, stats._nb_jit_reads));
@@ -106,6 +107,15 @@ DDRes symbols_update_stats(const SymbolHdr &symbol_hdr) {
                                    stats._nb_failed_lookups));
   DDRES_CHECK_FWD(
       ddprof_stats_set(STATS_SYMBOLS_JIT_SYMBOL_COUNT, stats._symbol_count));
+  if (symbolizer) {
+    const auto blaze = symbolizer->get_and_reset_blaze_stats();
+    DDRES_CHECK_FWD(ddprof_stats_set(STATS_SYMBOLS_BLAZE_INTERN_FN_CALLS,
+                                     static_cast<long>(blaze.intern_fn_calls)));
+    DDRES_CHECK_FWD(ddprof_stats_set(STATS_SYMBOLS_BLAZE_ADDR_MISSES,
+                                     static_cast<long>(blaze.addr_misses)));
+    DDRES_CHECK_FWD(ddprof_stats_set(STATS_SYMBOLS_BLAZE_ADDR_HITS,
+                                     static_cast<long>(blaze.addr_hits)));
+  }
   return {};
 }
 
@@ -141,7 +151,8 @@ DDRes worker_update_stats(DDProfWorkerContext &worker_context,
   // Symbol stats
   ddprof_stats_set(STATS_UNUSED_SYMBOLS_BINARIES_COUNT,
                    count_symbolizer_cleared);
-  DDRES_CHECK_FWD(symbols_update_stats(us.symbol_hdr));
+  DDRES_CHECK_FWD(
+      symbols_update_stats(us.symbol_hdr, worker_context.symbolizer));
 
   long target_cpu_nsec;
   ddprof_stats_get(STATS_TARGET_CPU_USAGE, &target_cpu_nsec);

--- a/src/symbolizer.cc
+++ b/src/symbolizer.cc
@@ -177,9 +177,16 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
         // intern_function when the same function is reached from a new call
         // site.
         ++_blaze_stats.addr_misses;
-        BlazeSymbolizerWrapper::AddressCacheEntry &new_entry =
-            symbolizer_wrapper.address_cache[addr];
-        new_entry.func_start = cur_sym->addr;
+
+        // Build the address_cache entry locally and commit it only after all
+        // frames are written successfully. An early return
+        // (DD_WHAT_UW_MAX_DEPTH) before the outer frame would leave a partial
+        // entry whose func_start has no matching function_id_cache value,
+        // causing .at() to throw on the next sample. function_id_cache /
+        // inlined_id_cache can be partially populated without harm — those
+        // handles are valid; only address_cache must be all-or-nothing.
+        BlazeSymbolizerWrapper::AddressCacheEntry candidate;
+        candidate.func_start = cur_sym->addr;
 
         constexpr std::string_view undef{};
         const auto sopath = mapping_id ? get_string(dict, mapping_id->filename)
@@ -217,7 +224,7 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
           loc.function = fn_it->second;
           loc.address = addr;
           loc.line = inlined->code_info.line;
-          new_entry.lines.push_back(inlined->code_info.line);
+          candidate.lines.push_back(inlined->code_info.line);
         }
 
         // Outer frame — shared across all call sites of the same function
@@ -247,7 +254,9 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
         loc.function = outer_it->second;
         loc.address = addr;
         loc.line = cur_sym->code_info.line;
-        new_entry.lines.push_back(cur_sym->code_info.line);
+        candidate.lines.push_back(cur_sym->code_info.line);
+        // All frames written — safe to commit the address cache entry.
+        symbolizer_wrapper.address_cache[addr] = std::move(candidate);
       }
       return {};
     }

--- a/src/symbolizer.cc
+++ b/src/symbolizer.cc
@@ -128,6 +128,7 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
       src_elf.debug_syms = false;
       // Invalidate caches: debug-derived symbols/lines are no longer valid.
       symbolizer_wrapper.function_id_cache.clear();
+      symbolizer_wrapper.inlined_id_cache.clear();
       symbolizer_wrapper.address_cache.clear();
       blaze_res = blaze_symbolize_elf_virt_offsets(
           symbolizer_wrapper.symbolizer.get(), &src_elf, elf_addrs.data(),
@@ -161,12 +162,11 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
             if (write_index >= locations.size()) {
               return ddres_warn(DD_WHAT_UW_MAX_DEPTH);
             }
-            const uint64_t fn_key = (j < n - 1)
-                ? BlazeSymbolizerWrapper::inlined_key(addr, j)
-                : entry.func_start;
             auto &loc = locations[write_index++];
             loc.mapping = mapping_id;
-            loc.function = symbolizer_wrapper.function_id_cache.at(fn_key);
+            loc.function = (j < n - 1)
+                ? symbolizer_wrapper.inlined_id_cache.at({addr, j})
+                : symbolizer_wrapper.function_id_cache.at(entry.func_start);
             loc.address = addr;
             loc.line = entry.lines[j];
           }
@@ -201,17 +201,18 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
               : sopath;
           const auto inlined_idx =
               static_cast<unsigned>(cur_sym->inlined_cnt - 1 - k);
-          const uint64_t key =
-              BlazeSymbolizerWrapper::inlined_key(addr, inlined_idx);
-          auto fn_it = symbolizer_wrapper.function_id_cache.find(key);
-          if (fn_it == symbolizer_wrapper.function_id_cache.end()) {
+          const auto inlined_key = std::make_pair(addr, inlined_idx);
+          auto fn_it = symbolizer_wrapper.inlined_id_cache.find(inlined_key);
+          if (fn_it == symbolizer_wrapper.inlined_id_cache.end()) {
             ddprof_stats_add(STATS_SYMBOLS_BLAZE_INTERN_FN_CALLS, 1, nullptr);
             ddog_prof_FunctionId2 fn = intern_function(dict, dname, fname);
             if (!fn) {
               DDRES_RETURN_ERROR_LOG(DD_WHAT_BADALLOC,
                                      "OOM interning inlined function");
             }
-            fn_it = symbolizer_wrapper.function_id_cache.emplace(key, fn).first;
+            fn_it =
+                symbolizer_wrapper.inlined_id_cache.emplace(inlined_key, fn)
+                    .first;
           }
           auto &loc = locations[write_index++];
           loc.mapping = mapping_id;

--- a/src/symbolizer.cc
+++ b/src/symbolizer.cc
@@ -6,6 +6,7 @@
 #include "symbolizer.hpp"
 
 #include "ddog_profiling_utils.hpp" // for write_location_blaze
+#include "ddprof_stats.hpp"
 #include "ddres.hpp"
 #include "demangler/demangler.hpp"
 #include "logger.hpp"
@@ -13,22 +14,43 @@
 #include <cassert>
 
 namespace ddprof {
+namespace {
+
+std::string_view
+demangled(const char *sym,
+          ddprof::HeterogeneousLookupStringMap<std::string> &cache) {
+  auto it = cache.find(sym);
+  if (it == cache.end()) {
+    it = cache
+             .insert({std::string(sym),
+                      ddprof::Demangler::non_microsoft_demangle(sym)})
+             .first;
+  }
+  return it->second;
+}
+
+} // namespace
 
 // static
-void Symbolizer::write_no_sym_cached(BlazeSymbolizerWrapper &wrapper,
+DDRes Symbolizer::write_no_sym_cached(BlazeSymbolizerWrapper &wrapper,
                                       ElfAddress_t ip,
                                       ddog_prof_MappingId2 mapping_id,
                                       const ddog_prof_ProfilesDictionary *dict,
                                       std::span<ddog_prof_Location2> locations,
                                       unsigned &write_index) {
   if (write_index >= locations.size()) {
-    return;
+    return ddres_warn(DD_WHAT_UW_MAX_DEPTH);
   }
   auto cache_it = wrapper.nosym_cache.find(mapping_id);
   if (cache_it == wrapper.nosym_cache.end()) {
-    const auto sopath =
-        mapping_id ? get_string(dict, mapping_id->filename) : std::string_view{};
+    const auto sopath = mapping_id ? get_string(dict, mapping_id->filename)
+                                   : std::string_view{};
     ddog_prof_FunctionId2 fn = intern_function(dict, {}, sopath);
+    if (!fn) {
+      DDRES_RETURN_ERROR_LOG(DD_WHAT_PPROF,
+                             "Unable to intern no-symbol function for %.*s",
+                             static_cast<int>(sopath.size()), sopath.data());
+    }
     cache_it = wrapper.nosym_cache.emplace(mapping_id, fn).first;
   }
   auto &loc = locations[write_index++];
@@ -36,6 +58,7 @@ void Symbolizer::write_no_sym_cached(BlazeSymbolizerWrapper &wrapper,
   loc.function = cache_it->second;
   loc.address = ip;
   loc.line = 0;
+  return {};
 }
 
 int Symbolizer::remove_unvisited() {
@@ -103,6 +126,9 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
              elf_src.c_str(), blaze_err_str(blaze_err_last()));
       symbolizer_wrapper.use_debug = false;
       src_elf.debug_syms = false;
+      // Invalidate caches: debug-derived symbols/lines are no longer valid.
+      symbolizer_wrapper.function_id_cache.clear();
+      symbolizer_wrapper.address_cache.clear();
       blaze_res = blaze_symbolize_elf_virt_offsets(
           symbolizer_wrapper.symbolizer.get(), &src_elf, elf_addrs.data(),
           elf_addrs.size());
@@ -118,36 +144,111 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
           // Some binaries expose a single symbol at address 0 (ex:
           // DD_AGENT_V1). Avoid emitting it so the backend still attempts
           // symbolication.
-          write_no_sym_cached(symbolizer_wrapper, elf_addrs[i], mapping_id,
-                              dict, locations, write_index);
+          DDRES_CHECK_FWD(write_no_sym_cached(symbolizer_wrapper, elf_addrs[i],
+                                              mapping_id, dict, locations,
+                                              write_index));
           continue;
         }
-        // Check the per-address function cache before hitting the dict.
         const ElfAddress_t addr = elf_addrs[i];
-        auto cache_it = symbolizer_wrapper.function_cache.find(addr);
-        if (cache_it != symbolizer_wrapper.function_cache.end()) {
-          for (const auto &cl : cache_it->second) {
+
+        // Level-2 hit: exact address seen before — write from caches, no blaze.
+        auto addr_it = symbolizer_wrapper.address_cache.find(addr);
+        if (addr_it != symbolizer_wrapper.address_cache.end()) {
+          ddprof_stats_add(STATS_SYMBOLS_BLAZE_ADDR_HITS, 1, nullptr);
+          const auto &entry = addr_it->second;
+          const unsigned n = entry.lines.size();
+          for (unsigned j = 0; j < n; ++j) {
             if (write_index >= locations.size()) {
               return ddres_warn(DD_WHAT_UW_MAX_DEPTH);
             }
+            const uint64_t fn_key = (j < n - 1)
+                ? BlazeSymbolizerWrapper::inlined_key(addr, j)
+                : entry.func_start;
             auto &loc = locations[write_index++];
             loc.mapping = mapping_id;
-            loc.function = cl.function;
+            loc.function = symbolizer_wrapper.function_id_cache.at(fn_key);
             loc.address = addr;
-            loc.line = cl.line;
+            loc.line = entry.lines[j];
           }
           continue;
         }
-        // Cache miss: intern strings, write locations, then cache the results.
-        const unsigned write_before = write_index;
-        DDRES_CHECK_FWD(write_location2_blaze(
-            addr, symbolizer_wrapper.demangled_names, mapping_id,
-            *cur_sym, write_index, dict, locations));
-        auto &cached = symbolizer_wrapper.function_cache[addr];
-        for (unsigned j = write_before; j < write_index; ++j) {
-          cached.push_back({locations[j].function,
-                            static_cast<uint32_t>(locations[j].line)});
+
+        // Cache miss for this address: run blaze, intern inlined frames, then
+        // check function_id_cache[func_start] for the outer frame — saving
+        // intern_function when the same function is reached from a new call
+        // site.
+        ddprof_stats_add(STATS_SYMBOLS_BLAZE_ADDR_MISSES, 1, nullptr);
+        BlazeSymbolizerWrapper::AddressCacheEntry &new_entry =
+            symbolizer_wrapper.address_cache[addr];
+        new_entry.func_start = cur_sym->addr;
+
+        constexpr std::string_view undef{};
+        const auto sopath = mapping_id ? get_string(dict, mapping_id->filename)
+                                       : std::string_view{};
+
+        // Inlined frames (innermost first in blaze order, reversed for pprof)
+        for (int k = cur_sym->inlined_cnt - 1;
+             k >= 0 && write_index < kMaxStackDepth; --k) {
+          const blaze_symbolize_inlined_fn *inlined = cur_sym->inlined + k;
+          if (write_index >= locations.size()) {
+            return ddres_warn(DD_WHAT_UW_MAX_DEPTH);
+          }
+          const std::string_view dname = inlined->name
+              ? demangled(inlined->name, symbolizer_wrapper.demangled_names)
+              : undef;
+          const std::string_view fname = inlined->code_info.file
+              ? std::string_view(inlined->code_info.file)
+              : sopath;
+          const auto inlined_idx =
+              static_cast<unsigned>(cur_sym->inlined_cnt - 1 - k);
+          const uint64_t key =
+              BlazeSymbolizerWrapper::inlined_key(addr, inlined_idx);
+          auto fn_it = symbolizer_wrapper.function_id_cache.find(key);
+          if (fn_it == symbolizer_wrapper.function_id_cache.end()) {
+            ddprof_stats_add(STATS_SYMBOLS_BLAZE_INTERN_FN_CALLS, 1, nullptr);
+            ddog_prof_FunctionId2 fn = intern_function(dict, dname, fname);
+            if (!fn) {
+              DDRES_RETURN_ERROR_LOG(DD_WHAT_BADALLOC,
+                                     "OOM interning inlined function");
+            }
+            fn_it = symbolizer_wrapper.function_id_cache.emplace(key, fn).first;
+          }
+          auto &loc = locations[write_index++];
+          loc.mapping = mapping_id;
+          loc.function = fn_it->second;
+          loc.address = addr;
+          loc.line = inlined->code_info.line;
+          new_entry.lines.push_back(inlined->code_info.line);
         }
+
+        // Outer frame — shared across all call sites of the same function
+        if (write_index >= locations.size()) {
+          return ddres_warn(DD_WHAT_UW_MAX_DEPTH);
+        }
+        const std::string_view dname = cur_sym->name
+            ? demangled(cur_sym->name, symbolizer_wrapper.demangled_names)
+            : undef;
+        const std::string_view fname = cur_sym->code_info.file
+            ? std::string_view{cur_sym->code_info.file}
+            : sopath;
+        auto outer_it =
+            symbolizer_wrapper.function_id_cache.find(cur_sym->addr);
+        if (outer_it == symbolizer_wrapper.function_id_cache.end()) {
+          ddprof_stats_add(STATS_SYMBOLS_BLAZE_INTERN_FN_CALLS, 1, nullptr);
+          ddog_prof_FunctionId2 fn = intern_function(dict, dname, fname);
+          if (!fn) {
+            DDRES_RETURN_ERROR_LOG(DD_WHAT_BADALLOC, "OOM interning function");
+          }
+          outer_it =
+              symbolizer_wrapper.function_id_cache.emplace(cur_sym->addr, fn)
+                  .first;
+        }
+        auto &loc = locations[write_index++];
+        loc.mapping = mapping_id;
+        loc.function = outer_it->second;
+        loc.address = addr;
+        loc.line = cur_sym->code_info.line;
+        new_entry.lines.push_back(cur_sym->code_info.line);
       }
       return {};
     }
@@ -159,13 +260,16 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
   if (!_disable_symbolization) {
     auto &symbolizer_wrapper = get_symbolizer(file_id, elf_src);
     for (auto el : elf_addrs) {
-      write_no_sym_cached(symbolizer_wrapper, el, mapping_id, dict, locations,
-                          write_index);
+      DDRES_CHECK_FWD(write_no_sym_cached(symbolizer_wrapper, el, mapping_id,
+                                          dict, locations, write_index));
     }
   } else {
     for (auto el : elf_addrs) {
-      DDRES_CHECK_FWD(
-          write_location2_no_sym(el, mapping_id, dict, &locations[write_index++]));
+      if (write_index >= locations.size()) {
+        return ddres_warn(DD_WHAT_UW_MAX_DEPTH);
+      }
+      DDRES_CHECK_FWD(write_location2_no_sym(el, mapping_id, dict,
+                                             &locations[write_index++]));
     }
   }
 

--- a/src/symbolizer.cc
+++ b/src/symbolizer.cc
@@ -6,7 +6,6 @@
 #include "symbolizer.hpp"
 
 #include "ddog_profiling_utils.hpp" // for write_location_blaze
-#include "ddprof_stats.hpp"
 #include "ddres.hpp"
 #include "demangler/demangler.hpp"
 #include "logger.hpp"
@@ -155,7 +154,7 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
         // Level-2 hit: exact address seen before — write from caches, no blaze.
         auto addr_it = symbolizer_wrapper.address_cache.find(addr);
         if (addr_it != symbolizer_wrapper.address_cache.end()) {
-          ddprof_stats_add(STATS_SYMBOLS_BLAZE_ADDR_HITS, 1, nullptr);
+          ++_blaze_stats.addr_hits;
           const auto &entry = addr_it->second;
           const unsigned n = entry.lines.size();
           for (unsigned j = 0; j < n; ++j) {
@@ -177,7 +176,7 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
         // check function_id_cache[func_start] for the outer frame — saving
         // intern_function when the same function is reached from a new call
         // site.
-        ddprof_stats_add(STATS_SYMBOLS_BLAZE_ADDR_MISSES, 1, nullptr);
+        ++_blaze_stats.addr_misses;
         BlazeSymbolizerWrapper::AddressCacheEntry &new_entry =
             symbolizer_wrapper.address_cache[addr];
         new_entry.func_start = cur_sym->addr;
@@ -204,7 +203,7 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
           const auto inlined_key = std::make_pair(addr, inlined_idx);
           auto fn_it = symbolizer_wrapper.inlined_id_cache.find(inlined_key);
           if (fn_it == symbolizer_wrapper.inlined_id_cache.end()) {
-            ddprof_stats_add(STATS_SYMBOLS_BLAZE_INTERN_FN_CALLS, 1, nullptr);
+            ++_blaze_stats.intern_fn_calls;
             ddog_prof_FunctionId2 fn = intern_function(dict, dname, fname);
             if (!fn) {
               DDRES_RETURN_ERROR_LOG(DD_WHAT_BADALLOC,
@@ -234,7 +233,7 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
         auto outer_it =
             symbolizer_wrapper.function_id_cache.find(cur_sym->addr);
         if (outer_it == symbolizer_wrapper.function_id_cache.end()) {
-          ddprof_stats_add(STATS_SYMBOLS_BLAZE_INTERN_FN_CALLS, 1, nullptr);
+          ++_blaze_stats.intern_fn_calls;
           ddog_prof_FunctionId2 fn = intern_function(dict, dname, fname);
           if (!fn) {
             DDRES_RETURN_ERROR_LOG(DD_WHAT_BADALLOC, "OOM interning function");

--- a/src/symbolizer.cc
+++ b/src/symbolizer.cc
@@ -14,6 +14,30 @@
 
 namespace ddprof {
 
+// static
+void Symbolizer::write_no_sym_cached(BlazeSymbolizerWrapper &wrapper,
+                                      ElfAddress_t ip,
+                                      ddog_prof_MappingId2 mapping_id,
+                                      const ddog_prof_ProfilesDictionary *dict,
+                                      std::span<ddog_prof_Location2> locations,
+                                      unsigned &write_index) {
+  if (write_index >= locations.size()) {
+    return;
+  }
+  auto cache_it = wrapper.nosym_cache.find(mapping_id);
+  if (cache_it == wrapper.nosym_cache.end()) {
+    const auto sopath =
+        mapping_id ? get_string(dict, mapping_id->filename) : std::string_view{};
+    ddog_prof_FunctionId2 fn = intern_function(dict, {}, sopath);
+    cache_it = wrapper.nosym_cache.emplace(mapping_id, fn).first;
+  }
+  auto &loc = locations[write_index++];
+  loc.mapping = mapping_id;
+  loc.function = cache_it->second;
+  loc.address = ip;
+  loc.line = 0;
+}
+
 int Symbolizer::remove_unvisited() {
   // Remove all unvisited blaze_symbolizer instances from the map
   const auto count = std::erase_if(_symbolizer_map, [](const auto &item) {
@@ -94,13 +118,36 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
           // Some binaries expose a single symbol at address 0 (ex:
           // DD_AGENT_V1). Avoid emitting it so the backend still attempts
           // symbolication.
-          DDRES_CHECK_FWD(write_location2_no_sym(elf_addrs[i], mapping_id, dict,
-                                                 &locations[write_index++]));
+          write_no_sym_cached(symbolizer_wrapper, elf_addrs[i], mapping_id,
+                              dict, locations, write_index);
           continue;
         }
+        // Check the per-address function cache before hitting the dict.
+        const ElfAddress_t addr = elf_addrs[i];
+        auto cache_it = symbolizer_wrapper.function_cache.find(addr);
+        if (cache_it != symbolizer_wrapper.function_cache.end()) {
+          for (const auto &cl : cache_it->second) {
+            if (write_index >= locations.size()) {
+              return ddres_warn(DD_WHAT_UW_MAX_DEPTH);
+            }
+            auto &loc = locations[write_index++];
+            loc.mapping = mapping_id;
+            loc.function = cl.function;
+            loc.address = addr;
+            loc.line = cl.line;
+          }
+          continue;
+        }
+        // Cache miss: intern strings, write locations, then cache the results.
+        const unsigned write_before = write_index;
         DDRES_CHECK_FWD(write_location2_blaze(
-            elf_addrs[i], symbolizer_wrapper.demangled_names, mapping_id,
+            addr, symbolizer_wrapper.demangled_names, mapping_id,
             *cur_sym, write_index, dict, locations));
+        auto &cached = symbolizer_wrapper.function_cache[addr];
+        for (unsigned j = write_before; j < write_index; ++j) {
+          cached.push_back({locations[j].function,
+                            static_cast<uint32_t>(locations[j].line)});
+        }
       }
       return {};
     }
@@ -109,9 +156,17 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
   // Handle the case of no blaze result
   // This can happen when file descriptors are exhausted
   // OR symbolization is disabled
-  for (auto el : elf_addrs) {
-    DDRES_CHECK_FWD(write_location2_no_sym(el, mapping_id, dict,
-                                           &locations[write_index++]));
+  if (!_disable_symbolization) {
+    auto &symbolizer_wrapper = get_symbolizer(file_id, elf_src);
+    for (auto el : elf_addrs) {
+      write_no_sym_cached(symbolizer_wrapper, el, mapping_id, dict, locations,
+                          write_index);
+    }
+  } else {
+    for (auto el : elf_addrs) {
+      DDRES_CHECK_FWD(
+          write_location2_no_sym(el, mapping_id, dict, &locations[write_index++]));
+    }
   }
 
   return {};

--- a/src/symbolizer.cc
+++ b/src/symbolizer.cc
@@ -210,9 +210,8 @@ DDRes Symbolizer::symbolize_pprof(std::span<ElfAddress_t> elf_addrs,
               DDRES_RETURN_ERROR_LOG(DD_WHAT_BADALLOC,
                                      "OOM interning inlined function");
             }
-            fn_it =
-                symbolizer_wrapper.inlined_id_cache.emplace(inlined_key, fn)
-                    .first;
+            fn_it = symbolizer_wrapper.inlined_id_cache.emplace(inlined_key, fn)
+                        .first;
           }
           auto &loc = locations[write_index++];
           loc.mapping = mapping_id;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -201,11 +201,13 @@ add_unit_test(
   ddprof_pprof-ut.cc
   ../src/ddog_profiling_utils.cc
   ../src/ddprof_cmdline_watcher.cc
+  ../src/ddprof_stats.cc
   ../src/pprof/ddprof_pprof.cc
   ../src/symbol_hdr.cc
   ../src/symbolizer.cc
   ../src/demangler/demangler.cc
   ../src/perf_watcher.cc
+  ../src/statsd.cc
   ../src/tracepoint_config.cc
   LIBRARIES Datadog::Profiling DDProf::Parser llvm-demangle
   DEFINITIONS MYNAME="ddprof_pprof-ut")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -215,9 +215,11 @@ add_unit_test(
 add_unit_test(
   ddprof_exporter-ut
   ../src/ddog_profiling_utils.cc
+  ../src/ddprof_stats.cc
   ../src/exporter/ddprof_exporter.cc
   ../src/pprof/ddprof_pprof.cc
   ../src/perf_watcher.cc
+  ../src/statsd.cc
   ../src/symbol_hdr.cc
   ../src/symbolizer.cc
   ../src/demangler/demangler.cc
@@ -486,7 +488,9 @@ add_benchmark(
   pprof_aggregate-bench.cc
   ../src/ddog_profiling_utils.cc
   ../src/ddprof_cmdline_watcher.cc
+  ../src/ddprof_stats.cc
   ../src/pprof/ddprof_pprof.cc
+  ../src/statsd.cc
   ../src/symbol_hdr.cc
   ../src/symbolizer.cc
   ../src/demangler/demangler.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -201,13 +201,11 @@ add_unit_test(
   ddprof_pprof-ut.cc
   ../src/ddog_profiling_utils.cc
   ../src/ddprof_cmdline_watcher.cc
-  ../src/ddprof_stats.cc
   ../src/pprof/ddprof_pprof.cc
   ../src/symbol_hdr.cc
   ../src/symbolizer.cc
   ../src/demangler/demangler.cc
   ../src/perf_watcher.cc
-  ../src/statsd.cc
   ../src/tracepoint_config.cc
   LIBRARIES Datadog::Profiling DDProf::Parser llvm-demangle
   DEFINITIONS MYNAME="ddprof_pprof-ut")
@@ -215,11 +213,9 @@ add_unit_test(
 add_unit_test(
   ddprof_exporter-ut
   ../src/ddog_profiling_utils.cc
-  ../src/ddprof_stats.cc
   ../src/exporter/ddprof_exporter.cc
   ../src/pprof/ddprof_pprof.cc
   ../src/perf_watcher.cc
-  ../src/statsd.cc
   ../src/symbol_hdr.cc
   ../src/symbolizer.cc
   ../src/demangler/demangler.cc
@@ -488,9 +484,7 @@ add_benchmark(
   pprof_aggregate-bench.cc
   ../src/ddog_profiling_utils.cc
   ../src/ddprof_cmdline_watcher.cc
-  ../src/ddprof_stats.cc
   ../src/pprof/ddprof_pprof.cc
-  ../src/statsd.cc
   ../src/symbol_hdr.cc
   ../src/symbolizer.cc
   ../src/demangler/demangler.cc


### PR DESCRIPTION
## Problem

`intern_function()` (→ 3× `ProfilesDictionary_insert_str`) was called on every sample for every blaze-symbolized frame, driving ~128 ms/min of CPU in `ProfilesDictionary_insert_str` even on stable workloads.

The existing `SymbolTable` / `symbol_idx` cache covers frames resolved at **unwind time** (DSO/common/base/runtime lookups). Blaze frames arrive with `k_symbol_idx_null`; `process_symbolization` runs blaze at pprof-creation time but never stores the resulting `FunctionId2` — so every sample for the same ELF address re-interns from scratch.

## Solution: two-level `FunctionId2` cache in `BlazeSymbolizerWrapper`

**Level 1 — function identity** (shared across all call sites of the same function):
- `function_id_cache[func_start]` → `FunctionId2` for outer frames, keyed by `blaze_sym.addr` (function start address). All call sites within the same function share one dict handle — **zero `intern_function` calls** after the first visit to any call site.
- `inlined_id_cache[{elf_addr, idx}]` → `FunctionId2` for inlined frames, using `std::pair` to avoid any assumption about address width.

**Level 2 — call site** (full hit for repeated exact addresses):
- `address_cache[elf_addr]` → `{func_start, lines[]}`. When the exact same ELF address recurs, write from the caches without calling blaze or touching the dict.

**`nosym_cache`** — `MappingId2 → FunctionId2` for no-symbol frames: all frames from the same DSO share one `(empty_name, sopath)` function handle.

The caches live in `BlazeSymbolizerWrapper` (one per ELF file, keyed by `FileInfoId_t`). When a file is evicted by `remove_unvisited()`, both caches evict with it — no stale handles.

## Observed results (collatz at 999 Hz, ~10 unique functions)

| Cycle | addr_misses | **intern_fn_calls** | addr_hits | hit_rate |
|-------|-------------|---------------------|-----------|----------|
| 1 (cold) | 2771 | 115 | 5.26 M | 99.9 % |
| 2+ (warm) | ~300 | **0** | ~6 M | 100.0 % |

Zero actual dict insertions in steady state.

## Relationship to `symbol_idx`

`symbol_idx` is set at **unwind time** and covers DSO/common/base/runtime symbols. Blaze frames arrive with `k_symbol_idx_null`; updating `symbol_idx` retroactively in committed `FunLoc` entries is unsafe. This cache is a complementary layer at pprof-creation time. Longer term, feeding blaze results back into the unwind-time cache would remove the need for this layer entirely.

## Metrics

Three new per-cycle stats via `--internal_stats` / statsd:
- `symbols.blaze.intern_fn_calls` — actual `intern_function()` calls (should approach 0 in steady state)
- `symbols.blaze.addr_misses`     — new ELF addresses not yet in address_cache
- `symbols.blaze.addr_hits`       — full cache hits (zero dict cost)

## Follow-up

The existing `ddprof_pprof-ut` tests pre-populate `symbol_idx` for all frames, so they exercise only the pre-symbolized fast path — the blaze cache is never touched. A dedicated `symbolizer-ut` against a real ELF from `test/data/` would give direct coverage of `address_cache`, `function_id_cache`, `inlined_id_cache`, `nosym_cache`, and `BlazeStats` accounting.