### PR TITLE
fix(jit): close JITDump startup race for Julia / .NET

### DIFF
--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -99,6 +99,9 @@ public:
     BackpopulateState _backpopulate_state;
     // save the start addr of the jit dump info if available
     ProcessAddress_t _jitdump_addr = {};
+    // True if we already tried to discover a JITDump file for this pid
+    // during the current cycle (cleared by reset_backpopulate_state).
+    bool _jitdump_discovery_attempted = false;
   };
   using DsoPidMap = std::unordered_map<pid_t, PidMapping>;
 
@@ -146,6 +149,13 @@ public:
   DsoFindRes dso_find_or_backpopulate(PidMapping &pid_mapping, pid_t pid,
                                       ElfAddress_t addr);
   DsoFindRes dso_find_or_backpopulate(pid_t pid, ElfAddress_t addr);
+
+  // Attempt to discover a JITDump file for a pid by rescanning
+  // /proc/<pid>/maps. This is used to recover from startup races where the
+  // JITDump mmap event arrived too late or was missed by an earlier
+  // backpopulate. Throttled to at most one attempt per cycle per pid. Returns
+  // true if a JITDump file is known for this pid after the call.
+  bool try_jitdump_discovery(PidMapping &pid_mapping, pid_t pid);
 
   void reset_backpopulate_state(
       int reset_threshold =

--- a/include/dso_hdr.hpp
+++ b/include/dso_hdr.hpp
@@ -99,9 +99,6 @@ public:
     BackpopulateState _backpopulate_state;
     // save the start addr of the jit dump info if available
     ProcessAddress_t _jitdump_addr = {};
-    // True if we already tried to discover a JITDump file for this pid
-    // during the current cycle (cleared by reset_backpopulate_state).
-    bool _jitdump_discovery_attempted = false;
   };
   using DsoPidMap = std::unordered_map<pid_t, PidMapping>;
 
@@ -150,11 +147,14 @@ public:
                                       ElfAddress_t addr);
   DsoFindRes dso_find_or_backpopulate(pid_t pid, ElfAddress_t addr);
 
