### PR TITLE
fix(jit): retry jitdump read when file grows

### DIFF
--- a/include/runtime_symbol_lookup.hpp
+++ b/include/runtime_symbol_lookup.hpp
@@ -58,9 +58,20 @@ public:
 private:
   using FailedCycle = HeterogeneousLookupStringMap<uint32_t>;
 
+  // Per-(pid, jitdump path) state used to decide when to retry a jitdump
+  // read after a soft miss (file readable, but the sampled PC was not in
+  // the records we already ingested). See get_or_insert_jitdump.
+  struct JitdumpRetryState {
+    int64_t size_bytes = 0;
+    inode_t inode = 0;
+    uint32_t misses_since_check = 0;
+  };
+  using JitdumpRetryMap = HeterogeneousLookupStringMap<JitdumpRetryState>;
+
   struct SymbolInfo {
     SymbolMap _map;
     FailedCycle _failed_cycle;
+    JitdumpRetryMap _jitdump_retry;
   };
   using PidUnorderedMap = std::unordered_map<pid_t, SymbolInfo>;
 
@@ -84,6 +95,25 @@ private:
                           SymbolMap &symbol_map, SymbolTable &symbol_table,
                           const ddog_prof_ProfilesDictionary *dict);
 
+  // Best-effort stat of the jitdump file using the same candidate paths
+  // as fill_from_jitdump. Returns true on success and fills *size and
+  // *inode. Returns false if no candidate path was stat-able.
+  bool stat_jitdump(pid_t pid, std::string_view jitdump_path, int64_t *size,
+                    inode_t *inode) const;
+
+  // Counter-gated stat to detect that the jitdump file has changed
+  // (grown or been replaced) since the last read. Returns true when a
+  // change is observed, in which case the retry state is updated to the
+  // freshly-observed size/inode so the change is not reported twice.
+  bool check_jitdump_changed(SymbolInfo &symbol_info, pid_t pid,
+                             std::string_view jitdump_path);
+
+  // Parse the jitdump file and refresh the retry-state book-keeping so
+  // subsequent retries only fire when the file changes again.
+  DDRes read_jitdump(SymbolInfo &symbol_info, pid_t pid,
+                     std::string_view jitdump_path, SymbolTable &symbol_table,
+                     const ddog_prof_ProfilesDictionary *dict);
+
   DDRes fill_from_perfmap(int pid, SymbolMap &symbol_map,
                           SymbolTable &symbol_table,
                           const ddog_prof_ProfilesDictionary *dict);
@@ -100,6 +130,30 @@ private:
     return false;
   }
 