-  // Attempt to discover a JITDump file for a pid by rescanning
-  // /proc/<pid>/maps. This is used to recover from startup races where the
-  // JITDump mmap event arrived too late or was missed by an earlier
-  // backpopulate. Throttled to at most one attempt per cycle per pid. Returns
-  // true if a JITDump file is known for this pid after the call.
+  // Attempt to discover a JITDump file for a pid by scanning
+  // /proc/<pid>/maps. Used to recover from the startup race where a sample
+  // lands in a JIT'd region before the JITDump perf MMAP2 event has been
+  // consumed from the ring buffer. Only fires when no full /proc scan has
+  // ever run for this pid (`last_backpopulate_time` is zero); after any
+  // backpopulate, late JITDump events are handled by the kJITDump bypass
+  // in maybe_insert_erase_overlap, so an extra rescan is not needed.
+  // Returns true if a JITDump file is known for this pid after the call.
   bool try_jitdump_discovery(PidMapping &pid_mapping, pid_t pid);
 
   void reset_backpopulate_state(

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -357,11 +357,21 @@ bool DsoHdr::maybe_insert_erase_overlap(Dso &&dso,
                                         PerfClock::time_point timestamp) {
   auto &pid_mapping = _pid_map[dso._pid];
 
+  // JITDump mmap events are idempotent (insert_erase_overlap dedupes via
+  // dso_find_adjust_same) and the marker is required to symbolize JIT frames.
+  // Always accept them, even if their timestamp predates the last backpopulate:
+  // this fixes a startup race where a backpopulate triggered by an early sample
+  // observes /proc/<pid>/maps before the runtime has mmap'd the JITDump file,
+  // and the subsequent perf MMAP2 event (with an older timestamp) would
+  // otherwise be silently dropped.
+  const bool is_jitdump = dso._type == DsoType::kJITDump;
+
   // If mmap event happened earlier than last backpopulate, just ignore it
   // Note that if no perf clock was found or not backpopulate was done,
   // last_backpopulate_time will be zero and therefore test will correctly
   // fail.
-  if (timestamp < pid_mapping._backpopulate_state.last_backpopulate_time) {
+  if (!is_jitdump &&
+      timestamp < pid_mapping._backpopulate_state.last_backpopulate_time) {
     return false;
   }
 
@@ -573,7 +583,35 @@ void DsoHdr::reset_backpopulate_state(int reset_threshold) {
     if (backpopulate_state.nb_unfound_dsos >= reset_threshold) {
       backpopulate_state = {};
     }
+    // Allow another JITDump discovery attempt next cycle, regardless of
+    // backpopulate threshold (cheap once-per-cycle /proc/maps rescan).
+    pid_mapping._jitdump_discovery_attempted = false;
   }
+}
+
+bool DsoHdr::try_jitdump_discovery(PidMapping &pid_mapping, pid_t pid) {
+  if (pid_mapping._jitdump_addr) {
+    return true;
+  }
+  if (pid_mapping._jitdump_discovery_attempted) {
+    return false;
+  }
+  pid_mapping._jitdump_discovery_attempted = true;
+
+  // Force a /proc/<pid>/maps rescan, bypassing the usual permission gate.
+  // The runtime may have published a JITDump file after the previous
+  // backpopulate, or its mmap event may have been missed.
+  BackpopulatePermission const saved_perm =
+      pid_mapping._backpopulate_state.perm;
+  pid_mapping._backpopulate_state.perm = kAllowed;
+  int nb_elts_added = 0;
+  pid_backpopulate(pid_mapping, pid, nb_elts_added);
+  // Preserve the original permission if backpopulate flipped it to forbidden
+  // for unrelated reasons; we only wanted a one-shot rescan here.
+  if (saved_perm == kAllowed) {
+    pid_mapping._backpopulate_state.perm = kAllowed;
+  }
+  return pid_mapping._jitdump_addr != 0;
 }
 
 void DsoHdr::pid_fork(pid_t child_pid, pid_t parent_pid) {

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -583,9 +583,6 @@ void DsoHdr::reset_backpopulate_state(int reset_threshold) {
     if (backpopulate_state.nb_unfound_dsos >= reset_threshold) {
       backpopulate_state = {};
     }
-    // Allow another JITDump discovery attempt next cycle, regardless of
-    // backpopulate threshold (cheap once-per-cycle /proc/maps rescan).
-    pid_mapping._jitdump_discovery_attempted = false;
   }
 }
 
@@ -593,26 +590,20 @@ bool DsoHdr::try_jitdump_discovery(PidMapping &pid_mapping, pid_t pid) {
   if (pid_mapping._jitdump_addr) {
     return true;
   }
-  if (pid_mapping._jitdump_discovery_attempted) {
+  // Only run when /proc/<pid>/maps has never been scanned for this pid.
+  // Once any backpopulate has run, late-arriving JITDump perf events are
+  // already handled by the kJITDump bypass in maybe_insert_erase_overlap,
+  // so an extra rescan would just be redundant work.
+  if (pid_mapping._backpopulate_state.last_backpopulate_time !=
+      PerfClock::time_point{}) {
     return false;
   }
-  pid_mapping._jitdump_discovery_attempted = true;
 
-  // Force a /proc/<pid>/maps rescan, bypassing the usual permission gate.
-  // The runtime may have published a JITDump file after the previous
-  // backpopulate, or its mmap event may have been missed.
-  // Note: pid_backpopulate may mutate pid_mapping._map via
-  // insert_erase_overlap / erase_range, so any DSO reference held by the
-  // caller across this call must be considered invalidated.
-  BackpopulatePermission const saved_perm =
-      pid_mapping._backpopulate_state.perm;
-  pid_mapping._backpopulate_state.perm = kAllowed;
+  // pid_backpopulate may mutate pid_mapping._map via insert_erase_overlap /
+  // erase_range; callers must invalidate any DSO reference held across this
+  // call.
   int nb_elts_added = 0;
   pid_backpopulate(pid_mapping, pid, nb_elts_added);
-  // Always restore the saved permission: this is a one-shot probe; we don't
-  // want a forced scan that added unrelated mappings to leave the gate open
-  // and bypass the normal throttle for subsequent unknown PCs.
-  pid_mapping._backpopulate_state.perm = saved_perm;
   return pid_mapping._jitdump_addr != 0;
 }
 

--- a/src/dso_hdr.cc
+++ b/src/dso_hdr.cc
@@ -601,16 +601,18 @@ bool DsoHdr::try_jitdump_discovery(PidMapping &pid_mapping, pid_t pid) {
   // Force a /proc/<pid>/maps rescan, bypassing the usual permission gate.
   // The runtime may have published a JITDump file after the previous
   // backpopulate, or its mmap event may have been missed.
+  // Note: pid_backpopulate may mutate pid_mapping._map via
+  // insert_erase_overlap / erase_range, so any DSO reference held by the
+  // caller across this call must be considered invalidated.
   BackpopulatePermission const saved_perm =
       pid_mapping._backpopulate_state.perm;
   pid_mapping._backpopulate_state.perm = kAllowed;
   int nb_elts_added = 0;
   pid_backpopulate(pid_mapping, pid, nb_elts_added);
-  // Preserve the original permission if backpopulate flipped it to forbidden
-  // for unrelated reasons; we only wanted a one-shot rescan here.
-  if (saved_perm == kAllowed) {
-    pid_mapping._backpopulate_state.perm = kAllowed;
-  }
+  // Always restore the saved permission: this is a one-shot probe; we don't
+  // want a forced scan that added unrelated mappings to leave the gate open
+  // and bypass the normal throttle for subsequent unknown PCs.
+  pid_mapping._backpopulate_state.perm = saved_perm;
   return pid_mapping._jitdump_addr != 0;
 }
 

--- a/src/unwind_dwfl.cc
+++ b/src/unwind_dwfl.cc
@@ -100,16 +100,26 @@ DDRes add_symbol(Dwfl_Frame *dwfl_frame, UnwindState *us) {
       add_error_frame(nullptr, us, pc, SymbolErrors::unknown_mapping);
       return {};
     }
-    const Dso &dso = find_res.first->second;
-    std::string_view jitdump_path = {};
-    if (has_runtime_symbols(dso)) {
+    if (has_runtime_symbols(find_res.first->second)) {
       // The JITDump mmap event may not yet have been processed (startup race),
       // or an earlier backpopulate may have observed /proc/maps before the
       // runtime published the JITDump. Force a one-shot rescan per cycle to
       // recover it before falling back to the perf-map path.
+      // Note: try_jitdump_discovery() may mutate pid_mapping._map, which
+      // invalidates iterators / references into it. Re-find after the call
+      // and bail if the mapping covering `pc` no longer qualifies.
       if (!pid_mapping._jitdump_addr) {
         dsoHdr.try_jitdump_discovery(pid_mapping, us->pid);
+        find_res = DsoHdr::dso_find_closest(pid_mapping._map, pc);
+        if (!find_res.second || !has_runtime_symbols(find_res.first->second)) {
+          LG_DBG("[UW] (PID%d) DSO at 0x%lx invalidated by JITDump discovery",
+                 us->pid, pc);
+          add_error_frame(nullptr, us, pc, SymbolErrors::unknown_mapping);
+          return {};
+        }
       }
+      const Dso &dso = find_res.first->second;
+      std::string_view jitdump_path = {};
       if (pid_mapping._jitdump_addr) {
         DsoHdr::DsoFindRes const find_mapping = DsoHdr::dso_find_closest(
             pid_mapping._map, pid_mapping._jitdump_addr);
@@ -119,6 +129,7 @@ DDRes add_symbol(Dwfl_Frame *dwfl_frame, UnwindState *us) {
       }
       return add_runtime_symbol_frame(us, dso, pc, jitdump_path);
     }
+    const Dso &dso = find_res.first->second;
     // if not encountered previously, update file location / key
     file_info_id = us->dso_hdr.get_or_insert_file_info(dso);
     if (file_info_id <= k_file_info_error) {

--- a/src/unwind_dwfl.cc
+++ b/src/unwind_dwfl.cc
@@ -101,10 +101,13 @@ DDRes add_symbol(Dwfl_Frame *dwfl_frame, UnwindState *us) {
       return {};
     }
     if (has_runtime_symbols(find_res.first->second)) {
-      // The JITDump mmap event may not yet have been processed (startup race),
-      // or an earlier backpopulate may have observed /proc/maps before the
-      // runtime published the JITDump. Force a one-shot rescan per cycle to
-      // recover it before falling back to the perf-map path.
+      // The JITDump mmap event may not yet have been processed (startup
+      // race): a sample can land in a JIT'd region before the MMAP2 for the
+      // JITDump file has been consumed from the ring buffer. If no /proc
+      // scan has ever run for this pid, do one now to discover the JITDump
+      // before falling back to the perf-map path. After any backpopulate,
+      // late JITDump events are picked up by the kJITDump bypass in
+      // maybe_insert_erase_overlap, so this rescan is a no-op.
       // Note: try_jitdump_discovery() may mutate pid_mapping._map, which
       // invalidates iterators / references into it. Re-find after the call
       // and bail if the mapping covering `pc` no longer qualifies.

--- a/src/unwind_dwfl.cc
+++ b/src/unwind_dwfl.cc
@@ -103,6 +103,13 @@ DDRes add_symbol(Dwfl_Frame *dwfl_frame, UnwindState *us) {
     const Dso &dso = find_res.first->second;
     std::string_view jitdump_path = {};
     if (has_runtime_symbols(dso)) {
+      // The JITDump mmap event may not yet have been processed (startup race),
+      // or an earlier backpopulate may have observed /proc/maps before the
+      // runtime published the JITDump. Force a one-shot rescan per cycle to
+      // recover it before falling back to the perf-map path.
+      if (!pid_mapping._jitdump_addr) {
+        dsoHdr.try_jitdump_discovery(pid_mapping, us->pid);
+      }
       if (pid_mapping._jitdump_addr) {
         DsoHdr::DsoFindRes const find_mapping = DsoHdr::dso_find_closest(
             pid_mapping._map, pid_mapping._jitdump_addr);

--- a/test/dso-ut.cc
+++ b/test/dso-ut.cc
@@ -442,6 +442,33 @@ TEST(DSOTest, insert_jitdump) {
   EXPECT_EQ(start, pid_mapping._jitdump_addr);
 }
 
+// Regression test: a JITDump mmap event whose timestamp predates the last
+// backpopulate must still be accepted (otherwise we lose the JITDump marker
+// in startup-race scenarios with JIT runtimes such as Julia / .NET).
+TEST(DSOTest, jitdump_bypasses_backpopulate_timestamp) {
+  PerfClock::init();
+  DsoHdr dso_hdr;
+  pid_t const test_pid = 3237589;
+  Dso jitdump_dso = DsoHdr::dso_from_proc_line(test_pid, s_jitdump_line);
+  ASSERT_EQ(jitdump_dso._type, DsoType::kJITDump);
+  ProcessAddress_t const start = jitdump_dso._start;
+
+  // Simulate a previous backpopulate that observed /proc/maps before the
+  // runtime published the JITDump file.
+  auto &pid_mapping = dso_hdr.get_pid_mapping(test_pid);
+  pid_mapping._backpopulate_state.last_backpopulate_time = PerfClock::now();
+
+  // The buffered perf MMAP2 event for the JITDump file has an older timestamp.
+  PerfClock::time_point const old_timestamp{};
+  ASSERT_LT(old_timestamp,
+            pid_mapping._backpopulate_state.last_backpopulate_time);
+
+  bool const inserted =
+      dso_hdr.maybe_insert_erase_overlap(std::move(jitdump_dso), old_timestamp);
+  EXPECT_TRUE(inserted);
+  EXPECT_EQ(start, pid_mapping._jitdump_addr);
+}
+
 TEST(DSOTest, exe_name) {
   ElfAddress_t ip = _THIS_IP_;
   DsoHdr dso_hdr;


### PR DESCRIPTION
## Problem

JIT runtimes (Julia, .NET) publish a JITDump file via mmap that ddprof uses to resolve symbols in JIT'd anon-exec regions. At process startup, samples can land in JIT'd code before `pid_mapping._jitdump_addr` is set, leaving frames unsymbolized.

Two races contribute:

1. **Lost JITDump MMAP2 event.** `maybe_insert_erase_overlap` drops perf MMAP2 events whose timestamp predates the last backpopulate. If a backpopulate runs while /proc/maps hasn't yet caught up to the JITDump mmap, the subsequent perf event for the JITDump (with an older timestamp) is silently dropped.

2. **Sample before MMAP2 is consumed.** Even with events in order, the first samples can run `add_symbol` before the JITDump MMAP2 has been drained from the ring buffer. `_jitdump_addr == 0` sends us down the perf-map fallback (which Julia doesn't publish) and frames stay unsymbolized.

## Changes

* **`maybe_insert_erase_overlap`**: bypass the backpopulate-timestamp guard for `kJITDump` events. They are idempotent (`dso_find_adjust_same` dedupes) and the marker is required for JIT symbolization.

* **`DsoHdr::try_jitdump_discovery`**: new helper that scans `/proc/<pid>/maps` to discover a JITDump file. Gated to fire **at most once per PID lifetime**, only when no full /proc scan has ever run for this PID (`last_backpopulate_time == 0`). After any backpopulate, late JITDump events are already covered by the bypass above, so further rescans would be redundant.

* **`add_symbol` (unwind_dwfl.cc)**: when a sample lands in a runtime-symbols DSO with no known JITDump, call `try_jitdump_discovery` before falling back to perf-map. The rescan may mutate `pid_mapping._map` so the DSO reference is re-fetched afterwards; an `unknown_mapping` error frame is emitted if the mapping no longer qualifies.

## Cost

Negligible. The discovery path is bounded to one extra `/proc/<pid>/maps` parse per PID lifetime, and only when samples have arrived purely via perf events without ever triggering a backpopulate. Cleared naturally on exec/exit via `worker_pid_free`.

## Tests

* New `DSOTest.jitdump_bypasses_backpopulate_timestamp` covers the timestamp-guard bypass.
* Full `dso-ut` and `runtime_symbol_lookup-ut` suites pass.

## Follow-ups (not in this PR)

* End-to-end correctness scenario for the Julia race.