+  // Soft-miss retry budget: a soft miss flags the (pid, path) pair as
+  // "already tried this cycle" so we don't reparse the jitdump for every
+  // subsequent missed PC. Without any retry mechanism however, a single
+  // unlucky first sample (e.g. fired while Julia was still flushing
+  // jit-<pid>.dump) leaves the whole cycle with 0 symbolized JIT frames.
+  //
+  // To recover, every k_jitdump_retry_check_every soft misses we stat the
+  // jitdump file. If it has grown / been replaced since the last read we
+  // unfreeze and reparse; otherwise we keep the freeze cheaply.
+  //
+  // Cost note: with 99 Hz CPU sampling on up to ~20 cores, the worst case
+  // (every sample misses) is ~99 * 20 / 64 ~= 30 stat() calls per second
+  // for the whole profiler. In practice the JIT map hits dominate and
+  // stat is invoked far less.
+  static constexpr uint32_t k_jitdump_retry_check_every = 64;
+
+  // Exposed for unit tests so tests can validate the retry budget without
+  // having to perform thousands of lookups.
+public:
+  static constexpr uint32_t jitdump_retry_check_every() {
+    return k_jitdump_retry_check_every;
+  }
+
+private:
   void flag_lookup_failure(SymbolInfo &symbol_info, std::string_view path) {
     const auto it = symbol_info._failed_cycle.find(path);
     // Written this way, we save up on creating strings

--- a/src/runtime_symbol_lookup.cc
+++ b/src/runtime_symbol_lookup.cc
@@ -10,6 +10,7 @@
 #include "defer.hpp"
 #include "jit/jitdump.hpp"
 #include "logger.hpp"
+#include "procutils.hpp"
 #include "unlikely.hpp"
 
 #include <absl/strings/substitute.h>
@@ -170,28 +171,107 @@ DDRes RuntimeSymbolLookup::fill_from_perfmap(
   return {};
 }
 
+bool RuntimeSymbolLookup::stat_jitdump(pid_t pid, std::string_view jitdump_path,
+                                       int64_t *size, inode_t *inode) const {
+  // The path advertised by perf for the jitdump mapping is observed from
+  // inside the target's mount namespace. When ddprof runs in a different
+  // namespace (typically the host, with the target in a container) that
+  // raw path is not directly reachable. Resolve it the same way
+  // fill_from_jitdump does so growth checks see the same file the parser
+  // would actually read:
+  //   - absolute path -> reach via /proc/<pid>/root/<path>
+  //   - relative path -> reach via /proc/<pid>/cwd/<path>
+  //   - if neither works (e.g. ddprof runs in the same namespace as the
+  //     target) fall back to the raw path.
+  const std::string proc_path = is_absolute_path(jitdump_path)
+      ? absl::Substitute("$0/proc/$1/root$2", _path_to_proc, pid, jitdump_path)
+      : absl::Substitute("$0/proc/$1/cwd/$2", _path_to_proc, pid, jitdump_path);
+
+  if (get_file_inode(proc_path.c_str(), inode, size)) {
+    return true;
+  }
+  const std::string fallback(jitdump_path);
+  return get_file_inode(fallback.c_str(), inode, size);
+}
+
+bool RuntimeSymbolLookup::check_jitdump_changed(SymbolInfo &symbol_info,
+                                                pid_t pid,
+                                                std::string_view jitdump_path) {
+  auto [retry_it, inserted] =
+      symbol_info._jitdump_retry.try_emplace(std::string(jitdump_path));
+  JitdumpRetryState &retry = retry_it->second;
+  if (++retry.misses_since_check < k_jitdump_retry_check_every) {
+    return false;
+  }
+  retry.misses_since_check = 0;
+  int64_t size = 0;
+  inode_t inode = 0;
+  if (!stat_jitdump(pid, jitdump_path, &size, &inode)) {
+    // Path is currently unreachable (e.g. //anon). Keep the freeze
+    // without churning; next cycle naturally retries.
+    return false;
+  }
+  if (size == retry.size_bytes && inode == retry.inode) {
+    return false;
+  }
+  retry.size_bytes = size;
+  retry.inode = inode;
+  return true;
+}
+
+DDRes RuntimeSymbolLookup::read_jitdump(
+    SymbolInfo &symbol_info, pid_t pid, std::string_view jitdump_path,
+    SymbolTable &symbol_table, const ddog_prof_ProfilesDictionary *dict) {
+  ++_stats._nb_jit_reads;
+  DDRes res = fill_from_jitdump(jitdump_path, pid, symbol_info._map,
+                                symbol_table, dict);
+  if (IsDDResFatal(res)) {
+    return res;
+  }
+  // Refresh the cached size/inode so subsequent retries only fire on growth.
+  auto [retry_it, inserted] =
+      symbol_info._jitdump_retry.try_emplace(std::string(jitdump_path));
+  stat_jitdump(pid, jitdump_path, &retry_it->second.size_bytes,
+               &retry_it->second.inode);
+  retry_it->second.misses_since_check = 0;
+  return res;
+}
+
 SymbolIdx_t RuntimeSymbolLookup::get_or_insert_jitdump(
     pid_t pid, ProcessAddress_t pc, SymbolTable &symbol_table,
     const ddog_prof_ProfilesDictionary *dict, std::string_view jitdump_path) {
   SymbolInfo &symbol_info = _pid_map[pid];
   SymbolMap::FindRes find_res = symbol_info._map.find_closest(pc);
-  if (!find_res.second && !has_lookup_failure(symbol_info, jitdump_path)) {
-    // refresh as we expect there to be new symbols
-    ++_stats._nb_jit_reads;
-    if (IsDDResFatal(fill_from_jitdump(jitdump_path, pid, symbol_info._map,
-                                       symbol_table, dict))) {
-      // Some warnings can be expected with incomplete files
+  if (find_res.second) {
+    return find_res.first->second.get_symbol_idx();
+  }
+
+  // Two reasons to (re)read the file:
+  //   1. We have never read it (or we did, but a new cycle has cleared the
+  //      previous failure flag).
+  //   2. We've already given up this cycle, but a periodic stat shows the
+  //      file has grown or been replaced since the last read.
+  const bool first_attempt = !has_lookup_failure(symbol_info, jitdump_path);
+  const bool should_read =
+      first_attempt || check_jitdump_changed(symbol_info, pid, jitdump_path);
+
+  if (should_read) {
+    if (IsDDResFatal(
+            read_jitdump(symbol_info, pid, jitdump_path, symbol_table, dict))) {
+      // Some warnings can be expected with incomplete files.
       flag_lookup_failure(symbol_info, jitdump_path);
       return -1;
     }
     find_res = symbol_info._map.find_closest(pc);
   }
-  // Avoid bouncing when we are failing lookups.
-  // !This could have a negative impact on symbolisation. To be studied
+
+  // Soft miss (or hard miss with no read attempted): freeze for the cycle.
+  // !This could have a negative impact on symbolisation. To be studied.
   if (!find_res.second) {
     flag_lookup_failure(symbol_info, jitdump_path);
+    return -1;
   }
-  return find_res.second ? find_res.first->second.get_symbol_idx() : -1;
+  return find_res.first->second.get_symbol_idx();
 }
 
 SymbolIdx_t

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -374,6 +374,7 @@ add_unit_test(
   ../src/demangler/demangler.cc
   ../src/symbol_map.cc
   ../src/jit/jitdump.cc
+  ../src/procutils.cc
   LIBRARIES Datadog::Profiling llvm-demangle)
 
 add_unit_test(ddprof_cpumask-ut ddprof_cpumask-ut.cc ../src/ddprof_cpumask.cc)

--- a/test/runtime_symbol_lookup-ut.cc
+++ b/test/runtime_symbol_lookup-ut.cc
@@ -11,8 +11,12 @@
 #include "symbol_hdr.hpp"
 #include "symbol_table.hpp"
 
+#include <cstdio>
 #include <datadog/profiling.h>
+#include <filesystem>
+#include <fstream>
 #include <string>
+#include <unistd.h>
 
 namespace ddprof {
 
@@ -239,6 +243,126 @@ TEST(runtime_symbol_lookup, jitdump_vs_perfmap) {
         runtime_symbol_lookup_perfmap.get_stats();
     EXPECT_EQ(stats._symbol_count, 11605);
   }
+}
+
+namespace {
+// Copy `src` into `dst`, truncating/replacing. Returns false on I/O error.
+bool copy_file_replace(const std::string &src, const std::string &dst) {
+  std::error_code ec;
+  std::filesystem::copy_file(
+      src, dst, std::filesystem::copy_options::overwrite_existing, ec);
+  return !ec;
+}
+
+// Test fixture for jitdump growth-retry behaviour.
+class JitdumpRetry : public ::testing::Test {
+protected:
+  void SetUp() override {
+    // Unique per-test tempfile we can grow / replace.
+    char tmpl[] = "/tmp/ddprof-jitdump-retry-XXXXXX";
+    int fd = ::mkstemp(tmpl);
+    ASSERT_GE(fd, 0);
+    ::close(fd);
+    _tmp_path = tmpl;
+    _partial = std::string(UNIT_TEST_DATA) + "/jit-julia-partial.dump";
+    _full = std::string(UNIT_TEST_DATA) + "/jit-simple-julia.dump";
+    // The PC matching `julia_b_11` in `_full`.
+    _matching_pc = 0x7bea23b00390;
+  }
+  void TearDown() override {
+    std::error_code ec;
+    std::filesystem::remove(_tmp_path, ec);
+  }
+
+  std::string _tmp_path;
+  std::string _partial;
+  std::string _full;
+  ProcessAddress_t _matching_pc;
+};
+} // namespace
+
+TEST_F(JitdumpRetry, no_growth_does_not_reread) {
+  SymbolHdr symbol_hdr;
+  SymbolTable symbol_table;
+  ASSERT_TRUE(copy_file_replace(_partial, _tmp_path));
+
+  RuntimeSymbolLookup lookup("");
+  pid_t mypid = getpid();
+
+  // First call: reads partial file, PC not present, freezes the path.
+  EXPECT_EQ(lookup.get_or_insert_jitdump(mypid, _matching_pc, symbol_table,
+                                         symbol_hdr.profiles_dictionary(),
+                                         _tmp_path),
+            -1);
+  EXPECT_EQ(lookup.get_stats()._nb_jit_reads, 1U);
+
+  // Without growth, every retry tick observes the same (size, inode) and
+  // does NOT trigger another read.
+  const uint32_t budget = RuntimeSymbolLookup::jitdump_retry_check_every();
+  for (uint32_t i = 0; i < 4U * budget; ++i) {
+    lookup.get_or_insert_jitdump(mypid, _matching_pc, symbol_table,
+                                 symbol_hdr.profiles_dictionary(), _tmp_path);
+  }
+  EXPECT_EQ(lookup.get_stats()._nb_jit_reads, 1U);
+}
+
+TEST_F(JitdumpRetry, growth_triggers_reread_and_resolves_pc) {
+  SymbolHdr symbol_hdr;
+  SymbolTable symbol_table;
+  ASSERT_TRUE(copy_file_replace(_partial, _tmp_path));
+
+  RuntimeSymbolLookup lookup("");
+  pid_t mypid = getpid();
+
+  // First read: partial file, PC misses → frozen.
+  ASSERT_EQ(lookup.get_or_insert_jitdump(mypid, _matching_pc, symbol_table,
+                                         symbol_hdr.profiles_dictionary(),
+                                         _tmp_path),
+            -1);
+  ASSERT_EQ(lookup.get_stats()._nb_jit_reads, 1U);
+
+  // Burn the retry budget while the file is unchanged: no extra reads.
+  const uint32_t budget = RuntimeSymbolLookup::jitdump_retry_check_every();
+  for (uint32_t i = 1; i < budget; ++i) {
+    lookup.get_or_insert_jitdump(mypid, _matching_pc, symbol_table,
+                                 symbol_hdr.profiles_dictionary(), _tmp_path);
+  }
+  EXPECT_EQ(lookup.get_stats()._nb_jit_reads, 1U);
+
+  // Replace the file with a fuller jitdump that contains the PC.
+  ASSERT_TRUE(copy_file_replace(_full, _tmp_path));
+
+  // The next missed lookup should hit the stat tick, observe the change,
+  // reparse the file, and resolve the PC.
+  SymbolIdx_t idx =
+      lookup.get_or_insert_jitdump(mypid, _matching_pc, symbol_table,
+                                   symbol_hdr.profiles_dictionary(), _tmp_path);
+  EXPECT_NE(idx, -1);
+  EXPECT_EQ(lookup.get_stats()._nb_jit_reads, 2U);
+}
+
+TEST_F(JitdumpRetry, unreachable_path_does_not_churn) {
+  // "//anon" reproduces the path-resolution pathology observed in CI:
+  // the jitdump DSO ended up tagged with a placeholder filename. stat()
+  // fails on every retry tick; we must not loop on reads.
+  SymbolHdr symbol_hdr;
+  SymbolTable symbol_table;
+  RuntimeSymbolLookup lookup("");
+  pid_t mypid = getpid();
+  const std::string bogus = "//anon";
+
+  EXPECT_EQ(lookup.get_or_insert_jitdump(mypid, 0xbadbeef, symbol_table,
+                                         symbol_hdr.profiles_dictionary(),
+                                         bogus),
+            -1);
+  const uint32_t initial_reads = lookup.get_stats()._nb_jit_reads;
+
+  const uint32_t budget = RuntimeSymbolLookup::jitdump_retry_check_every();
+  for (uint32_t i = 0; i < 4U * budget; ++i) {
+    lookup.get_or_insert_jitdump(mypid, 0xbadbeef, symbol_table,
+                                 symbol_hdr.profiles_dictionary(), bogus);
+  }
+  EXPECT_EQ(lookup.get_stats()._nb_jit_reads, initial_reads);
 }
 
 } // namespace ddprof


### PR DESCRIPTION
## Why

`RuntimeSymbolLookup::get_or_insert_jitdump` freezes a `(pid, path)` pair for the rest of the export cycle as soon as one sampled PC misses the symbol map after a successful jitdump read. The intent was to avoid reparsing the file for every subsequent miss in the same cycle.

The side effect: a single unlucky first sample — fired while the runtime is still flushing `jit-<pid>.dump` (Julia, .NET) — produces **zero symbolised JIT frames for the entire run** on scenarios that only export once. This matches the flaky Julia failure on prof-correctness, e.g. `ddprof_julia-20260601-074729`:

```
datadog.profiling.native.symbols.jit.reads: 1
datadog.profiling.native.symbols.jit.failed_lookups: 2177
datadog.profiling.native.symbols.jit.symbol_count: 0
```

## What

Add a soft-miss retry path. Every `k_jitdump_retry_check_every = 64` soft misses on a frozen jitdump, stat the file via the existing `get_file_inode` helper. If size or inode changed since the last read, unfreeze and reparse; otherwise keep the freeze cheaply. Hard read errors keep the existing behaviour (no churn on unreachable files such as `//anon`).

The new logic is in two small helpers — `check_jitdump_changed` and `read_jitdump` — so `get_or_insert_jitdump` remains a short orchestrator.

## Cost

At 99 Hz CPU sampling on up to ~20 cores, the worst case (every sample misses) is ~`99 * 20 / 64 ≈ 30` `stat()` calls per second profiler-wide. Reparses only happen when the file actually grew. In practice JIT map hits dominate and `stat` is invoked far less.

## Tests

Three new unit tests (`JitdumpRetry` fixture):
- `no_growth_does_not_reread` — burning the retry budget on an unchanged file does not trigger extra reads.
- `growth_triggers_reread_and_resolves_pc` — after `k_jitdump_retry_check_every` misses on a partial file, replacing it with a fuller one resolves the PC on the next lookup.
- `unreachable_path_does_not_churn` — `stat()` failing on `//anon` does not loop on reads.

## Notes / follow-ups

- `//anon` showing up as the jitdump path is a separate (pre-existing) issue: the kJITDump DSO gets shadowed by an anon mapping over the same range, likely during a backpopulate. Worth investigating, but orthogonal to this fix.
- Incremental parse (track `last_offset`, `pread` from there) is a natural follow-up if reparse cost ever becomes visible.